### PR TITLE
indi-eqmod: check if mount supports led brightness control

### DIFF
--- a/indi-eqmod/eqmodbase.cpp
+++ b/indi-eqmod/eqmodbase.cpp
@@ -335,7 +335,7 @@ void EQMod::ISGetProperties(const char *dev)
         defineSwitch(TrackDefaultSP);
         defineSwitch(ST4GuideRateNSSP);
         defineSwitch(ST4GuideRateWESP);
-        defineNumber(LEDBrightnessNP);
+
 #if defined WITH_ALIGN && defined WITH_ALIGN_GEEHALEL
         defineSwitch(&AlignMethodSP);
 #endif
@@ -359,7 +359,6 @@ void EQMod::ISGetProperties(const char *dev)
             defineSwitch(DEPPECTrainingSP);
             defineSwitch(DEPPECSP);
         }
-
         if (mount->HasSnapPort1())
         {
             defineSwitch(SNAPPORT1SP);
@@ -367,6 +366,10 @@ void EQMod::ISGetProperties(const char *dev)
         if (mount->HasSnapPort2())
         {
             defineSwitch(SNAPPORT2SP);
+        }
+        if (mount->HasPolarLed())
+        {
+            defineNumber(LEDBrightnessNP);
         }
 
 #ifdef WITH_ALIGN_GEEHALEL
@@ -495,7 +498,7 @@ bool EQMod::updateProperties()
         defineSwitch(TrackDefaultSP);
         defineSwitch(ST4GuideRateNSSP);
         defineSwitch(ST4GuideRateWESP);
-        defineNumber(LEDBrightnessNP);
+
 #if defined WITH_ALIGN && defined WITH_ALIGN_GEEHALEL
         defineSwitch(&AlignMethodSP);
 #endif
@@ -576,6 +579,11 @@ bool EQMod::updateProperties()
                     DEPPECSP->s       = IPS_BUSY;
                     IDSetSwitch(DEPPECSP, nullptr);
                 }
+            }
+
+            if (mount->HasPolarLed())
+            {
+                defineNumber(LEDBrightnessNP);
             }
 
             LOG_DEBUG("Init backlash.");
@@ -677,6 +685,10 @@ bool EQMod::updateProperties()
         if (mount->HasSnapPort2())
         {
             deleteProperty(SNAPPORT2SP->name);
+        }
+        if (mount->HasPolarLed())
+        {
+            deleteProperty(LEDBrightnessNP->name);
         }
 #if defined WITH_ALIGN && defined WITH_ALIGN_GEEHALEL
         deleteProperty(AlignMethodSP.name);
@@ -2604,14 +2616,17 @@ bool EQMod::ISNewNumber(const char *dev, const char *name, double values[], char
             return true;
         }
 
-        if (strcmp(name, "LED_BRIGHTNESS") == 0)
+        if (mount->HasPolarLed())
         {
-            IUUpdateNumber(LEDBrightnessNP, values, names, n);
-            LEDBrightnessNP->s = IPS_OK;
-            IDSetNumber(LEDBrightnessNP, nullptr);
-            mount->SetLEDBrightness(static_cast<uint8_t>(values[0]));
-            LOGF_INFO("Setting LED brightness to %.f", values[0]);
-            return true;
+            if (strcmp(name, "LED_BRIGHTNESS") == 0)
+            {
+                IUUpdateNumber(LEDBrightnessNP, values, names, n);
+                LEDBrightnessNP->s = IPS_OK;
+                IDSetNumber(LEDBrightnessNP, nullptr);
+                mount->SetLEDBrightness(static_cast<uint8_t>(values[0]));
+                LOGF_INFO("Setting LED brightness to %.f", values[0]);
+                return true;
+            }
         }
 
         if (strcmp(name, "STANDARDSYNCPOINT") == 0)

--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -553,6 +553,11 @@ bool Skywatcher::HasSnapPort2()
     return MountCode == 0x06;
 }
 
+bool Skywatcher::HasPolarLed()
+{
+    return (AxisFeatures[Axis1].hasPolarLed) && (AxisFeatures[Axis2].hasPolarLed);
+}
+
 void Skywatcher::InquireRAEncoderInfo(INumberVectorProperty *encoderNP)
 {
     double steppersvalues[3];
@@ -1279,7 +1284,12 @@ void Skywatcher::SetLEDBrightness(uint8_t value)
     char hexa[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
     cmd[0] = hexa[(value & 0xF0) >> 4];
     cmd[1] = hexa[(value & 0x0F)];
-    dispatch_command(SetPolarScopeLED, Axis1, cmd);
+    try {
+        dispatch_command(SetPolarScopeLED, Axis1, cmd);
+    } catch (EQModError e) {
+        DEBUGF(telescope->DBG_MOUNT, "%s(): Mount does not support led brightness  (%c command)", __FUNCTION__,
+                   SetPolarScopeLED);
+    }
 }
 
 void Skywatcher::TurnRAPPECTraining(bool on)

--- a/indi-eqmod/skywatcher.h
+++ b/indi-eqmod/skywatcher.h
@@ -63,6 +63,7 @@ class Skywatcher
         bool HasPPEC();
         bool HasSnapPort1();
         bool HasSnapPort2();
+        bool HasPolarLed();
 
         uint32_t GetRAEncoder();
         uint32_t GetDEEncoder();


### PR DESCRIPTION
The commit https://github.com/indilib/indi-3rdparty/commit/9379f0b7e5e7159a4c70fbec37a1bbe56ed663de made for issue https://github.com/indilib/indi-3rdparty/issues/70 introduced an error for mounts not supporting polar scope led control.
- Added an exception handler around the `dispatch_command` used to set led brightness
- Use the getFeatureCmd at mount initialization to state if the mount model has support for polar scope led control

This has been tested on EQ6-R Pro (with polar scope led control) and AZ-EQ5 (no polar scope).