### PR TITLE
Stargo 1.9 | Tracking adjustment

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,8 +1,11 @@
 indi-avalon (1.9) buster; urgency=medium
 
   * Bug fix, ignoring unsolicitated ge#
+  * Use INDI_ENABLED and INDI_DISABLED
+  * Types corrected to correct compiler warnings
+  * Tracking adjustment added
 
- -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Mon, 02 Dec 2019 17:06:15 +0100
+-- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sat, 13 Mar 2020 15:40:00 +0100
 
 indi-avalon (1.8) buster; urgency=medium
 

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.9) buster; urgency=medium
+
+  * Bug fix, ignoring unsolicitated ge#
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Mon, 02 Dec 2019 17:06:15 +0100
+
 indi-avalon (1.8) buster; urgency=medium
 
   * Make mount command delay configurable

--- a/indi-avalon/CMakeLists.txt
+++ b/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 8)
+set(AVALON_VERSION_MINOR 9)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -1103,6 +1103,7 @@ bool LX200StarGo::saveConfigItems(FILE *fp)
     IUSaveConfigText(fp, &SiteNameTP);
     IUSaveConfigSwitch(fp, &Aux1FocuserSP);
     IUSaveConfigNumber(fp, &MountRequestDelayNP);
+    IUSaveConfigNumber(fp, &TrackingAdjustmentNP);
 
     focuserAux1->saveConfigItems(fp);
 
@@ -1699,7 +1700,6 @@ bool LX200StarGo::syncSideOfPier()
             setPierSide(INDI::Telescope::PIER_UNKNOWN);
             break;
         case 'W':
-            // seems to be vice versa
             LOG_DEBUG("Detected pier side west.");
             setPierSide(INDI::Telescope::PIER_EAST);
             break;

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -201,7 +201,7 @@ bool LX200StarGo::ISNewSwitch(const char *dev, const char *name, ISState *states
         {
             if (IUUpdateSwitch(&TrackModeSP, states, names, n) < 0)
                 return false;
-            int trackMode = IUFindOnSwitchIndex(&TrackModeSP);
+            uint8_t trackMode = static_cast<uint8_t>(IUFindOnSwitchIndex(&TrackModeSP));
 
             bool result = SetTrackMode(trackMode);
 
@@ -365,6 +365,20 @@ bool LX200StarGo::ISNewNumber(const char *dev, const char *name, double values[]
             MountRequestDelayNP.s = IPS_OK;
             IDSetNumber(&MountRequestDelayNP, nullptr);
             return true;
+        } else if (!strcmp(name, TrackingAdjustmentNP.name))
+        {
+            // changing tracking adjustment
+            bool success = setTrackingAdjustment(values[0]);
+            if (success)
+            {
+                TrackingAdjustment[0].value = values[0];
+                TrackingAdjustmentNP.s      = IPS_OK;
+            }
+            else
+                TrackingAdjustmentNP.s = IPS_ALERT;
+
+            IDSetNumber(&TrackingAdjustmentNP, nullptr);
+            return success;
         }
     }
 
@@ -420,6 +434,9 @@ bool LX200StarGo::initProperties()
     IUFillSwitch(&SystemSpeedSlewS[3], "SYSTEM_SLEW_SPEED_HIGH", "high", ISS_OFF);
     IUFillSwitchVector(&SystemSpeedSlewSP, SystemSpeedSlewS, 4, getDeviceName(), "SYSTEM_SLEW_SPEED", "Slew Speed", RA_DEC_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
+    // Tracking adjustment
+    IUFillNumber(&TrackingAdjustment[0], "ADJUSTMENT_RA", "Adj. (max +/- 5%)", "%.2f", -5.0, 5.0, 0.01, 0.0);
+    IUFillNumberVector(&TrackingAdjustmentNP, TrackingAdjustment, 1, getDeviceName(), "TRACKING_ADJUSTMENT", "Tracking", RA_DEC_TAB, IP_RW, 60.0, IPS_IDLE);
 
     // meridian flip
     IUFillSwitch(&MeridianFlipModeS[0], "MERIDIAN_FLIP_AUTO", "auto", ISS_OFF);
@@ -453,6 +470,7 @@ bool LX200StarGo::updateProperties()
         defineSwitch(&ST4StatusSP);
         defineSwitch(&KeypadStatusSP);
         defineSwitch(&SystemSpeedSlewSP);
+        defineNumber(&TrackingAdjustmentNP);
         defineSwitch(&MeridianFlipModeSP);
         defineNumber(&MountRequestDelayNP);
         defineText(&MountFirmwareInfoTP);
@@ -466,6 +484,7 @@ bool LX200StarGo::updateProperties()
         deleteProperty(GuidingSpeedNP.name);
         deleteProperty(ST4StatusSP.name);
         deleteProperty(KeypadStatusSP.name);
+        deleteProperty(TrackingAdjustmentNP.name);
         deleteProperty(SystemSpeedSlewSP.name);
         deleteProperty(MeridianFlipModeSP.name);
         deleteProperty(MountRequestDelayNP.name);
@@ -1935,6 +1954,57 @@ bool LX200StarGo::setSlewMode(int slewMode)
     }
     return true;
 }
+
+/*
+ * Adjust RA tracking speed.
+ */
+bool LX200StarGo::setTrackingAdjustment(double adjust)
+{
+    LOG_DEBUG(__FUNCTION__);
+    char cmd[AVALON_COMMAND_BUFFER_LENGTH];
+
+    /*
+     * X1Etttt#  where tttt are four decimal digits with a little bit trickly meaning.
+     * The cf  (correction factor) value will be: cf =  [10000 + (tttt - 1000)] / 10000
+     *
+     *       AdjustedSiderealSpeed = DefaultSiderealSpeed*cf
+     *
+     * So e.g.: if tttt = 1000 then cf = 1.0000 (No corr)
+     *          if tttt = 1027 then cf = 1.0027 i.e.  27 on 10000  (0.27%  faster)
+     *          if tttt = 0973 then cf = 0.9973 i.e. -27 on 10000  (0.27% slower)
+     */
+
+    // ensure that -5 <= adjust <= 5
+    if (adjust > 5.0)
+    {
+        LOGF_ERROR("Adjusting tracking by %0.2f%% not allowed. Maximal value is 5.0%%", adjust);
+        return false;
+    }
+    else if (adjust < -5.0)
+    {
+        LOGF_ERROR("Adjusting tracking by %0.2f%% not allowed. Minimal value is -5.0%%", adjust);
+        return false;
+    }
+
+    int parameter = static_cast<int>(adjust * 100) + 1000;
+
+    sprintf(cmd, ":X1E%04u#", parameter);
+
+    // no response expected
+    if(!transmit(cmd))
+    {
+        LOGF_ERROR("Cannot adjust tracking by %d%%", adjust);
+        return false;
+    }
+    if (adjust == 0.0)
+        LOG_INFO("RA tracking adjustment cleared.");
+    else if (adjust > 0.0)
+        LOGF_INFO("RA tracking adjustment to +%0.2f%% succeded.", adjust);
+    else
+        LOGF_INFO("RA tracking adjustment to %0.2f%% succeded.", adjust);
+
+    return true;
+}
 bool LX200StarGo::SetMeridianFlipMode(int index)
 {
     // 0: Auto mode: Enabled and not Forced
@@ -2071,7 +2141,7 @@ IPState LX200StarGo::GuideNorth(uint32_t ms)
     SlewRateS[SLEW_GUIDE].s = ISS_ON;
     IDSetSwitch(&SlewRateSP, nullptr);
     guide_direction_ns = LX200_NORTH;
-    GuideNSTID      = IEAddTimer(ms, guideTimeoutHelperNS, this);
+    GuideNSTID      = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
@@ -2120,7 +2190,7 @@ IPState LX200StarGo::GuideSouth(uint32_t ms)
     SlewRateS[SLEW_GUIDE].s = ISS_ON;
     IDSetSwitch(&SlewRateSP, nullptr);
     guide_direction_ns = LX200_SOUTH;
-    GuideNSTID      = IEAddTimer(ms, guideTimeoutHelperNS, this);
+    GuideNSTID         = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
@@ -2169,7 +2239,7 @@ IPState LX200StarGo::GuideEast(uint32_t ms)
     SlewRateS[SLEW_GUIDE].s = ISS_ON;
     IDSetSwitch(&SlewRateSP, nullptr);
     guide_direction_we = LX200_EAST;
-    GuideWETID      = IEAddTimer(ms, guideTimeoutHelperWE, this);
+    GuideWETID         = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
 }
 
@@ -2218,7 +2288,7 @@ IPState LX200StarGo::GuideWest(uint32_t ms)
     SlewRateS[SLEW_GUIDE].s = ISS_ON;
     IDSetSwitch(&SlewRateSP, nullptr);
     guide_direction_we = LX200_WEST;
-    GuideWETID      = IEAddTimer(ms, guideTimeoutHelperWE, this);
+    GuideWETID         = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
 }
 
@@ -2274,11 +2344,10 @@ bool LX200StarGo::SetTrackEnabled(bool enabled)
 bool LX200StarGo::SetTrackRate(double raRate, double deRate)
 {
     LOG_DEBUG(__FUNCTION__);
-    INDI_UNUSED(raRate);
     INDI_UNUSED(deRate);
     char cmd[AVALON_COMMAND_BUFFER_LENGTH];
     char response[AVALON_RESPONSE_BUFFER_LENGTH];
-    int rate = raRate;
+    int rate = static_cast<int>(raRate);
     sprintf(cmd, ":X1E%04d", rate);
     if(!sendQuery(cmd, response, 0))
     {
@@ -2565,7 +2634,7 @@ bool LX200StarGo::setUTCOffset(double offset)
     LOG_DEBUG(__FUNCTION__);
     char cmd[RB_MAX_LEN] = {0};
     char response[RB_MAX_LEN] = {0};
-    int hours = offset * -1.0;
+    int hours = static_cast<int>(offset * -1.0);
 
     snprintf(cmd, sizeof(cmd), ":SG %+03d#", hours);
 

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -1211,6 +1211,12 @@ bool LX200StarGo::ParseMotionState(char* state)
         };
         return true;
     }
+    else if (strcmp(state, "ge"))
+    {
+        // ignore ge#, which signals that a goto ended or stopped
+        LOG_DEBUG("Received motion state ge#");
+        return true;
+    }
     else
     {
         return false;

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -507,6 +507,7 @@ bool LX200StarGo::ReadScopeStatus()
         return true;
     }
 
+    LOG_DEBUG("################################ ReadScopeStatus (start) ################################");
     int x, y;
 
     if (! getMotorStatus(&x, &y))
@@ -580,6 +581,8 @@ bool LX200StarGo::ReadScopeStatus()
         LOG_ERROR("Cannot determine scope status, failed to determine pier side.");
         return false;
     }
+
+    LOG_DEBUG("################################ ReadScopeStatus (finish) ###############################");
 
     if (focuserAux1.get() != nullptr && TrackState != SCOPE_SLEWING)
         return focuserAux1.get()->ReadFocuserStatus();
@@ -1209,12 +1212,6 @@ bool LX200StarGo::ParseMotionState(char* state)
                 CurrentSlewRate = SLEW_MAX;
                 break;
         };
-        return true;
-    }
-    else if (strcmp(state, "ge") == 0)
-    {
-        // ignore ge#, which signals that a goto ended or stopped
-        LOG_DEBUG("Received motion state 'ge#' (goto finished or stopped)");
         return true;
     }
     else

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -1211,10 +1211,10 @@ bool LX200StarGo::ParseMotionState(char* state)
         };
         return true;
     }
-    else if (strcmp(state, "ge"))
+    else if (strcmp(state, "ge") == 0)
     {
         // ignore ge#, which signals that a goto ended or stopped
-        LOG_DEBUG("Received motion state ge#");
+        LOG_DEBUG("Received motion state 'ge#' (goto finished or stopped)");
         return true;
     }
     else

--- a/indi-avalon/lx200stargo.h
+++ b/indi-avalon/lx200stargo.h
@@ -138,6 +138,9 @@ class LX200StarGo : public LX200Telescope
         ISwitch SystemSpeedSlewS[4];
         ISwitchVectorProperty SystemSpeedSlewSP;
 
+        // tracking adjustment setting
+        INumberVectorProperty TrackingAdjustmentNP;
+        INumber TrackingAdjustment[1];
 
         // meridian flip
         ISwitchVectorProperty MeridianFlipModeSP;
@@ -214,9 +217,9 @@ class LX200StarGo : public LX200Telescope
         virtual bool setST4Enabled(bool enabled);
 
         // meridian flip
-
         virtual bool syncSideOfPier();
         bool checkLX200Format();
+
         // Guide Commands
         virtual IPState GuideNorth(uint32_t ms) override;
         virtual IPState GuideSouth(uint32_t ms) override;
@@ -245,6 +248,9 @@ class LX200StarGo : public LX200Telescope
         int MoveTo(int direction);
 
         bool setSlewMode(int slewMode);
+
+        // tracking adjustment
+        bool setTrackingAdjustment(double adjust);
 
 };
 inline bool LX200StarGo::sendQuery(const char* cmd, char* response, int wait)

--- a/indi-avalon/lx200stargofocuser.cpp
+++ b/indi-avalon/lx200stargofocuser.cpp
@@ -177,10 +177,11 @@ bool LX200StarGoFocuser::ISNewNumber(const char *dev, const char *name, double v
  ***************************************************************************/
 
 bool LX200StarGoFocuser::changeFocusTimer(double values[], char* names[], int n) {
-    int time = (int)values[0];
+    int time = static_cast<int>(values[0]);
     if (validateFocusTimer(time)) {
         IUUpdateNumber(&FocusTimerNP, values, names, n);
-        FocusTimerNP.s = MoveFocuser(FocusMotionS[0].s == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD, FocusSpeedN[0].value, FocusTimerN[0].value);
+        FocusTimerNP.s = MoveFocuser(FocusMotionS[0].s == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD,
+                static_cast<int>(FocusSpeedN[0].value), static_cast<uint16_t>(FocusTimerN[0].value));
         IDSetNumber(&FocusTimerNP, nullptr);
     }
     return true;
@@ -196,7 +197,7 @@ bool LX200StarGoFocuser::changeFocusMotion(ISState* states, char* names[], int n
 
 
 bool LX200StarGoFocuser::changeFocusAbsPos(double values[], char* names[], int n) {
-    int absolutePosition = (int)values[0];
+    uint32_t absolutePosition = static_cast<uint32_t>(values[0]);
     if (validateFocusAbsPos(absolutePosition)) {
         double currentPosition = FocusAbsPosN[0].value;
         IUUpdateNumber(&FocusAbsPosNP, values, names, n);
@@ -211,7 +212,7 @@ bool LX200StarGoFocuser::changeFocusAbsPos(double values[], char* names[], int n
 }
 
 bool LX200StarGoFocuser::changeFocusRelPos(double values[], char* names[], int n) {
-    int relativePosition = (int)values[0];
+    int relativePosition = static_cast<int>(values[0]);
     if (validateFocusRelPos(relativePosition)) {
         IUUpdateNumber(&FocusRelPosNP, values, names, n);
         FocusRelPosNP.s = moveFocuserRelative(relativePosition);
@@ -221,7 +222,7 @@ bool LX200StarGoFocuser::changeFocusRelPos(double values[], char* names[], int n
 }
 
 bool LX200StarGoFocuser::changeFocusSpeed(double values[], char* names[], int n) {
-    int speed = (int)values[0];
+    int speed = static_cast<int>(values[0]);
     if (validateFocusSpeed(speed)) {
         IUUpdateNumber(&FocusSpeedNP, values, names, n);
         FocusSpeedNP.s = SetFocuserSpeed(speed) ? IPS_OK : IPS_ALERT;
@@ -261,7 +262,7 @@ bool LX200StarGoFocuser::changeFocusAbort(ISState* states, char* names[], int n)
 
 
 bool LX200StarGoFocuser::changeFocusSyncPos(double values[], char* names[], int n) {
-    int absolutePosition = (int)values[0];
+    int absolutePosition = static_cast<int>(values[0]);
     if (validateFocusSyncPos(absolutePosition)) {
         IUUpdateNumber(&FocusSyncPosNP, values, names, n);
         FocusSyncPosNP.s = syncFocuser(absolutePosition);
@@ -271,8 +272,8 @@ bool LX200StarGoFocuser::changeFocusSyncPos(double values[], char* names[], int 
 }
 
 bool LX200StarGoFocuser::validateFocusSpeed(int speed) {
-    int minSpeed = FocusSpeedN[0].min;
-    int maxSpeed = FocusSpeedN[0].max;
+    int minSpeed = static_cast<int>(FocusSpeedN[0].min);
+    int maxSpeed = static_cast<int>(FocusSpeedN[0].max);
     if (speed < minSpeed || speed > maxSpeed) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Cannot set focuser speed to %d, it is outside the valid range of [%d, %d]", getDeviceName(), speed, minSpeed, maxSpeed);
         return false;
@@ -281,8 +282,8 @@ bool LX200StarGoFocuser::validateFocusSpeed(int speed) {
 }
 
 bool LX200StarGoFocuser::validateFocusTimer(int time) {
-    int minTime = FocusTimerN[0].min;
-    int maxTime = FocusTimerN[0].max;
+    int minTime = static_cast<int>(FocusTimerN[0].min);
+    int maxTime = static_cast<int>(FocusTimerN[0].max);
     if (time < minTime || time > maxTime) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Cannot set focuser timer to %d, it is outside the valid range of [%d, %d]", getDeviceName(), time, minTime, maxTime);
         return false;
@@ -290,9 +291,9 @@ bool LX200StarGoFocuser::validateFocusTimer(int time) {
     return true;
 }
 
-bool LX200StarGoFocuser::validateFocusAbsPos(int absolutePosition) {
-    int minPosition = FocusAbsPosN[0].min;
-    int maxPosition = FocusAbsPosN[0].max;
+bool LX200StarGoFocuser::validateFocusAbsPos(uint32_t absolutePosition) {
+    uint32_t minPosition = static_cast<uint32_t>(FocusAbsPosN[0].min);
+    uint32_t maxPosition = static_cast<uint32_t>(FocusAbsPosN[0].max);
     if (absolutePosition < minPosition || absolutePosition > maxPosition) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Cannot set focuser absolute position to %d, it is outside the valid range of [%d, %d]", getDeviceName(), absolutePosition, minPosition, maxPosition);
         return false;
@@ -301,19 +302,19 @@ bool LX200StarGoFocuser::validateFocusAbsPos(int absolutePosition) {
 }
 
 bool LX200StarGoFocuser::validateFocusRelPos(int relativePosition) {
-    int minRelativePosition = FocusRelPosN[0].min;
-    int maxRelativePosition = FocusRelPosN[0].max;
+    int minRelativePosition = static_cast<int>(FocusRelPosN[0].min);
+    int maxRelativePosition = static_cast<int>(FocusRelPosN[0].max);
     if (relativePosition < minRelativePosition || relativePosition > maxRelativePosition) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Cannot set focuser relative position to %d, it is outside the valid range of [%d, %d]", getDeviceName(), relativePosition, minRelativePosition, maxRelativePosition);
         return false;
     }
-    int absolutePosition = getAbsoluteFocuserPositionFromRelative(relativePosition);
+    uint32_t absolutePosition = getAbsoluteFocuserPositionFromRelative(relativePosition);
     return validateFocusAbsPos(absolutePosition);
 }
 
 bool LX200StarGoFocuser::validateFocusSyncPos(int absolutePosition) {
-    int minPosition = FocusSyncPosN[0].min;
-    int maxPosition = FocusSyncPosN[0].max;
+    int minPosition = static_cast<int>(FocusSyncPosN[0].min);
+    int maxPosition = static_cast<int>(FocusSyncPosN[0].max);
     if (absolutePosition < minPosition || absolutePosition > maxPosition) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Cannot sync focuser to position %d, it is outside the valid range of [%d, %d]", getDeviceName(), absolutePosition, minPosition, maxPosition);
         return false;
@@ -321,12 +322,12 @@ bool LX200StarGoFocuser::validateFocusSyncPos(int absolutePosition) {
     return true;
 }
 
-int LX200StarGoFocuser::getAbsoluteFocuserPositionFromRelative(int relativePosition) {
+uint32_t LX200StarGoFocuser::getAbsoluteFocuserPositionFromRelative(int relativePosition) {
     bool inward = FocusMotionS[0].s == ISS_ON;
     if (inward) {
         relativePosition *= -1;
     }
-    return FocusAbsPosN[0].value + relativePosition;
+    return static_cast<uint32_t>(FocusAbsPosN[0].value + relativePosition);
 }
 
 
@@ -364,9 +365,9 @@ IPState LX200StarGoFocuser::MoveFocuser(FocusDirection dir, int speed, uint16_t 
     if (duration == 0) {
         return IPS_OK;
     }
-    int position = FocusAbsPosN[0].min;
+    uint32_t position = static_cast<uint32_t>(FocusAbsPosN[0].min);
     if (dir == FOCUS_INWARD) {
-        position = FocusAbsPosN[0].max;
+        position = static_cast<uint32_t>(FocusAbsPosN[0].max);
     }
     moveFocuserDurationRemaining = duration;
     bool result = sendMoveFocuserToPosition(position);
@@ -388,7 +389,7 @@ IPState LX200StarGoFocuser::moveFocuserRelative(int relativePosition) {
     if (relativePosition == 0) {
         return IPS_OK;
     }
-    int absolutePosition = getAbsoluteFocuserPositionFromRelative(relativePosition);
+    uint32_t absolutePosition = getAbsoluteFocuserPositionFromRelative(relativePosition);
     return MoveAbsFocuser(absolutePosition);
 }
 
@@ -507,7 +508,7 @@ bool LX200StarGoFocuser::sendQueryFocuserPosition(int* position) {
     return true;
 }
 
-bool LX200StarGoFocuser::sendMoveFocuserToPosition(int position) {
+bool LX200StarGoFocuser::sendMoveFocuserToPosition(uint32_t position) {
     // Command  - :X16pppppp#
     // Response - Nothing
     targetFocuserPosition = (focuserReversed == INDI_DISABLED) ? position : -position;
@@ -540,7 +541,7 @@ bool LX200StarGoFocuser::isFocuserMoving() {
 }
 
 bool LX200StarGoFocuser::atFocuserTargetPosition() {
-    return FocusAbsPosN[0].value == (focuserReversed == INDI_DISABLED) ? targetFocuserPosition : -targetFocuserPosition;
+    return static_cast<uint32_t>(FocusAbsPosN[0].value) == (focuserReversed == INDI_DISABLED) ? targetFocuserPosition : -targetFocuserPosition;
 }
 
 

--- a/indi-avalon/lx200stargofocuser.cpp
+++ b/indi-avalon/lx200stargofocuser.cpp
@@ -236,7 +236,7 @@ bool LX200StarGoFocuser::setFocuserDirection(ISState* states, char* names[], int
     if (IUUpdateSwitch(&FocusReverseSP, states, names, n) < 0)
         return false;
 
-    focuserReversed = (IUFindOnSwitchIndex(&FocusReverseSP) > 0 ? REVERSED_ENABLED : REVERSED_DISABLED);
+    focuserReversed = (IUFindOnSwitchIndex(&FocusReverseSP) > 0 ? INDI_ENABLED : INDI_DISABLED);
 
     FocusReverseSP.s = IPS_OK;
     IDSetSwitch(&FocusReverseSP, nullptr);
@@ -337,7 +337,7 @@ bool LX200StarGoFocuser::ReadFocuserStatus() {
 
     int absolutePosition = 0;
     if (sendQueryFocuserPosition(&absolutePosition)) {
-        FocusAbsPosN[0].value = (focuserReversed == REVERSED_DISABLED) ? absolutePosition : -absolutePosition;
+        FocusAbsPosN[0].value = (focuserReversed == INDI_DISABLED) ? absolutePosition : -absolutePosition;
         IDSetNumber(&FocusAbsPosNP, nullptr);
     }
     else
@@ -475,7 +475,7 @@ bool LX200StarGoFocuser::sendSyncFocuserToPosition(int position) {
     // Command  - :X0Cpppppp#
     // Response - Nothing
     char command[AVALON_COMMAND_BUFFER_LENGTH] = {0};
-    sprintf(command, ":X0C%06d#", AVALON_FOCUSER_POSITION_OFFSET + ((focuserReversed == REVERSED_DISABLED) ? position : -position));
+    sprintf(command, ":X0C%06d#", AVALON_FOCUSER_POSITION_OFFSET + ((focuserReversed == INDI_DISABLED) ? position : -position));
     if (!baseDevice->transmit(command)) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Failed to send AUX1 sync command.", getDeviceName());
         return false;
@@ -510,7 +510,7 @@ bool LX200StarGoFocuser::sendQueryFocuserPosition(int* position) {
 bool LX200StarGoFocuser::sendMoveFocuserToPosition(int position) {
     // Command  - :X16pppppp#
     // Response - Nothing
-    targetFocuserPosition = (focuserReversed == REVERSED_DISABLED) ? position : -position;
+    targetFocuserPosition = (focuserReversed == INDI_DISABLED) ? position : -position;
     char command[AVALON_COMMAND_BUFFER_LENGTH] = {0};
     sprintf(command, ":X16%06d#", AVALON_FOCUSER_POSITION_OFFSET + targetFocuserPosition);
     if (!baseDevice->transmit(command)) {
@@ -540,7 +540,7 @@ bool LX200StarGoFocuser::isFocuserMoving() {
 }
 
 bool LX200StarGoFocuser::atFocuserTargetPosition() {
-    return FocusAbsPosN[0].value == (focuserReversed == REVERSED_DISABLED) ? targetFocuserPosition : -targetFocuserPosition;
+    return FocusAbsPosN[0].value == (focuserReversed == INDI_DISABLED) ? targetFocuserPosition : -targetFocuserPosition;
 }
 
 

--- a/indi-avalon/lx200stargofocuser.h
+++ b/indi-avalon/lx200stargofocuser.h
@@ -32,23 +32,23 @@ class LX200StarGoFocuser : public INDI::DefaultDevice, public INDI::FocuserInter
 {
 public:
     LX200StarGoFocuser(LX200StarGo* defaultDevice, const char* name);
-    virtual ~LX200StarGoFocuser() = default;
+    virtual ~LX200StarGoFocuser() override = default;
 
     void initProperties(const char *groupName);
-    bool updateProperties();
+    bool updateProperties() override;
     bool ReadFocuserStatus();
 
-    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
-    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
     const char *getDeviceName();
-    const char *getDefaultName();
+    const char *getDefaultName() override;
 
     bool isConnected();
 
     bool activate(bool enabled);
 
-    bool saveConfigItems(FILE *fp);
+    bool saveConfigItems(FILE *fp) override;
 
 protected:
 
@@ -69,13 +69,10 @@ protected:
     bool AbortFocuser() override;
     IPState syncFocuser(int absolutePosition);
 
-    ISwitchVectorProperty FocusAbortSP;
-    ISwitch FocusAbortS[1];
-
     INumberVectorProperty FocusSyncPosNP;
     INumber FocusSyncPosN[1];
 
-    int targetFocuserPosition;
+    uint32_t targetFocuserPosition;
     bool startMovingFocuserInward;
     bool startMovingFocuserOutward;
     uint32_t moveFocuserDurationRemaining;
@@ -85,7 +82,7 @@ protected:
 
     // LX200 commands
     bool sendNewFocuserSpeed(int speed);
-    bool sendMoveFocuserToPosition(int position);
+    bool sendMoveFocuserToPosition(uint32_t position);
     bool sendAbortFocuser();
     bool sendSyncFocuserToPosition(int position);
     bool sendQueryFocuserPosition(int* position);
@@ -96,11 +93,11 @@ protected:
 
     bool validateFocusSpeed(int speed);
     bool validateFocusTimer(int time);
-    bool validateFocusAbsPos(int absolutePosition);
+    bool validateFocusAbsPos(uint32_t absolutePosition);
     bool validateFocusRelPos(int relativePosition);
     bool validateFocusSyncPos(int absolutePosition);
 
-    int getAbsoluteFocuserPositionFromRelative(int relativePosition);
+    uint32_t getAbsoluteFocuserPositionFromRelative(int relativePosition);
 
 private:
     LX200StarGo* baseDevice;

--- a/indi-avalon/lx200stargofocuser.h
+++ b/indi-avalon/lx200stargofocuser.h
@@ -28,7 +28,7 @@
 #include "defaultdevice.h"
 
 
-class LX200StarGoFocuser : public INDI::FocuserInterface
+class LX200StarGoFocuser : public INDI::DefaultDevice, public INDI::FocuserInterface
 {
 public:
     LX200StarGoFocuser(LX200StarGo* defaultDevice, const char* name);
@@ -80,7 +80,7 @@ protected:
     bool startMovingFocuserOutward;
     uint32_t moveFocuserDurationRemaining;
     bool focuserActivated;
-    int focuserReversed = REVERSED_DISABLED;
+    int focuserReversed = INDI_DISABLED;
 
 
     // LX200 commands

--- a/indi-sx/sxconfig.h
+++ b/indi-sx/sxconfig.h
@@ -8,4 +8,4 @@
 #pragma once
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 14
+#define VERSION_MINOR 13


### PR DESCRIPTION
Avalon StarGO has the feature to adjust the tracking speed in the range of +/- 5%. This release adds a control to the RA/DEC tab to set the value.

Additionally, this release holds some bug fixes and code cleanup.