### PR TITLE
Save horizon configuration items.

### DIFF
--- a/indi-eqmod/eqmodbase.cpp
+++ b/indi-eqmod/eqmodbase.cpp
@@ -3674,6 +3674,10 @@ bool EQMod::saveConfigItems(FILE *fp)
     if (align)
         align->saveConfigItems(fp);
 #endif
+#ifdef WITH_SCOPE_LIMITS
+    if (horizon)
+        horizon->saveConfigItems(fp);
+#endif
     return true;
 }
 

--- a/indi-eqmod/scope-limits/scope-limits.cpp
+++ b/indi-eqmod/scope-limits/scope-limits.cpp
@@ -590,3 +590,12 @@ bool HorizonLimits::checkLimits(double az, double alt, INDI::Telescope::Telescop
         warningMessageDispatched = false;
     return (abortscope);
 }
+
+bool HorizonLimits::saveConfigItems(FILE *fp)
+{
+    if (HorizonLimitsOnLimitSP)
+        IUSaveConfigSwitch(fp, HorizonLimitsOnLimitSP);
+    if (HorizonLimitsLimitGotoSP)
+        IUSaveConfigSwitch(fp, HorizonLimitsLimitGotoSP);
+    return true;
+}

--- a/indi-eqmod/scope-limits/scope-limits.h
+++ b/indi-eqmod/scope-limits/scope-limits.h
@@ -72,4 +72,5 @@ class HorizonLimits
     virtual bool inLimits(double az, double alt);
     virtual bool inGotoLimits(double az, double alt);
     virtual bool checkLimits(double az, double alt, INDI::Telescope::TelescopeStatus status, bool ingoto);
+    virtual bool saveConfigItems(FILE *fp);
 };


### PR DESCRIPTION
This is a proposal for saving the configuration items "Abort tracking", "Abort slewing" and "Abort Goto" in the context of horizon management. Saving configuration now includes those items.

As for other drivers, configuration should never be saved when the device is not connected, as undefined properties won't be part of the saved data stream. Properties not saved because they are undefined revert to their default value on next load.

Tested with simulation mode, loading/saving, connecting/disconnecting.