### PR TITLE
StarGO 1.8 | Configurable delay between mount commands

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.8) buster; urgency=medium
+
+  * Make mount command delay configurable
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sat, 19 Oct 2019 22:16:11 +0200
+
 indi-avalon (1.7) stretch; urgency=medium
 
   * Retrying once reading the motor state to capture timeouts

--- a/indi-avalon/CMakeLists.txt
+++ b/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 7)
+set(AVALON_VERSION_MINOR 8)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -1115,6 +1115,8 @@ bool LX200StarGo::sendQuery(const char* cmd, char* response, char end, int wait)
     if(!transmit(cmd))
     {
         LOGF_ERROR("Command <%s> failed.", cmd);
+        // sleep for 50 mseconds to avoid flooding the mount with commands
+        nanosleep(&mount_request_delay, nullptr);
         return false;
     }
     lresponse[0] = '\0';
@@ -1134,6 +1136,10 @@ bool LX200StarGo::sendQuery(const char* cmd, char* response, char end, int wait)
         }
     }
     flush();
+
+    // sleep for 50 mseconds to avoid flooding the mount with commands
+    nanosleep(&mount_request_delay, nullptr);
+
     return true;
 }
 
@@ -1778,9 +1784,6 @@ bool LX200StarGo::transmit(const char* buffer)
     int bytesWritten = 0;
     flush();
     int returnCode = tty_write_string(PortFD, buffer, &bytesWritten);
-
-    // sleep for 50 mseconds to avoid flooding the mount with commands
-    nanosleep(&mount_request_delay, nullptr);
 
     if (returnCode != TTY_OK)
     {

--- a/indi-avalon/lx200stargo.h
+++ b/indi-avalon/lx200stargo.h
@@ -148,6 +148,10 @@ class LX200StarGo : public LX200Telescope
         ISwitchVectorProperty MeridianFlipForcedSP;
         ISwitch MeridianFlipForcedS[2];
 
+        // configurable delay between two commands to avoid flooding StarGO
+        INumberVectorProperty MountRequestDelayNP;
+        INumber MountRequestDelayN[1];
+
         int controller_format { LX200_LONG_FORMAT };
 
         // override LX200Generic
@@ -169,6 +173,9 @@ class LX200StarGo : public LX200Telescope
         bool setKeyPadEnabled(bool enabled);
         bool getSystemSlewSpeedMode (int *index);
         bool setSystemSlewSpeedMode(int index);
+
+        struct timespec mount_request_delay = {0, 50000000L};
+        void setMountRequestDelay(int secs, long nanosecs) {mount_request_delay.tv_sec = secs; mount_request_delay.tv_nsec = nanosecs; };
 
         // autoguiding
         virtual bool setGuidingSpeeds(int raSpeed, int decSpeed);


### PR DESCRIPTION
In rare cases, StarGO gets overflooded with too many commands in a row. This could lead to the situation, that StarGO hangs completely and does not react any more on new commands.

To avoid this, a configurable delay is added between two mount commands. It's set to 50ms as standard, but can be changed individually, if this value turns out to be inappropriate.
