### PR TITLE
WIP: Nexstarevo add serial link

### DIFF
--- a/indi-nexstarevo/NexStarAUXScope.cpp
+++ b/indi-nexstarevo/NexStarAUXScope.cpp
@@ -380,7 +380,9 @@ bool NexStarAUXScope::Abort()
     AUXCommand stopAlt(MC_MOVE_POS, APP, ALT, b);
     AUXCommand stopAz(MC_MOVE_POS, APP, AZM, b);
     sendCmd(stopAlt);
+    readMsgs();
     sendCmd(stopAz);
+    readMsgs();
     return true;
 };
 
@@ -544,6 +546,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             dat[1] = 0x00;
             AUXCommand cmd(GET_VER, GPS, m.src, dat);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         case GPS_GET_LAT:
@@ -556,6 +559,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             else
                 cmd.setPosition(Lon);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         case GPS_GET_TIME:
@@ -572,6 +576,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             dat[2] = unsigned(ptm->tm_sec);
             AUXCommand cmd(GPS_GET_TIME, GPS, m.src, dat);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         case GPS_GET_DATE:
@@ -587,6 +592,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             dat[1] = unsigned(ptm->tm_mday);
             AUXCommand cmd(GPS_GET_DATE, GPS, m.src, dat);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         case GPS_GET_YEAR:
@@ -603,6 +609,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             // fprintf(stderr," Sending: %d [%d,%d]\n",ptm->tm_year,dat[0],dat[1]);
             AUXCommand cmd(GPS_GET_YEAR, GPS, m.src, dat);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         case GPS_LINKED:
@@ -613,6 +620,7 @@ void NexStarAUXScope::emulateGPS(AUXCommand &m)
             dat[0] = unsigned(1);
             AUXCommand cmd(GPS_LINKED, GPS, m.src, dat);
             sendCmd(cmd);
+	    readMsgs();
             break;
         }
         default:

--- a/indi-nexstarevo/NexStarAUXScope.h
+++ b/indi-nexstarevo/NexStarAUXScope.h
@@ -1,8 +1,14 @@
 
 #pragma once
 
+#include <indicom.h>
+#include <inditelescope.h>
+#include <connectionplugins/connectionserial.h>
+#include <connectionplugins/connectiontcp.h>
+
 #include <vector>
 #include <netinet/in.h>
+#include <sys/ioctl.h>
 
 typedef std::vector<unsigned char> buffer;
 
@@ -72,7 +78,7 @@ class AUXCommand
     bool valid;
 };
 
-class NexStarAUXScope
+class NexStarAUXScope : public INDI::Telescope
 {
   public:
     NexStarAUXScope(char const *ip, int port);
@@ -95,6 +101,13 @@ class NexStarAUXScope
     bool Park();
     bool Connect(int PortFD);
     bool Disconnect();
+
+  protected:
+    virtual const char *getDefaultName() override;
+    virtual const char *getDeviceName();
+    virtual bool ReadScopeStatus() override;
+    int sendBuffer(int PortFD, buffer buf);
+
 
   private:
     static const long STEPS_PER_REVOLUTION = 16777216;
@@ -120,4 +133,10 @@ class NexStarAUXScope
     int sock;
     struct sockaddr_in addr;
     bool simulator = false;
+    // FP
+    int modem_ctrl;
+    void setRTS(bool rts);
+    bool waitCTS(float timeout);
+    int nevo_tty_read(int PortFD,char *buf,int bufsiz,int timeout,int *n);
+    int nevo_tty_write (int PortFD,char *buf,int bufsiz,float timeout,int *n);
 };

--- a/indi-nexstarevo/nexstarevo.cpp
+++ b/indi-nexstarevo/nexstarevo.cpp
@@ -3,8 +3,6 @@
 
 #include "config.h"
 
-#include <indicom.h>
-#include <connectionplugins/connectionserial.h>
 
 using namespace INDI::AlignmentSubsystem;
 
@@ -73,6 +71,13 @@ NexStarEvo::NexStarEvo()
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                                TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION,
                            4);
+
+    //FP
+    LOG_INFO("NexStarEvo instancing\n");
+
+    //FP Both communication available, Serial and network (tcp/ip)
+    setTelescopeConnection(CONNECTION_SERIAL | CONNECTION_TCP);
+
     // Approach from no further then degs away
     Approach = 1.0;
 
@@ -148,6 +153,7 @@ bool NexStarEvo::Connect()
 bool NexStarEvo::Handshake()
 {
     //scope.initScope(tcpConnection->host(), tcpConnection->port());
+    
     return scope.Connect(PortFD);
 }
 
@@ -358,15 +364,18 @@ bool NexStarEvo::initProperties()
     IUFillSwitchVector(&SlewRateSP, SlewRateS, 4, getDeviceName(), "TELESCOPE_SLEW_RATE", "Slew Rate", MOTION_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     TrackState = SCOPE_IDLE;
-
-    // We don't want serial port for now
-    unRegisterConnection(serialConnection);
-
+ 
     /* Add debug controls so we may debug driver if necessary */
     addDebugControl();
 
-    // Add alignment properties
+    /* Add alignment properties */
     InitAlignmentProperties(this);
+
+    //FP default connection options
+    serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
+
+    tcpConnection->setDefaultHost("192.168.1.1");
+    tcpConnection->setDefaultPort(2000);
 
     return true;
 }

--- a/indi-nexstarevo/nexstarevo.h
+++ b/indi-nexstarevo/nexstarevo.h
@@ -3,8 +3,11 @@
 
 #include "NexStarAUXScope.h"
 
-#include <inditelescope.h>
+//#include <indicom.h>
+//#include <inditelescope.h>
 #include <alignment/AlignmentSubsystemForDrivers.h>
+//#include "connectionplugins/connectionserial.h"
+//#include "connectionplugins/connectiontcp.h"
 
 class NexStarEvo : public INDI::Telescope, public INDI::AlignmentSubsystem::AlignmentSubsystemForDrivers
 {
@@ -110,6 +113,9 @@ class NexStarEvo : public INDI::Telescope, public INDI::AlignmentSubsystem::Alig
     // Tracing in timer tick
     int TraceThisTickCount;
     bool TraceThisTick;
+
+    // connection
+    uint8_t nseConnection { CONNECTION_SERIAL | CONNECTION_TCP };
 
     unsigned int DBG_NSEVO;
     unsigned int DBG_MOUNT;


### PR DESCRIPTION
The nexstarevo driver is modified to add the serial link capability to the network link capability already present. Since the serial ports AUX and PC of Celestron scopes requires hardware handshake with echo of transmitted characters, its read/write logic is different from the network link one. I tried to merge them, but, probably, the network link is broken now.