### PR TITLE
Fix astrolink4 driver declaration

### DIFF
--- a/indi-astrolink4/indi_astrolink4.xml.cmake
+++ b/indi-astrolink4/indi_astrolink4.xml.cmake
@@ -2,7 +2,7 @@
 <driversList>
 <devGroup group="Auxiliary">
         <device label="AstroLink 4">
-                <driver name="AstroLink 4">astrolink4</driver>
+                <driver name="AstroLink 4">indi_astrolink4</driver>
                 <version>@ASTROLINK4_VERSION_MAJOR@.@ASTROLINK4_VERSION_MINOR@</version>
         </device>
 </devGroup>


### PR DESCRIPTION
Hi,

I was using the astrolink4 driver from its original repository for a few weeks now and had no problem with it. I then installed the "official" driver package since it was recently integrated into the indi-3rdparty repository. Since then, the driver refused to load.

If using Kstars or INDI Web Manager interface to select the "AstroLink 4" driver from the available driver list, the driver refuse to start.

![image](https://user-images.githubusercontent.com/5184737/80318714-524d3c80-880c-11ea-8bb8-c46ce41f9154.png)
> 2020-04-26T20:01:25: Driver astrolink4: 2020-04-26T20:01:25: Driver astrolink4: execlp: No such file or directory

If however I use INDI Web Manager to explicitly add the `indi_astrolink4` driver, it works fine.
![image](https://user-images.githubusercontent.com/5184737/80318736-7446bf00-880c-11ea-9106-cb3d1e279b15.png)

I'm not familiar with INDI driver development, but changing the xml as this PR does has allowed me to choose the driver using either Kstars or INDI Web Manager interfaces.

Regars,
Bertrand

