### PR TITLE
Productive version 1.0 of AOK Skywalker

### DIFF
--- a/debian/indi-aok/changelog
+++ b/debian/indi-aok/changelog
@@ -1,6 +1,10 @@
 indi-aok (1.0) bionic; urgency=low
   * cleared up the handling of notification of mountlock & trackstate
   * added query of mount when connecting, so mountlock and trackstate is reflected correctly
+
+ -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Sat, 2 May 2019 07:45:00 +0300
+
+indi-aok (0.9) bionic; urgency=low
   * implemented park position management
   * corrected readout of firmwareserial
   * renamed driver to product line (AOK Skywalker)

--- a/debian/indi-aok/changelog
+++ b/debian/indi-aok/changelog
@@ -1,4 +1,6 @@
-indi-aok (0.9) bionic; urgency=low
+indi-aok (1.0) bionic; urgency=low
+  * cleared up the handling of notification of mountlock & trackstate
+  * added query of mount when connecting, so mountlock and trackstate is reflected correctly
   * implemented park position management
   * corrected readout of firmwareserial
   * renamed driver to product line (AOK Skywalker)

--- a/indi-aok/ChangeLog
+++ b/indi-aok/ChangeLog
@@ -1,6 +1,12 @@
+Version 1.0 - 2020-03-06
+	+ cleared up the handling of notification of mountlock & trackstate
+	+ added query of mount when connecting, so mountlock and trackstate
+          is reflected correctly
+
 Version 0.9 - 2019-11-23 (minor changes after pull)
 	+ corrected readout of firmwareserial
 	+ implemented improved park position management
+
 Version 0.8 - 2019-10-08
 	+ renamed driver to product line (AOK Skywalker)
 	- removed real 'unpark()' at start, TCS unparks automatically

--- a/indi-aok/lx200aok.cpp
+++ b/indi-aok/lx200aok.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
     AOK Skywalker driver
 
     Copyright (C) 2019 T. Schriber
@@ -430,18 +430,10 @@ bool LX200Skywalker::isSlewComplete()
         {
             if (TrackState == SCOPE_SLEWING)
             {
-                TrackStateS[TRACK_ON].s = ISS_ON;
-                TrackStateS[TRACK_OFF].s = ISS_OFF;
-                TrackState = SCOPE_TRACKING;
-                TrackStateSP.s = IPS_OK;
-                IDSetSwitch(&TrackStateSP, nullptr);
-                if ((setPierSide()) && (MountLocked())) // Normally lock is set by TCS if slew ends
+                notifyTrackState(SCOPE_TRACKING);
+                if ((notifyPierSide()) && (MountLocked())) // Normally lock is set by TCS if slew ends
                 {
-                    MountStateS[0].s = ISS_ON;
-                    MountStateS[1].s = ISS_OFF;
-                    MountStateSP.s = IPS_OK;
-                    CurrentMountState = MOUNT_LOCKED; // ALWAYS set status!
-                    IDSetSwitch(&MountStateSP, nullptr);
+                    notifyMountLock(true);
                     result = true;
                 }
                 else
@@ -449,18 +441,10 @@ bool LX200Skywalker::isSlewComplete()
             }
             else if (TrackState == SCOPE_PARKING)
             {
-                TrackStateS[TRACK_ON].s = ISS_OFF;
-                TrackStateS[TRACK_OFF].s = ISS_ON;
-                TrackState = SCOPE_PARKED;
-                TrackStateSP.s = IPS_OK;
-                IDSetSwitch(&TrackStateSP, nullptr);
+                notifyTrackState(SCOPE_PARKED);
                 if (SetMountLock(false))
                 {
-                    MountStateS[0].s = ISS_OFF;
-                    MountStateS[1].s = ISS_ON;
-                    MountStateSP.s = IPS_OK;
-                    CurrentMountState = MOUNT_UNLOCKED; // ALWAYS set status!
-                    IDSetSwitch(&MountStateSP, nullptr);
+                    notifyMountLock(false);
                     result = true;
                 }
                 else
@@ -520,7 +504,27 @@ void LX200Skywalker::getBasicData()
             IDSetSwitch(&TrackModeSP, nullptr);
         }
         if (InitPark())
+        {
             LOG_INFO("Parkdata loaded");
+            if (!INDI::Telescope::isParked()) // Mount is unparked and working on connection of the driver!
+            {
+                    if ((MountLocked()) && (MountTracking())) // default state of working mount
+                     {
+                        notifyMountLock(true);
+                        notifyTrackState(SCOPE_TRACKING);
+                        ParkSP.s = IPS_OK;
+                        IDSetSwitch(&ParkSP, nullptr);
+                        //LOG_INFO("Mount is working");
+                     }
+                     else
+                        LOG_WARN("Mount is unparked but not locked and/or not tracking!");
+            }
+            else // Mount is parked
+            {
+                notifyMountLock(MountLocked());
+                notifyTrackState(SCOPE_PARKED);
+            }
+        }
         else
             LOG_INFO("Parkdata load failed");
     }
@@ -566,7 +570,7 @@ bool LX200Skywalker::updateLocation(double latitude, double longitude, double el
     fs_sexa(l, latitude, 3, 3600);
     fs_sexa(L, longitude, 4, 3600);
 
-    LOGF_INFO("Site location updated to Lat %.32s - Long %.32s", l, L);
+    // LOGF_INFO("Site location updated to Lat %.32s - Long %.32s", l, L); Info provided by "inditelescope"
 
    return true;
 }
@@ -598,22 +602,12 @@ bool LX200Skywalker::UnPark()
         INDI::Telescope::SetParked(false);
         if ((MountLocked()) && (MountTracking())) // TCS sets Mountlock & Tracking
         {
-            MountStateS[0].s = ISS_ON;
-            MountStateS[1].s = ISS_OFF;
-            MountStateSP.s = IPS_OK;
-            CurrentMountState = MOUNT_LOCKED; // ALWAYS set status!
+            notifyMountLock(true);
             // INDI::Telescope::SetParked(false) sets TrackState = SCOPE_IDLE but TCS is tracking
-            TrackStateS[TRACK_ON].s = ISS_ON;
-            TrackStateS[TRACK_OFF].s = ISS_OFF;
-            TrackStateSP.s = IPS_OK;
-            INDI::Telescope::TrackState = SCOPE_TRACKING;
+            notifyTrackState(SCOPE_TRACKING);
             // INDI::Telescope::SetParked(false) sets ParkSP.S = IPS_IDLE but mount IS unparked!
             ParkSP.s = IPS_OK;
-            IDSetSwitch(&MountStateSP, nullptr);
-            IDSetSwitch(&TrackStateSP, nullptr);
             IDSetSwitch(&ParkSP, nullptr);
-            // return true;
-            // Should we do a sync here to show pierside?
             return SyncDefaultPark();
         }
         else
@@ -633,6 +627,72 @@ bool LX200Skywalker::SavePark()
         LOG_ERROR("Controller did not accept 'SetPark'.");
         return false;
     }
+}
+
+/********************************************************************************
+ * Notifier-Section
+ ********************************************************************************/
+// Changed from original "set_" to "notify_" because of the logic behind: From
+// the controller view we change the viewer (and a copy of the model), not the
+// the model itself!
+bool LX200Skywalker::notifyPierSide()
+{
+    char lstat[20] = {0};
+    if (getJSONData_Y(5, lstat)) // this is the model!
+    {
+        int li = std::stoi(lstat);
+        li = li & (1 << 7);
+        if (li > 0)
+            Telescope::setPierSide(INDI::Telescope::PIER_WEST);
+        else
+            Telescope::setPierSide(INDI::Telescope::PIER_EAST);
+        LOGF_INFO("Telescope pointing %s", (li > 0) ? "east" : "west");
+        return true;
+    }
+    else
+    {
+        Telescope::setPierSide(INDI::Telescope::PIER_UNKNOWN);
+        LOG_ERROR("Telescope pointing unknown!");
+        return false;
+    }
+}
+
+void LX200Skywalker::notifyMountLock(bool locked)
+{
+    if (locked)
+    {
+        MountStateS[0].s = ISS_ON;
+        MountStateS[1].s = ISS_OFF;
+        MountStateSP.s = IPS_OK;
+        CurrentMountState = MOUNT_LOCKED; // ALWAYS set status!
+    }
+    else
+    {
+        MountStateS[0].s = ISS_OFF;
+        MountStateS[1].s = ISS_ON;
+        MountStateSP.s = IPS_OK;
+        CurrentMountState = MOUNT_UNLOCKED; // ALWAYS set status!
+    }
+    IDSetSwitch(&MountStateSP, nullptr);
+}
+
+void LX200Skywalker::notifyTrackState(INDI::Telescope::TelescopeStatus state)
+{
+    if (state == SCOPE_TRACKING)
+    {
+        TrackStateS[TRACK_ON].s = ISS_ON;
+        TrackStateS[TRACK_OFF].s = ISS_OFF;
+        TrackStateSP.s = IPS_OK;
+        INDI::Telescope::TrackState = state;
+    }
+    else
+    {
+        TrackStateS[TRACK_ON].s = ISS_OFF;
+        TrackStateS[TRACK_OFF].s = ISS_ON;
+        TrackStateSP.s = IPS_OK;
+        INDI::Telescope::TrackState = state;
+    }
+    IDSetSwitch(&TrackStateSP, nullptr);
 }
 
 /*********************************************************************************
@@ -783,28 +843,6 @@ bool LX200Skywalker::getJSONData_Y(int jindex, char *jstr) // preliminary hardco
     }
     strcpy(jstr, data[jindex]);
     return true;
-}
-
-bool LX200Skywalker::setPierSide()
-{
-    char lstat[20] = {0};
-    if (getJSONData_Y(5, lstat))
-    {
-        int li = std::stoi(lstat);
-        li = li & (1 << 7);
-        if (li > 0)
-            Telescope::setPierSide(INDI::Telescope::PIER_WEST);
-        else
-            Telescope::setPierSide(INDI::Telescope::PIER_EAST);
-        LOGF_INFO("Telescope pointing %s", (li > 0) ? "east" : "west");
-        return true;
-    }
-    else
-    {
-        Telescope::setPierSide(INDI::Telescope::PIER_UNKNOWN);
-        LOG_ERROR("Telescope pointing unknown!");
-        return false;
-    }
 }
 
 bool LX200Skywalker::MountLocked()
@@ -1633,7 +1671,7 @@ bool LX200Skywalker::Sync(double ra, double dec)
 
     NewRaDec(currentRA, currentDEC);
 
-    if (!setPierSide())
+    if (!notifyPierSide())
         return false;
     // show lock
     if (MountLocked()) // Normally lock is set by TCS on syncing

--- a/indi-aok/lx200aok.h
+++ b/indi-aok/lx200aok.h
@@ -135,7 +135,9 @@ class LX200Skywalker : public LX200Telescope
         bool setSystemSlewSpeed (int xx);
         bool getJSONData_Y(int jindex, char *jstr);
         bool getJSONData_gp(int jindex, char *jstr);
-        bool setPierSide();
+        bool notifyPierSide();
+        void notifyMountLock(bool locked);
+        void notifyTrackState(INDI::Telescope::TelescopeStatus state);
         bool MountLocked();
         bool SetMountLock(bool enable);
 


### PR DESCRIPTION
This is the thoroughly tested AOK Skywalker driver at our observatory in the last few months. It behaves quit well, so I think it's time for an update.

0.9 -> 1.0
Cleared up the handling of notification of mountlock & trackstate and
added query of mount when connecting, so mountlock and trackstate is
always reflected correctly on start or reconnect.

There are some changes in the UI as well, so [here](https://github.com/indilib/indi-3rdparty/files/4559845/indi_aok.zip.zip) is the updated manual including the new screenshots.