### PR TITLE
BlackLevel and continuous gain scale for LCG/HCG

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -522,7 +522,7 @@ bool ToupBase::Connect()
     uint32_t cap = 0;
 
     cap |= CCD_CAN_ABORT;
-    
+
     m_MonoCamera = false;
     // If raw format is support then we have bayer
     if (m_Instance->model->flag & (CP(FLAG_MONO)))
@@ -1092,7 +1092,7 @@ bool ToupBase::ISNewNumber(const char *dev, const char *name, double values[], c
                         break;
                 }
             }
-            
+
             ControlNP.s = IPS_OK;
             IDSetNumber(&ControlNP, nullptr);
             return true;
@@ -2236,6 +2236,7 @@ bool ToupBase::saveConfigItems(FILE * fp)
         IUSaveConfigSwitch(fp, &CoolerSP);
     IUSaveConfigNumber(fp, &ControlNP);
     
+    IUSaveConfigNumber(fp, &GainConversionNP);
     IUSaveConfigNumber(fp, &BlackLevelNP);
 
     if (m_MonoCamera == false)

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -801,6 +801,10 @@ void ToupBase::setupParams()
     uint16_t nMin = 0, nMax = 0, nDef = 0;
 
     // Dual Conversion Gain Mode
+    if (m_Instance->model->flag & (CP(FLAG_CG) | CP(FLAG_CGHDR)))
+    {
+        m_hasDualGain = true;
+    }
     int highConversionGain = 0;
     rc = FP(get_Option(m_CameraHandle, CP(OPTION_CG), &highConversionGain));
     LOGF_DEBUG("Dual Conversion Gain %d rc: %d", highConversionGain, rc);
@@ -815,7 +819,7 @@ void ToupBase::setupParams()
     {
         m_MaxGainHCG = m_MaxGainNative * GainConversionN[TC_HCG_LCG_RATIO].value;
         ControlN[TC_GAIN].max = m_MaxGainHCG;
-        LOGF_INFO("Maximum gain considering dual gain is %d.", nMax);
+        LOGF_INFO("Maximum gain considering dual gain is %d.", m_MaxGainHCG);
     }
     else
     {

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -391,6 +391,13 @@ class ToupBase : public INDI::CCD
         void refreshControls();
 
         //#############################################################################
+        // Dual conversion Gain
+        //#############################################################################
+        bool dualGainEnabled();
+        double setDualGainMode(double gain);
+        void setDualGainRange();
+
+        //#############################################################################
         // Resolution
         //#############################################################################
         ISwitch ResolutionS[CP(MAX)];
@@ -443,7 +450,7 @@ class ToupBase : public INDI::CCD
         };
 
         INumberVectorProperty ControlNP;
-        INumber ControlN[10];
+        INumber ControlN[8];
         enum
         {
             TC_GAIN,
@@ -454,8 +461,6 @@ class ToupBase : public INDI::CCD
             TC_GAMMA,
             TC_SPEED,
             TC_FRAMERATE_LIMIT,
-            TC_HCG_THRESHOLD,
-            TC_HCG_LCG_RATIO,
         };
 
         ISwitch AutoControlS[3];
@@ -575,6 +580,14 @@ class ToupBase : public INDI::CCD
         };
 
         // Gain Conversion
+        INumberVectorProperty GainConversionNP;
+        INumber GainConversionN[2];
+        enum
+        {
+            TC_HCG_THRESHOLD,
+            TC_HCG_LCG_RATIO,
+        };
+        
         ISwitchVectorProperty GainConversionSP;
         ISwitch GainConversionS[3];
         enum
@@ -592,6 +605,7 @@ class ToupBase : public INDI::CCD
         bool m_RAWFormatSupport { false };
         bool m_RAWHighDepthSupport { false };
         bool m_MonoCamera { false };
+        bool m_hasDualGain { false };
 
         uint8_t m_BitsPerPixel { 8 };
         uint8_t m_RawBitsPerPixel { 8 };

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -443,7 +443,7 @@ class ToupBase : public INDI::CCD
         };
 
         INumberVectorProperty ControlNP;
-        INumber ControlN[9];
+        INumber ControlN[10];
         enum
         {
             TC_GAIN,
@@ -455,6 +455,7 @@ class ToupBase : public INDI::CCD
             TC_SPEED,
             TC_FRAMERATE_LIMIT,
             TC_HCG_THRESHOLD,
+            TC_HCG_LCG_RATIO,
         };
 
         ISwitch AutoControlS[3];
@@ -481,6 +482,13 @@ class ToupBase : public INDI::CCD
             TC_BLACK_R,
             TC_BLACK_G,
             TC_BLACK_B,
+        };
+
+        INumberVectorProperty BlackLevelNP;
+        INumber BlackLevelN[1];
+        enum
+        {
+            TC_BLACK_LEVEL,
         };
 
         // R/G/B/Gray low/high levels
@@ -590,6 +598,10 @@ class ToupBase : public INDI::CCD
         uint8_t m_MaxBitDepth { 8 };
         uint8_t m_Channels { 1 };
         uint8_t m_TimeoutRetries { 0 };
+        
+        uint32_t m_MaxGainNative { 0 };
+        uint32_t m_MaxGainHCG { 0 };
+        uint32_t m_NativeGain { 0 };
 
         friend void ::ISGetProperties(const char *dev);
         friend void ::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num);


### PR DESCRIPTION
To improve support for Altair Hypercams I have implemented BlackLevel and aligned the handling of Low and High conversion gain consistent with the way other camera manufactures like ZWO do this.

HCG adds an additional gain to the readout. In the case of an IMX294 this is a factor 4.5. The common approach is to have one continuous gain scale of which the upper limit is the in the case of the example 4.5 times higher than the native sensor upper limit. The switch over happens at the HCG threshold and the driver now calculates the sensor gain to be applied. When the LCG/HCG ratio parameter is changed it is now required to update the range of the gain parameter. [This](https://nighttime-imaging.eu/docs/develop/site/troubleshooting/altair_dualgain/) link provides some more background information.

BlackLevel was not present yet. The BlackBalance is applicable to RGB mode, and BlackLevel to RAW images. In the implemenation a range maximum is set based on the maximum bit depth. This calculation is correct, but a sligth deviation form the toupcam api and could be replaced with some more elaborate code using a switch and the separate defines for the blacklevel maximum values.