### PR TITLE
indi-3rdparty: Replacing stime() with clocksettime() in gps_driver & …

### DIFF
--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -152,6 +152,23 @@ bool GPSD::updateProperties()
     }
     return true;
 }
+bool GPSD::setSystemTime(time_t& raw_time)
+{
+    #ifdef __linux__
+        #if defined(__GNU_LIBRARY__)
+            #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+                timespec sTime = {};
+                sTime.tv_sec = raw_time;
+                clock_settime(CLOCK_REALTIME, &sTime);
+            #else
+                stime(&raw_time);
+            #endif
+        #else
+            stime(&raw_time);
+        #endif
+    #endif
+    return true;
+}
 
 IPState GPSD::updateGPS()
 {
@@ -202,19 +219,7 @@ IPState GPSD::updateGPS()
 
         time(&raw_time);
 
-#ifdef __linux__
-    #if defined(__GNU_LIBRARY__)
-        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
-            timespec tss = {};
-            tss.tv_sec = raw_time;
-            clock_settime(CLOCK_REALTIME, &tss);
-        #else
-            stime(&raw_time);
-        #endif
-    #else
-        stime(&raw_time);
-    #endif
-#endif
+        setSystemTime(raw_time);
 
         struct tm *utc = gmtime(&raw_time);
         strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", utc);
@@ -330,19 +335,8 @@ IPState GPSD::updateGPS()
 #else
         raw_time = gpsData->fix.time.tv_sec;
 #endif
-#ifdef __linux__
-    #if defined(__GNU_LIBRARY__)
-        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
-            timespec tss = {};
-            tss.tv_sec = raw_time;
-            clock_settime(CLOCK_REALTIME, &tss);
-        #else
-            stime(&raw_time);
-        #endif
-    #else
-        stime(&raw_time);
-    #endif
-#endif
+    
+        setSystemTime(raw_time);
 
 #if GPSD_API_MAJOR_VERSION < 9
         unix_to_iso8601(gpsData->fix.time, ts, 32);

--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -203,7 +203,17 @@ IPState GPSD::updateGPS()
         time(&raw_time);
 
 #ifdef __linux__
+    #if defined(__GNU_LIBRARY__)
+        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            timespec tss = {};
+            tss.tv_sec = raw_time;
+            clock_settime(CLOCK_REALTIME, &tss);
+        #else
+            stime(&raw_time);
+        #endif
+    #else
         stime(&raw_time);
+    #endif
 #endif
 
         struct tm *utc = gmtime(&raw_time);
@@ -321,7 +331,17 @@ IPState GPSD::updateGPS()
         raw_time = gpsData->fix.time.tv_sec;
 #endif
 #ifdef __linux__
+    #if defined(__GNU_LIBRARY__)
+        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            timespec tss = {};
+            tss.tv_sec = raw_time;
+            clock_settime(CLOCK_REALTIME, &tss);
+        #else
+            stime(&raw_time);
+        #endif
+    #else
         stime(&raw_time);
+    #endif
 #endif
 
 #if GPSD_API_MAJOR_VERSION < 9

--- a/indi-gpsd/gps_driver.h
+++ b/indi-gpsd/gps_driver.h
@@ -39,7 +39,7 @@ class GPSD : public INDI::GPS
         virtual bool updateProperties() override;
 
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-
+        virtual bool setSystemTime(time_t& raw_time);
     protected:
         virtual bool Connect() override;
         virtual bool Disconnect() override;

--- a/indi-gpsnmea/gpsnmea_driver.cpp
+++ b/indi-gpsnmea/gpsnmea_driver.cpp
@@ -255,7 +255,17 @@ void GPSNMEA::parseNEMA()
                         IUSaveText(&TimeT[0], ts);
 
 #ifdef __linux__
-                        stime(&raw_time);
+    #if defined(__GNU_LIBRARY__)
+        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            timespec tss = {};
+            tss.tv_sec = raw_time;
+            clock_settime(CLOCK_REALTIME, &tss);
+        #else
+            stime(&raw_time);
+        #endif
+    #else
+        stime(&raw_time);
+    #endif
 #endif
 
                         local = localtime(&raw_time);
@@ -309,7 +319,17 @@ void GPSNMEA::parseNEMA()
                         IUSaveText(&TimeT[0], ts);
 
 #ifdef __linux__
-                        stime(&raw_time);
+    #if defined(__GNU_LIBRARY__)
+        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            timespec tss = {};
+            tss.tv_sec = raw_time;
+            clock_settime(CLOCK_REALTIME, &tss);
+        #else
+            stime(&raw_time);
+        #endif
+    #else
+        stime(&raw_time);
+    #endif
 #endif
 
                         local = localtime(&raw_time);
@@ -386,7 +406,17 @@ void GPSNMEA::parseNEMA()
                     IUSaveText(&TimeT[0], ts);
 
 #ifdef __linux__
-                    stime(&raw_time);
+    #if defined(__GNU_LIBRARY__)
+        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+            timespec tss = {};
+            tss.tv_sec = raw_time;
+            clock_settime(CLOCK_REALTIME, &tss);
+        #else
+            stime(&raw_time);
+        #endif
+    #else
+        stime(&raw_time);
+    #endif
 #endif
 
                     local = localtime(&raw_time);

--- a/indi-gpsnmea/gpsnmea_driver.cpp
+++ b/indi-gpsnmea/gpsnmea_driver.cpp
@@ -171,6 +171,24 @@ bool GPSNMEA::isNMEA()
     return (minmea_sentence_id(line, false) != MINMEA_INVALID);
 }
 
+bool GPSNMEA::setSystemTime(time_t& raw_time)
+{
+    #ifdef __linux__
+        #if defined(__GNU_LIBRARY__)
+            #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
+                timespec sTime = {};
+                sTime.tv_sec = raw_time;
+                clock_settime(CLOCK_REALTIME, &sTime);
+            #else
+                stime(&raw_time);
+            #endif
+        #else
+            stime(&raw_time);
+        #endif
+    #endif
+    return true;
+}
+
 void* GPSNMEA::parseNMEAHelper(void *obj)
 {
     static_cast<GPSNMEA*>(obj)->parseNEMA();
@@ -254,19 +272,7 @@ void GPSNMEA::parseNEMA()
                         strftime(ts, 32, "%Y-%m-%dT%H:%M:%S", utc);
                         IUSaveText(&TimeT[0], ts);
 
-#ifdef __linux__
-    #if defined(__GNU_LIBRARY__)
-        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
-            timespec tss = {};
-            tss.tv_sec = raw_time;
-            clock_settime(CLOCK_REALTIME, &tss);
-        #else
-            stime(&raw_time);
-        #endif
-    #else
-        stime(&raw_time);
-    #endif
-#endif
+                        setSystemTime(raw_time);
 
                         local = localtime(&raw_time);
                         snprintf(ts, 32, "%4.2f", (local->tm_gmtoff / 3600.0));
@@ -317,20 +323,7 @@ void GPSNMEA::parseNEMA()
                         utc = gmtime(&raw_time);
                         strftime(ts, 32, "%Y-%m-%dT%H:%M:%S", utc);
                         IUSaveText(&TimeT[0], ts);
-
-#ifdef __linux__
-    #if defined(__GNU_LIBRARY__)
-        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
-            timespec tss = {};
-            tss.tv_sec = raw_time;
-            clock_settime(CLOCK_REALTIME, &tss);
-        #else
-            stime(&raw_time);
-        #endif
-    #else
-        stime(&raw_time);
-    #endif
-#endif
+                        setSystemTime(raw_time);
 
                         local = localtime(&raw_time);
                         snprintf(ts, 32, "%4.2f", (local->tm_gmtoff / 3600.0));
@@ -404,20 +397,7 @@ void GPSNMEA::parseNEMA()
                     utc = gmtime(&raw_time);
                     strftime(ts, 32, "%Y-%m-%dT%H:%M:%S", utc);
                     IUSaveText(&TimeT[0], ts);
-
-#ifdef __linux__
-    #if defined(__GNU_LIBRARY__)
-        #if (__GLIBC__ >= 2) && (__GLIBC_MINOR__ > 30)
-            timespec tss = {};
-            tss.tv_sec = raw_time;
-            clock_settime(CLOCK_REALTIME, &tss);
-        #else
-            stime(&raw_time);
-        #endif
-    #else
-        stime(&raw_time);
-    #endif
-#endif
+                    setSystemTime(raw_time);
 
                     local = localtime(&raw_time);
                     snprintf(ts, 32, "%4.2f", (local->tm_gmtoff / 3600.0));

--- a/indi-gpsnmea/gpsnmea_driver.h
+++ b/indi-gpsnmea/gpsnmea_driver.h
@@ -36,6 +36,7 @@ class GPSNMEA : public INDI::GPS
     ITextVectorProperty GPSstatusTP;
 
     static void* parseNMEAHelper(void *);
+    virtual bool setSystemTime(time_t& raw_time);
 
   protected:    
     //  Generic indi device entries

--- a/libricohcamerasdk/CMakeLists.txt
+++ b/libricohcamerasdk/CMakeLists.txt
@@ -16,14 +16,14 @@ set(LIBMTP_SOVERSION "9")
 
 set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 
-if("${CMAKE_LIBRARY_ARCHITECTURE}" MATCHES "^(x86_64|amd64)")
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86_64|amd64)")
   set(architecture_path "x64")
-elseif("${CMAKE_LIBRARY_ARCHITECTURE}" MATCHES "^i[3-6]86")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^i[3-6]86")
   set(architecture_path "x86")
-elseif("${CMAKE_LIBRARY_ARCHITECTURE}" MATCHES "^arm-linux-gnueabihf")
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm-linux-gnueabihf")
   set(architecture_path "armv7l")
 else()
-  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_LIBRARY_ARCHITECTURE}")
+  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
 exec_program(cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/lib/${architecture_path}/libRicohCameraSDKCpp.so ${CMAKE_BINARY_DIR}/libRicohCameraSDKCpp.so.${LIBPENTAX_VERSION})


### PR DESCRIPTION
…gpsnmea_driver
as GLIBC moved to 2.31

As the GLIBC moved to 2.31 from 2.30 the stime() was removed in 2.31 and
it throws error while building indi-3rdparty-Drivers in indi-gpsd/gps_driver.cpp and indi-gpsnmea/gpsnmea_driver.cpp .So replacing the
stime() with clocksesttime().

https://sourceware.org/git/?p=glibc.git&amp;a=commit&amp;h=12cbde1da


    /usr/include/features.h:397:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
    397 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
        |    ^~~~~~~
    /home/ge49gar/AstroRoot/indi-3rdparty/indi-gpsd/gps_driver.cpp: In member function ‘virtual IPState GPSD::updateGPS()’:
    /home/ge49gar/AstroRoot/indi-3rdparty/indi-gpsd/gps_driver.cpp:206:9: error: ‘stime’ was not declared in this scope; did you mean ‘ctime’?
    206 |         stime(&raw_time);
        |         ^~~~~
        |         ctime
    /home/ge49gar/AstroRoot/indi-3rdparty/indi-gpsd/gps_driver.cpp:324:9: error: ‘stime’ was not declared in this scope; did you mean ‘ctime’?
    324 |         stime(&raw_time);
        |         ^~~~~
        |         ctime
    make[2]: *** [indi-gpsd/CMakeFiles/indi_gpsd.dir/build.make:63: indi-gpsd/CMakeFiles/indi_gpsd.dir/gps_driver.cpp.o] Error 1
    make[2]: Leaving directory '/home/ge49gar/AstroRoot/indi-build/3rdparty-Drivers'
    make[1]: *** [CMakeFiles/Makefile2:2424: indi-gpsd/CMakeFiles/indi_gpsd.dir/all] Error 2
    make[1]: Leaving directory '/home/ge49gar/AstroRoot/indi-build/3rdparty-Drivers'
    make: *** [Makefile:152: all] Error 2
    [ge49gar@islam-pc 3rdparty-Drivers]$ 



As well, the build fail in non Debian and Ubuntu because CMAKE_LIBRARY_ARCHITECTURE variable which is autodetected on Debian systems only, is empty for Fedora, RHEL, Arch Linux, Manjaro. Therefore, it has been replaced with CMAKE_SYSTEM_PROCESSOR.

https://bugzilla.redhat.com/show_bug.cgi?id=1531678
https://wiki.debian.org/Multiarch/Implementation

    running cp /home/ge49gar/AstroRoot/indi-3rdparty/libsbig/libsbig_x64.bin /home/ge49gar/AstroRoot/indi-build/3rdparty-Libraries/libsbig.so.4.9.9  2>&1
    CMake Error at libricohcamerasdk/CMakeLists.txt:26 (message):
    Unsupported architecture:


    -- Configuring incomplete, errors occurred!
    See also "/home/ge49gar/AstroRoot/indi-build/3rdparty-Libraries/CMakeFiles/CMakeOutput.log".
    make: *** [Makefile:280: cmake_check_build_system] Error 1
