### PR TITLE
Stargo 1.10 | Tracking adjustment stored permanently

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.10) buster; urgency=medium
+
+  * Tracking adjustment made permanent in StarGO
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Tue, 24 Mar 2020 20:43:46 +0100
+
 indi-avalon (1.9) buster; urgency=medium
 
   * Bug fix, ignoring unsolicitated ge#

--- a/indi-avalon/CMakeLists.txt
+++ b/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 9)
+set(AVALON_VERSION_MINOR 10)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/indi-avalon/lx200stargo.h
+++ b/indi-avalon/lx200stargo.h
@@ -250,7 +250,8 @@ class LX200StarGo : public LX200Telescope
         bool setSlewMode(int slewMode);
 
         // tracking adjustment
-        bool setTrackingAdjustment(double adjust);
+        bool setTrackingAdjustment(double adjustRA);
+        bool getTrackingAdjustment(double *valueRA);
 
 };
 inline bool LX200StarGo::sendQuery(const char* cmd, char* response, int wait)


### PR DESCRIPTION
The tracking adjustment released with 1.9 has been updated so that the configured value is directly stored in the firmware and no longer in the INDI server configuration.