### PR TITLE
Increase time delay for sending exposure updates

### DIFF
--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -2111,7 +2111,7 @@ void ASICCD::getExposure()
         }
         else
         {
-            uSecs = 10000;
+            uSecs = 100000;
         }
         if (timeLeft >= 0.0049)
         {


### PR DESCRIPTION
During the last second the exposure updates were send in 10ms intervals. This does not make sense for any GUI. I raised this value to  100ms, which is still fast enough.