### PR TITLE
Increase bulk timeout in SX driver to support older SXV-M25C 

### DIFF
--- a/indi-sx/sxccdusb.cpp
+++ b/indi-sx/sxccdusb.cpp
@@ -115,7 +115,7 @@
 #define BULK_OUT 0x0001
 
 #define BULK_COMMAND_TIMEOUT 2000
-#define BULK_DATA_TIMEOUT    10000
+#define BULK_DATA_TIMEOUT    20000 //Older SXV-M25C takes 14s unbinned
 
 #ifdef __arm__
 #define CHUNK_SIZE (4 * 1024 * 1024)


### PR DESCRIPTION
This increases the bulk timeout in the SX driver so that the older SXV-M25C is able to download a unbinned image from the camera. This older model is slower than the SXVR-M25C and takes 14 seconds to transfer. The older timeout was 10 seconds, this PR changes it to 20 seconds.

Link below is discussion on the issue.
https://indilib.org/forum/ccds-dslrs/5767-failure-to-take-exposure-with-starlight-sxvr-m25c.html

It gets identified as the new SXVR-M25C because it has the same USB id. It appears to work fine that way except for the timeout.