### PR TITLE
Induino weather name standards

### DIFF
--- a/indi-duino/devices/Firmwares/indiduinoMETEO/indiduinoMETEO.ino
+++ b/indi-duino/devices/Firmwares/indiduinoMETEO/indiduinoMETEO.ino
@@ -288,11 +288,13 @@ void checkMeteo() {
        digitalWrite(PIN_TO_DIGITAL(5), LOW); // disable internal pull-ups
     }
   
+#ifdef USE_IRRADIANCE_SENSOR
     if (Light>MINIMUM_DAYLIGHT) {
        digitalWrite(PIN_TO_DIGITAL(6), HIGH); // enable internal pull-ups
     } else {
        digitalWrite(PIN_TO_DIGITAL(6), LOW); // disable internal pull-ups
     }
+#endif //USE_IRRADIANCE_SENSOR
 
 }
 

--- a/indi-duino/devices/meteostation_sk.xml
+++ b/indi-duino/devices/meteostation_sk.xml
@@ -1,40 +1,40 @@
 <INDIDriver>
 
-<defNumberVector device="Arduino MeteoStation" name="Meteo" label="Meteo" group="METEO" state="Idle" perm="ro" timeout="60">
-    <defNumber name="T" label="Celsius" format="%4.2f" min="-100" max="100" step="1">
+<defNumberVector device="Arduino MeteoStation" name="WEATHER_PARAMETERS" label="Parameters" group="METEO" state="Idle" perm="ro" timeout="60">
+    <defNumber name="WEATHER_TEMPERATURE" label="Temperature (C)" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="24" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
-    <defNumber name="HR" label="HR" format="%4.2f" min="0" max="10240" step="1">
+    <defNumber name="WEATHER_HUMIDITY" label="Humidity (%)" format="%4.2f" min="0" max="10240" step="1">
     <indiduino pin="18" type="input" mul="0.01" add="0"/>
 0
     </defNumber>
 
-    <defNumber name="P" label="mBars" format="%4.2f" min="0" max="10240" step="1">
+    <defNumber name="WEATHER_PRESSURE" label="Pressure (hPa)" format="%4.2f" min="0" max="10240" step="1">
     <indiduino pin="16" type="input" mul="0.1" add="0"/>
 0
     </defNumber>
-    <defNumber name="DEW" label="DEW.POINT" format="%4.2f" min="-100" max="100" step="1">
+    <defNumber name="WEATHER_DEWPOINT" label="Dewpoint (C)" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="20" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
 
-    <defNumber name="clouds" label="clouds" format="%4.0f" min="0" max="100" step="1">
+    <defNumber name="WEATHER_CLOUD_COVER" label="Clouds (%)" format="%4.0f" min="0" max="100" step="1">
     <indiduino pin="22" type="input" mul="1" add="0"/>
 0
     </defNumber>
-    <defNumber name="SkyT" label="SkyT" format="%4.2f" min="-40" max="40" step="1">
+    <defNumber name="WEATHER_SKY_TEMPERATURE" label="Sky Temp (C)" format="%4.2f" min="-40" max="40" step="1">
     <indiduino pin="23" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
 
-    <defNumber name="Irradiance" label="Irradiance" format="%5.0f" min="0" max="10240" step="1">
+    <defNumber name="WEATHER_IR_RADIANCE" label="IR Radiance" format="%5.0f" min="0" max="10240" step="1">
     <indiduino pin="21" type="input" mul="1" add="0"/>
 0
     </defNumber>
 
 </defNumberVector>
-<defLightVector device="Arduino INPUTS" name="STATUS" label="STATUS" group="METEO" state="Idle" perm="ro" rule="AnyOfMany" timeout="60">
+<defLightVector device="Arduino INPUTS" name="WEATHER_STATUS" label="STATUS" group="METEO" state="Idle" perm="ro" rule="AnyOfMany" timeout="60">
 
     <defLight name="clouds" label="Cloudy">
         <indiduino pin="3"/>
@@ -74,55 +74,55 @@ On
 </defSwitchVector>
 
 
-<defNumberVector device="Arduino MeteoStation" name="IR" label="IR Sensor" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
-    <defNumber name="IR" label="IR" format="%4.2f" min="-100" max="100" step="1">
+<defNumberVector device="Arduino MeteoStation" name="IR" label="IR" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
+    <defNumber name="IR_IR" label="IR" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="14" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
-    <defNumber name="T" label="Celsius" format="%4.2f" min="-100" max="-100" step="1">
+    <defNumber name="IR_Temperature" label="Temperature (C)" format="%4.2f" min="-100" max="-100" step="1">
     <indiduino pin="15" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
 </defNumberVector>
-<defNumberVector device="Arduino MeteoStation" name="Presure" label="Presure Sensor" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
+<defNumberVector device="Arduino MeteoStation" name="Pressure" label="Pressure" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
 
-    <defNumber name="P" label="mBars" format="%4.2f" min="0" max="10240" step="1">
+    <defNumber name="P_Pressure" label="Pressure (hPa)" format="%4.2f" min="0" max="10240" step="1">
     <indiduino pin="16" type="input" mul="0.1" add="0"/>
 0
     </defNumber>
-    <defNumber name="T" label="Celsius" format="%4.2f" min="-100" max="100" step="1">
+    <defNumber name="P_Temperature" label="Temperature (C)" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="17" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
 </defNumberVector>
-<defNumberVector device="Arduino MeteoStation" name="HR" label="HR Sensor" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
-    <defNumber name="HR" label="HR" format="%4.2f" min="0" max="10240" step="1">
+<defNumberVector device="Arduino MeteoStation" name="Humidity" label="Humidity" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
+    <defNumber name="HR_Humidity" label="Humidity (%)" format="%4.2f" min="0" max="10240" step="1">
     <indiduino pin="18" type="input" mul="0.01" add="0"/>
 0
     </defNumber>
-    <defNumber name="T" label="Celsius" format="%4.2f" min="-100" max="100" step="1">
+    <defNumber name="HR_Temperature" label="Temperature (C)" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="19" type="input" mul="0.05" add="-273"/>
 0
     </defNumber>
 </defNumberVector>
-<defNumberVector device="Arduino MeteoStation" name="LIGHT" label="Irradiance" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
-    <defNumber name="LIGHT" label="LIGHT" format="%5.0f" min="0" max="10240" step="1">
+<defNumberVector device="Arduino MeteoStation" name="LIGHT" label="IR Radiance" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
+    <defNumber name="IR_RADIANCE" label="IR Radiance" format="%5.0f" min="0" max="10240" step="1">
     <indiduino pin="21" type="input" mul="1" add="0"/>
 0
     </defNumber>
 </defNumberVector>
 
 
-<defLightVector device="Arduino INPUTS" name="FAIL" label="Sensor FAIL" group="METEO" state="Idle" perm="ro" rule="AnyOfMany" timeout="60">
-    <defLight name="IR" label="IR Fail">
+<defLightVector device="Arduino INPUTS" name="FAIL" label="Sensor Failure" group="METEO" state="Idle" perm="ro" rule="AnyOfMany" timeout="60">
+    <defLight name="IR_FAIL" label="IR Failure">
         <indiduino pin="7"/>
         Idle
     </defLight>
-    <defLight name="HR" label="HR Fail">
+    <defLight name="HR_FAIL" label="HR Failure">
         <indiduino pin="8"/>
         Idle
     </defLight>
-    <defLight name="P" label="P Fail">
+    <defLight name="P_FAILURE" label="P Failure">
         <indiduino pin="9"/>
         Idle
     </defLight>

--- a/indi-duino/devices/meteostation_sk.xml
+++ b/indi-duino/devices/meteostation_sk.xml
@@ -63,17 +63,6 @@ On
     </defSwitch>
 </defSwitchVector>
 
-<defSwitchVector device="Arduino MeteoStation" name="BACK_LIGHT" label="BACK_LIGHT" group="Connection" state="Idle" perm="rw" rule="OneOfMany" timeout="1">
-    <defSwitch name="ON" label="OPEN">
-Off
-    <indiduino pin="13"/>
-    </defSwitch>
-    <defSwitch name="OFF" label="CLOSE">
-On
-    </defSwitch>
-</defSwitchVector>
-
-
 <defNumberVector device="Arduino MeteoStation" name="IR" label="IR" group="Raw Sensors" state="Idle" perm="ro" timeout="60">
     <defNumber name="IR_IR" label="IR" format="%4.2f" min="-100" max="100" step="1">
     <indiduino pin="14" type="input" mul="0.05" add="-273"/>


### PR DESCRIPTION
The Arduino based INDI weather driver has it's own style defining the property names. With this change, all sensor parameters obtain the prefix WEATHER_, similar to other INDI weather drivers.

This makes it possible using this INDI weather driver in the EKOS Observatory module to display the weather data there.

Additionally, a weakness has been eliminated for the cases that there is no IR radiance sensor present, which created compile problems on Arduino.