### PR TITLE
GPSD 3.20 compile fix

### DIFF
--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -315,13 +315,20 @@ IPState GPSD::updateGPS()
     if (IUFindOnSwitchIndex(&TimeSourceSP) == TS_GPS)
     {
         char ts[32] = {0};
+#if GPSD_API_MAJOR_VERSION < 9
         raw_time = gpsData->fix.time;
-
+#else
+        raw_time = gpsData->fix.time.tv_sec;
+#endif
 #ifdef __linux__
         stime(&raw_time);
 #endif
 
+#if GPSD_API_MAJOR_VERSION < 9
         unix_to_iso8601(gpsData->fix.time, ts, 32);
+#else
+        timespec_to_iso8601(gpsData->fix.time, ts, 32);
+#endif
         IUSaveText(&TimeT[0], ts);
 
         struct tm *local = localtime(&raw_time);


### PR DESCRIPTION
GPSD 3.20 has changed type of time in gps_fix_t and renamed a function so use conditionals to select either one.  Tested to compile with 3.17 (in Ubuntu 19.10 and Raspbian Buster) and 3.20 (in Ubuntu 20.04).