### PR TITLE
indi-eqmod: Implement Snapport control 

### DIFF
--- a/indi-eqmod/eqmodbase.cpp
+++ b/indi-eqmod/eqmodbase.cpp
@@ -360,6 +360,15 @@ void EQMod::ISGetProperties(const char *dev)
             defineSwitch(DEPPECSP);
         }
 
+        if (mount->HasSnapPort1())
+        {
+            defineSwitch(SNAPPORT1SP);
+        }
+        if (mount->HasSnapPort2())
+        {
+            defineSwitch(SNAPPORT2SP);
+        }
+
 #ifdef WITH_ALIGN_GEEHALEL
         if (align)
         {
@@ -420,6 +429,8 @@ bool EQMod::loadProperties()
     DEPPECTrainingSP    = getSwitch("DE_PPEC_TRAINING");
     DEPPECSP            = getSwitch("DE_PPEC");
     LEDBrightnessNP     = getNumber("LED_BRIGHTNESS");
+    SNAPPORT1SP         = getSwitch("SNAPPORT1");
+    SNAPPORT2SP         = getSwitch("SNAPPORT2");
 #ifdef WITH_ALIGN_GEEHALEL
     align->initProperties();
 #endif
@@ -573,6 +584,15 @@ bool EQMod::updateProperties()
             mount->SetBacklashRA((uint32_t)(IUFindNumber(BacklashNP, "BACKLASHRA")->value));
             mount->SetBacklashDE((uint32_t)(IUFindNumber(BacklashNP, "BACKLASHDE")->value));
 
+            if (mount->HasSnapPort1())
+            {
+                defineSwitch(SNAPPORT1SP);
+            }
+            if (mount->HasSnapPort2())
+            {
+                defineSwitch(SNAPPORT2SP);
+            }
+
             mount->Init();
 
             zeroRAEncoder  = mount->GetRAEncoderZero();
@@ -649,6 +669,14 @@ bool EQMod::updateProperties()
             deleteProperty(RAPPECSP->name);
             deleteProperty(DEPPECTrainingSP->name);
             deleteProperty(DEPPECSP->name);
+        }
+        if (mount->HasSnapPort1())
+        {
+            deleteProperty(SNAPPORT1SP->name);
+        }
+        if (mount->HasSnapPort2())
+        {
+            deleteProperty(SNAPPORT2SP->name);
         }
 #if defined WITH_ALIGN && defined WITH_ALIGN_GEEHALEL
         deleteProperty(AlignMethodSP.name);
@@ -3062,6 +3090,52 @@ bool EQMod::ISNewSwitch(const char *dev, const char *name, ISState *states, char
                 return true;
             }
         }
+
+        if (mount->HasSnapPort1())
+        {
+            if (SNAPPORT1SP && strcmp(name, SNAPPORT1SP->name) == 0)
+            {
+                IUUpdateSwitch(SNAPPORT1SP, states, names, n);
+                if (SNAPPORT1SP->sp[1].s == ISS_ON)
+                {
+                    SNAPPORT1SP->s = IPS_OK;
+                    DEBUG(INDI::Logger::DBG_DEBUG, "Turning snap port 1 on.");
+                    mount->TurnSnapPort1(true);
+                }
+                else
+                {
+                    SNAPPORT1SP->s = IPS_IDLE;
+                    DEBUG(INDI::Logger::DBG_DEBUG, "Turning snap port 1 off.");
+                    mount->TurnSnapPort1(false);
+                }
+                IDSetSwitch(SNAPPORT1SP, nullptr);
+                return true;
+            }
+        }
+
+        if (mount->HasSnapPort2())
+        {
+            if (SNAPPORT2SP && strcmp(name, SNAPPORT2SP->name) == 0)
+            {
+                IUUpdateSwitch(SNAPPORT2SP, states, names, n);
+                if (SNAPPORT2SP->sp[1].s == ISS_ON)
+                {
+                    SNAPPORT2SP->s = IPS_OK;
+                    DEBUG(INDI::Logger::DBG_DEBUG, "Turning snap port 2 on.");
+                    mount->TurnSnapPort2(true);
+                }
+                else
+                {
+                    SNAPPORT2SP->s = IPS_IDLE;
+                    DEBUG(INDI::Logger::DBG_DEBUG, "Turning snap port 2 off.");
+                    mount->TurnSnapPort2(false);
+                }
+                IDSetSwitch(SNAPPORT2SP, nullptr);
+                return true;
+            }
+        }
+
+
 
 #if defined WITH_ALIGN || defined WITH_ALIGN_GEEHALEL
         if (AlignSyncModeSP && strcmp(name, AlignSyncModeSP->name) == 0)

--- a/indi-eqmod/eqmodbase.h
+++ b/indi-eqmod/eqmodbase.h
@@ -133,6 +133,9 @@ class EQMod : public INDI::Telescope, public INDI::GuiderInterface
         ISwitchVectorProperty *RAPPECSP         = nullptr;
         ISwitchVectorProperty *DEPPECSP         = nullptr;
 
+        ISwitchVectorProperty *SNAPPORT1SP      = nullptr;
+        ISwitchVectorProperty *SNAPPORT2SP      = nullptr;
+
         INumber *MinPulseN                   = nullptr;
         INumber *MinPulseTimerN              = nullptr;
         INumberVectorProperty *PulseLimitsNP = nullptr;

--- a/indi-eqmod/indi_eqmod_sk.xml
+++ b/indi-eqmod/indi_eqmod_sk.xml
@@ -308,4 +308,20 @@ Off
 255
 </defNumber>
 </defNumberVector>
+<defSwitchVector device="EQMod Mount" name="SNAPPORT1" label="Snap Port 1" group="Options" state="Idle" perm="rw" rule="OneOfMany">
+<defSwitch name="SNAPPORT1_OFF" label="Off">
+On
+</defSwitch>
+<defSwitch name="SNAPPORT1_ON" label="On">
+Off
+</defSwitch>
+</defSwitchVector>
+<defSwitchVector device="EQMod Mount" name="SNAPPORT2" label="Snap Port 2" group="Options" state="Idle" perm="rw" rule="OneOfMany">
+<defSwitch name="SNAPPORT2_OFF" label="Off">
+On
+</defSwitch>
+<defSwitch name="SNAPPORT2_ON" label="On">
+Off
+</defSwitch>
+</defSwitchVector>
 </INDIDriver>

--- a/indi-eqmod/simulator/skywatcher-simulator.cpp
+++ b/indi-eqmod/simulator/skywatcher-simulator.cpp
@@ -588,7 +588,10 @@ void SkywatcherSimulator::process_command(const char *cmd, int *received)
         case 'P': // Set ST4 guide Rate
             send_byte('=');
             break;
-        case 'V':
+        case 'V': // Set Led Brightness
+            send_byte('=');
+            break;
+        case 'O': // Snap ports
             send_byte('=');
             break;
         default:

--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -432,6 +432,9 @@ void Skywatcher::InquireBoardVersion(ITextVectorProperty *boardTP)
         case 0x06:
             strcpy(boardinfo[0], "AZEQ5");
             break;
+        case 0x23:
+            strcpy(boardinfo[0], "EQ6-R Pro");
+            break;
         case 0x80:
             strcpy(boardinfo[0], "GT");
             break;
@@ -542,7 +545,7 @@ bool Skywatcher::HasPPEC()
 
 bool Skywatcher::HasSnapPort1()
 {
-    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06;
+    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06 ||  MountCode == 0x23;
 }
 
 bool Skywatcher::HasSnapPort2()

--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -313,6 +313,17 @@ void Skywatcher::Init()
     SetST4DEGuideRate('2');
     LOGF_WARN("%s() : Setting both ST4 guide rates to  0.5x (2)", __FUNCTION__);
 
+    if (HasSnapPort1())
+    {
+        TurnSnapPort1(false);
+        LOGF_DEBUG("%s() : Resetting snap port 1", __FUNCTION__);
+    }
+    if (HasSnapPort2())
+    {
+        TurnSnapPort2(false);
+        LOGF_DEBUG("%s() : Resetting snap port 2", __FUNCTION__);
+    }
+
     //Park status
     if (telescope->InitPark() == false)
     {
@@ -527,6 +538,16 @@ bool Skywatcher::HasAuxEncoders()
 bool Skywatcher::HasPPEC()
 {
     return (AxisFeatures[Axis1].hasPPEC) && (AxisFeatures[Axis2].hasPPEC);
+}
+
+bool Skywatcher::HasSnapPort1()
+{
+    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06;
+}
+
+bool Skywatcher::HasSnapPort2()
+{
+    return MountCode == 0x06;
 }
 
 void Skywatcher::InquireRAEncoderInfo(INumberVectorProperty *encoderNP)
@@ -1303,6 +1324,41 @@ void Skywatcher::GetDEPPECStatus(bool *intraining, bool *inppec)
 {
     return GetPPECStatus(Axis2, intraining, inppec);
 }
+
+void Skywatcher::TurnSnapPort(SkywatcherAxis axis, bool on)
+{
+    char snapcmd[2]="0";
+    if (on)
+        snapcmd[0]='1';
+    else
+        snapcmd[0]='0';
+    snapportstatus[axis] = on;
+    DEBUGF(telescope->DBG_MOUNT, "%s() : Axis = %c -- snap=%c", __FUNCTION__, AxisCmd[axis], snapcmd);
+    dispatch_command(SetSnapPort, axis, snapcmd);
+    //read_eqmod();
+}
+
+void Skywatcher::TurnSnapPort1(bool on)
+{
+    TurnSnapPort(Axis1, on);
+}
+
+void Skywatcher::TurnSnapPort2(bool on)
+{
+    TurnSnapPort(Axis2, on);
+}
+
+bool Skywatcher::GetSnapPort1Status()
+{
+    return snapportstatus[Axis1];
+}
+
+bool Skywatcher::GetSnapPort2Status()
+{
+    return snapportstatus[Axis2];
+}
+
+
 
 void Skywatcher::SetAxisPosition(SkywatcherAxis axis, uint32_t step)
 {

--- a/indi-eqmod/skywatcher.h
+++ b/indi-eqmod/skywatcher.h
@@ -61,6 +61,8 @@ class Skywatcher
         bool HasHomeIndexers();
         bool HasAuxEncoders();
         bool HasPPEC();
+        bool HasSnapPort1();
+        bool HasSnapPort2();
 
         uint32_t GetRAEncoder();
         uint32_t GetDEEncoder();
@@ -124,6 +126,10 @@ class Skywatcher
         void SetST4RAGuideRate(unsigned char r);
         void SetST4DEGuideRate(unsigned char r);
         void SetLEDBrightness(uint8_t value);
+        void TurnSnapPort1(bool on);
+        void TurnSnapPort2(bool on);
+        bool GetSnapPort1Status();
+        bool GetSnapPort2Status();
 
         void setPortFD(int value);
 
@@ -151,7 +157,7 @@ class Skywatcher
             SetAxisPositionCmd        = 'E',
             GetAxisPosition           = 'j',
             GetAxisStatus             = 'f',
-            SetSwitch                 = 'O',
+            SetSnapPort               = 'O', // EQ8/AZEQ6/AZEQ5/EQ6-R only
             SetMotionMode             = 'G',
             SetGotoTargetIncrement    = 'H',
             SetBreakPointIncrement    = 'M',
@@ -266,6 +272,7 @@ class Skywatcher
         void TurnPPECTraining(SkywatcherAxis axis, bool on);
         void TurnPPEC(SkywatcherAxis axis, bool on);
         void GetPPECStatus(SkywatcherAxis axis, bool *intraining, bool *inppec);
+        void TurnSnapPort(SkywatcherAxis axis, bool on);
 
         bool read_eqmod();
         bool dispatch_command(SkywatcherCommand cmd, SkywatcherAxis axis, char *arg);
@@ -331,6 +338,8 @@ class Skywatcher
         uint32_t backlashperiod[NUMBER_OF_SKYWATCHERAXIS];
 
         uint32_t lastreadIndexer[NUMBER_OF_SKYWATCHERAXIS];
+
+        bool snapportstatus[NUMBER_OF_SKYWATCHERAXIS];
 
         const uint8_t EQMOD_TIMEOUT = 5;
         const uint8_t EQMOD_MAX_RETRY = 3;


### PR DESCRIPTION
This fixes the issue #39 and besides adds support for EQ6-R Pro mount.

- adds one or two snap port switches in the options tab depending on the mount model (hardcoded in HasSnapPort functions)
- adds EQ6-R Pro mount model with code 0x23 (with a built-in USB port) 