### PR TITLE
Fix problem for finding shutterspeed widget for small exposure value

### DIFF
--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -719,7 +719,7 @@ int find_exposure_setting(gphoto_driver *gphoto, gphoto_widget *widget, uint32_t
         if (exact)
         {
             // Close "enough" to be exact
-            if (std::fabs(delta) < 0.001)
+            if (std::fabs(delta) < 1e-4)
             {
                 best_match = delta;
                 best_idx   = i;


### PR DESCRIPTION
Reproduce:

    Connect DSLR in "M" mode
    set "force bulb" to OFF
    In CCD TAB add a 1/1000s exposure to the queue
    activate the queue
    Picture taken is a 1/500s

Expected behaviour would be a 1/1000s picture taken.

[2019-09-17T13:11:53.645 CEST DEBG ][ org.kde.kstars.indi] - Canon DSLR EOS 5D Mark II : "[DEBUG] Finding optimal exposure setting for 0.001001 seconds in shutterspeed (count=37)... "
[2019-09-17T13:11:53.645 CEST DEBG ][ org.kde.kstars.indi] - Canon DSLR EOS 5D Mark II : "[DEBUG] Closest match: 0.002 seconds Index: 28 "
[2019-09-17T13:11:53.645 CEST DEBG ][ org.kde.kstars.indi] - Canon DSLR EOS 5D Mark II : "[DEBUG] Setting radio/menu widget shutterspeed: 28 (1/500) "
[2019-09-17T13:11:53.672 CEST DEBG ][ org.kde.kstars.indi] - Canon DSLR EOS 5D Mark II : "[DEBUG] Setting new configuration OK. "
[2019-09-17T13:11:53.672 CEST DEBG ][ org.kde.kstars.indi] - Canon DSLR EOS 5D Mark II : "[DEBUG] Using predefined exposure time: 0.002 seconds "

The problem is as follows:
The widget exposure speed 1/500s = 0.002 is picked and tested against desired value: 0.001001

delta = exptime - gphoto->exposureList[i];
if (exact)
{
    // Close "enough" to be exact
    if (std::fabs(delta) < 0.001) // 0.002 - 0.001001 with test: 0.000999 < 0.001
    {
        best_match = delta;
        best_idx   = i; // here 1/500s = 0.002 is chosen.
        break;
    }
}

So make sure we test for even smaller delta, e.g. 1e-6.