### PR TITLE
Added Bayer filter support for color cameras

### DIFF
--- a/debian/indi-sx/changelog
+++ b/debian/indi-sx/changelog
@@ -1,3 +1,9 @@
+indi-sx (1.14) bionic; urgency=low
+
+  * Added Bayer filter support option for color cameras
+
+ -- Karl Rees <indidev@karlrees.com>  Mon, 04 Nov 2019 17:45:00 +0300
+
 indi-sx (1.13) bionic; urgency=low
 
   * New release

--- a/indi-sx/sxccd.h
+++ b/indi-sx/sxccd.h
@@ -4,6 +4,8 @@
   Copyright (c) 2012-2013 Cloudmakers, s. r. o.
   All Rights Reserved.
 
+  Bayer Support Added by Karl Rees, Copyright(c) 2019
+
   Code is based on SX INDI Driver by Gerry Rozema and Jasem Mutlaq
   Copyright(c) 2010 Gerry Rozema.
   Copyright(c) 2012 Jasem Mutlaq.
@@ -51,6 +53,8 @@ class SXCCD : public INDI::CCD
     ISwitchVectorProperty CoolerSP;
     ISwitch ShutterS[2];
     ISwitchVectorProperty ShutterSP;
+    ISwitch BayerS[2];
+    ISwitchVectorProperty BayerSP;
     float TemperatureRequest;
     float TemperatureReported;
     float ExposureTimeLeft;
@@ -84,6 +88,7 @@ class SXCCD : public INDI::CCD
     void GuideExposureTimerHit();
     void WEGuiderTimerHit();
     void NSGuiderTimerHit();
+    bool saveConfigItems(FILE *fp);
     IPState GuideWest(uint32_t ms);
     IPState GuideEast(uint32_t ms);
     IPState GuideNorth(uint32_t ms);
@@ -94,6 +99,7 @@ class SXCCD : public INDI::CCD
     bool HasShutter;
     bool HasST4Port;
     bool HasGuideHead;
+    bool HasColor;
     SXCCD(DEVICE device, const char *name);
     virtual ~SXCCD();
     void debugTriggered(bool enable);

--- a/indi-sx/sxconfig.h
+++ b/indi-sx/sxconfig.h
@@ -8,4 +8,4 @@
 #pragma once
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 13
+#define VERSION_MINOR 14


### PR DESCRIPTION
- Added switch to specify whether camera has a Bayer filter or not.
- Enable Bayer-related text fields when Bayer filter selected.
- Update minor version number.