### PR TITLE
Stargo 1.7 | improvements to avoid timeouts

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.7) stretch; urgency=medium
+
+  * Retrying once reading the motor state to capture timeouts
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sat, 22 Jun 2019 11:47:02 +0200
+
 indi-avalon (1.5) stretch; urgency=medium
 
   * Implemented switch for enabling / disabling the keypad

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,8 +1,11 @@
 indi-avalon (1.7) stretch; urgency=medium
 
   * Retrying once reading the motor state to capture timeouts
+  * Avoid pulse guiding while slewing or parking
+  * 50ms delay after pulse guiding command to avoid device flooding
+  * Removing tracking speed NONE
 
- -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sat, 22 Jun 2019 11:47:02 +0200
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sun 29 Sep 2019 21:47:57 +0200
 
 indi-avalon (1.5) stretch; urgency=medium
 

--- a/indi-avalon/CMakeLists.txt
+++ b/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 5)
+set(AVALON_VERSION_MINOR 7)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -509,7 +509,6 @@ bool LX200StarGo::ReadScopeStatus()
             return false;
         }
     }
-    LOGF_DEBUG("Motor state = (%d, %d)", x, y);
 
     char parkHomeStatus[1] = {0};
     if (! getParkHomeStatus(parkHomeStatus))
@@ -614,6 +613,7 @@ bool LX200StarGo::syncHomePosition()
 
 bool LX200StarGo::getEqCoordinates (double *ra, double *dec)
 {
+    LOG_DEBUG(__FUNCTION__);
     // Use X590 for RA DEC
     char response[AVALON_RESPONSE_BUFFER_LENGTH] = {0};
     if(!sendQuery(":X590#", response))

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -1108,14 +1108,17 @@ bool LX200StarGo::sendQuery(const char* cmd, char* response, char end, int wait)
     }
     lresponse[0] = '\0';
     int lwait = wait;
+    bool found = false;
     while (receive(lresponse, &lbytes, end, lwait))
     {
         //        LOGF_DEBUG("Found response after %ds %s", lwait, lresponse);
         lbytes = 0;
         if(! ParseMotionState(lresponse))
         {
-            // Don't change wait requirement but get the response
-            strcpy(response, lresponse);
+            // Take the first response that is no motion state
+            if (!found)
+                strcpy(response, lresponse);
+            found = true;
             lwait = 0;
         }
     }

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2224,11 +2224,13 @@ int LX200StarGo::SendPulseCmd(int8_t direction, uint32_t duration_msec)
         default:
             return 1;
     }
-    if (!sendQuery(cmd, response, 0)) // Don't wait for response - there isn't one
-    {
-        return false;
-    }
-    return true;
+    bool success = !sendQuery(cmd, response, 0); // no response expected
+
+    const struct timespec timeout = {0, 50000000L};
+    // sleep for 50 mseconds to avoid flooding the mount with commands
+    nanosleep(&timeout, nullptr);
+
+    return success;
 }
 
 bool LX200StarGo::SetTrackEnabled(bool enabled)

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -501,8 +501,13 @@ bool LX200StarGo::ReadScopeStatus()
 
     if (! getMotorStatus(&x, &y))
     {
-        LOG_ERROR("Cannot determine scope status, failed to parse motor state.");
-        return false;
+        LOG_INFO("Failed to parse motor state. Retrying...");
+        // retry once
+        if (! getMotorStatus(&x, &y))
+        {
+            LOG_ERROR("Cannot determine scope status, failed to parse motor state.");
+            return false;
+        }
     }
     LOGF_DEBUG("Motor state = (%d, %d)", x, y);
 

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2208,6 +2208,13 @@ IPState LX200StarGo::GuideWest(uint32_t ms)
 int LX200StarGo::SendPulseCmd(int8_t direction, uint32_t duration_msec)
 {
     LOGF_DEBUG("%s dir=%d dur=%d ms", __FUNCTION__, direction, duration_msec );
+
+    if (TrackState == SCOPE_SLEWING || TrackState == SCOPE_PARKING)
+    {
+        // having pulse guiding while slewing or parking creates confusion
+        LOGF_INFO("Pulse command (dir=%d dur=%d ms) ingnored due to track state %d.", direction, duration_msec, TrackState);
+        return 1;
+    }
     char cmd[AVALON_COMMAND_BUFFER_LENGTH];
     char response[AVALON_RESPONSE_BUFFER_LENGTH];
     switch (direction)

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -203,8 +203,7 @@ bool LX200StarGo::ISNewSwitch(const char *dev, const char *name, ISState *states
                 return false;
             int trackMode = IUFindOnSwitchIndex(&TrackModeSP);
 
-            bool result = true;
-            if (trackMode != TRACK_NONE) result = SetTrackMode(trackMode);
+            bool result = SetTrackMode(trackMode);
 
             switch (trackMode)
             {
@@ -216,10 +215,6 @@ bool LX200StarGo::ISNewSwitch(const char *dev, const char *name, ISState *states
                     break;
                 case TRACK_LUNAR:
                     LOG_INFO("Lunar tracking rate selected");
-                    break;
-                case TRACK_NONE:
-                    LOG_INFO("Tracking stopped.");
-                    result = SetTrackEnabled(false);
                     break;
             }
             TrackModeSP.s = result ? IPS_OK : IPS_ALERT;
@@ -422,8 +417,7 @@ bool LX200StarGo::initProperties()
     IUFillSwitch(&MeridianFlipModeS[2], "MERIDIAN_FLIP_FORCED", "forced", ISS_OFF);
     IUFillSwitchVector(&MeridianFlipModeSP, MeridianFlipModeS, 3, getDeviceName(), "MERIDIAN_FLIP_MODE", "Meridian Flip", RA_DEC_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    // overwrite the custom tracking mode button
-    IUFillSwitch(&TrackModeS[3], "TRACK_NONE", "None", ISS_OFF);
+    // focuser on AUX1 port
     focuserAux1->initProperties("AUX1 Focuser");
 
     return true;
@@ -1160,7 +1154,7 @@ bool LX200StarGo::ParseMotionState(char* state)
         switch(lmode)
         {
             case 0:
-                CurrentTrackMode = TRACK_NONE;
+                // TRACK_NONE removed, do nothing
                 break;
             case 1:
                 CurrentTrackMode = TRACK_LUNAR;
@@ -1800,10 +1794,6 @@ bool LX200StarGo::SetTrackMode(uint8_t mode)
         case TRACK_LUNAR:
             strcpy(cmd, ":TL#");
             strcpy(s_mode, "Lunar");
-            break;
-        case TRACK_NONE:
-            strcpy(cmd, ":TM#");
-            strcpy(s_mode, "None");
             break;
         default:
             return false;

--- a/indi-avalon/lx200stargo.h
+++ b/indi-avalon/lx200stargo.h
@@ -71,8 +71,7 @@ class LX200StarGo : public LX200Telescope
         {
             TRACK_SIDEREAL = 0, //=Telescope::TelescopeTrackMode::TRACK_SIDEREAL,
             TRACK_SOLAR = 1, //=Telescope::TelescopeTrackMode::TRACK_SOLAR,
-            TRACK_LUNAR = 2, //=Telescope::TelescopeTrackMode::TRACK_LUNAR,
-            TRACK_NONE = 3
+            TRACK_LUNAR = 2 //=Telescope::TelescopeTrackMode::TRACK_LUNAR,
         };
         enum MotorsState
         {


### PR DESCRIPTION
Several improvements to avoid timeouts:
  * Retrying once reading the motor state to capture timeouts
  * Avoid pulse guiding while slewing or parking
  * 50ms delay after pulse guiding command to avoid device flooding

Additionally, the tracking speed NONE is removed which overrode the CUSTOM speed button. Meanwhile, the CUSTOM speed is only present if the mount supports custom tracking speeds - which is not the case for Avalon StarGO.
