### PR TITLE
Support for Atik CMOS camera features

### DIFF
--- a/indi-atik/CMakeLists.txt
+++ b/indi-atik/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ATIK REQUIRED)
 FIND_LIBRARY(M_LIB m)
 
 set(ATIK_VERSION_MAJOR 2)
-set(ATIK_VERSION_MINOR 6)
+set(ATIK_VERSION_MINOR 7)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_atik.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_atik.xml)

--- a/indi-atik/atik_ccd.cpp
+++ b/indi-atik/atik_ccd.cpp
@@ -69,7 +69,8 @@ void ATIK_CCD_ISInit()
 
             if (loop+1 < MAX_CONNECTION_RETRIES)
             {
-                IDMessage(nullptr, "No Atik devices detected on attempt %d/%d, retrying...", loop+1, MAX_CONNECTION_RETRIES);
+                if (0 < loop)
+                    IDMessage(nullptr, "No Atik devices detected on attempt %d/%d, retrying...", loop+1, MAX_CONNECTION_RETRIES);
                 usleep(1000000);
             }
         }

--- a/indi-atik/atik_ccd.cpp
+++ b/indi-atik/atik_ccd.cpp
@@ -281,28 +281,28 @@ bool ATIKCCD::initProperties()
                        IP_RW, 60, IPS_IDLE);
 
     // Pad data from 12 to 16 bits
-    IUFillSwitch(&PadDataS[PADDATA_ON], "PADDATA_ON", "ON", ISS_ON);
-    IUFillSwitch(&PadDataS[PADDATA_OFF], "PADDATA_OFF", "OFF", ISS_OFF);
-    IUFillSwitchVector(&PadDataSP, PadDataS, 2, getDeviceName(), "PADDATA", "Pad Data", CONTROLS_TAB, IP_WO,
-                       ISR_1OFMANY, 2, IPS_IDLE);
+    IUFillSwitch(&PadDataS[PADDATA_ON], "CONTROL_PAD_DATA_ON", "ON", ISS_ON);
+    IUFillSwitch(&PadDataS[PADDATA_OFF], "CONTROL_PAD_DATA_OFF", "OFF", ISS_OFF);
+    IUFillSwitchVector(&PadDataSP, PadDataS, 2, getDeviceName(), "CCD_PAD_DATA", "Pad Data", CONTROLS_TAB, IP_WO,
+                       ISR_1OFMANY, 60, IPS_IDLE);
 
     // Even illumination
-    IUFillSwitch(&EvenIlluminationS[PADDATA_ON], "EVENILLUMINATION_ON", "ON", ISS_OFF);
-    IUFillSwitch(&EvenIlluminationS[PADDATA_OFF], "EVENILLUMINATION_OFF", "OFF", ISS_ON);
-    IUFillSwitchVector(&EvenIlluminationSP, EvenIlluminationS, 2, getDeviceName(), "EVENILLUMINATION", "Even Illumination", CONTROLS_TAB,
-                       IP_WO, ISR_1OFMANY, 2, IPS_IDLE);
+    IUFillSwitch(&EvenIlluminationS[PADDATA_ON], "CONTROL_EVEN_ILLUMINATION_ON", "ON", ISS_OFF);
+    IUFillSwitch(&EvenIlluminationS[PADDATA_OFF], "CONTROL_EVEN_ILLUMINATION_OFF", "OFF", ISS_ON);
+    IUFillSwitchVector(&EvenIlluminationSP, EvenIlluminationS, 2, getDeviceName(), "CCD_EVEN_ILLUMINATION", "Even Illumination", CONTROLS_TAB,
+                       IP_WO, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Exposure Speed
-    IUFillSwitch(&FastModeS[FASTMODE_POWERSAVE], "POWERSAVE", "Powersave / Low noise", ISS_ON);
-    IUFillSwitch(&FastModeS[FASTMODE_NORMAL], "NORMAL", "Normal", ISS_OFF);
-    IUFillSwitch(&FastModeS[FASTMODE_FAST], "FAST", "Fast / Stream", ISS_OFF);
-    IUFillSwitchVector(&FastModeSP, FastModeS, 2, getDeviceName(), "FAST_MODE", "Fast Mode", CONTROLS_TAB, IP_RW,
-                       ISR_1OFMANY, 4, IPS_IDLE);
+    IUFillSwitch(&FastModeS[FASTMODE_POWERSAVE], "CONTROL_POWERSAVE", "Powersave / Low noise", ISS_ON);
+    IUFillSwitch(&FastModeS[FASTMODE_NORMAL], "CONTROL_NORMAL", "Normal", ISS_OFF);
+    IUFillSwitch(&FastModeS[FASTMODE_FAST], "CONTROL_FAST", "Fast / Stream", ISS_OFF);
+    IUFillSwitchVector(&FastModeSP, FastModeS, 3, getDeviceName(), "CCD_FAST_MODE", "Fast Mode", CONTROLS_TAB, IP_RW,
+                       ISR_1OFMANY, 60, IPS_IDLE);
 
     // Bit send format
     IUFillSwitch(&BitSendS[BITSEND_16BITS], "BITSEND_16BITS", "16BITS", ISS_ON);
     IUFillSwitch(&BitSendS[BITSEND_12BITS], "BITSEND_16BITS", "12BITS", ISS_OFF);
-    IUFillSwitchVector(&BitSendSP, BitSendS, 2, getDeviceName(), "BITSEND", "Bit Send", CONTROLS_TAB, IP_WO,
+    IUFillSwitchVector(&BitSendSP, BitSendS, 2, getDeviceName(), "CCD_BIT_SEND", "Bit Send", CONTROLS_TAB, IP_WO,
                        ISR_1OFMANY, 2, IPS_IDLE);
 
     IUSaveText(&BayerT[2], "RGGB");
@@ -337,17 +337,17 @@ bool ATIKCCD::updateProperties()
         if (m_isHorizon)
         {
             defineSwitch(&ControlPresetsSP);
-            loadConfig(true, "");
+            loadConfig(true, "CCD_CONTROL_PRESETS");
             defineNumber(&ControlNP);
-            loadConfig(true, "");
+            loadConfig(true, "CCD_CONTROLS");
             defineSwitch(&PadDataSP);
-            loadConfig(true, "");
+            loadConfig(true, "CCD_PAD_DATA");
             defineSwitch(&EvenIlluminationSP);
-            loadConfig(true, "");
+            loadConfig(true, "CCD_EVEN_ILLUMINATION");
             defineSwitch(&FastModeSP);
-            //loadConfig(true, "");
+            loadConfig(true, "CCD_FAST_MODE");
             defineSwitch(&BitSendSP);
-            //loadConfig(true, "");
+            loadConfig(true, "CCD_BIT_SEND");
 }
 
         if (m_CameraFlags & ARTEMIS_PROPERTIES_CAMERAFLAGS_HAS_FILTERWHEEL)

--- a/indi-atik/atik_ccd.cpp
+++ b/indi-atik/atik_ccd.cpp
@@ -422,7 +422,6 @@ bool ATIKCCD::setupParams()
         LOGF_ERROR("Failed to inquire camera max binning (%d)", rc);
     }
 
-    PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", 0.001, 3600, 1, false);
     PrimaryCCD.setMinMaxStep("CCD_BINNING", "HOR_BIN", 1, binX, 1, false);
     PrimaryCCD.setMinMaxStep("CCD_BINNING", "VER_BIN", 1, binY, 1, false);
 
@@ -596,6 +595,19 @@ bool ATIKCCD::setupParams()
             uint16_t const patch = *(reinterpret_cast<uint16_t*>(&data+sizeof(uint16_t)*2));
             LOGF_DEBUG("Horizon currrent FPGA version: data[0-1] %d%d data[2-3] %d data[4-5] %d %value %d.%d.%d", data[0], data[0], data[2], data[3], data[4], data[5], major, minor, patch);
         }
+
+        // Horizon and Horizon2 cameras have exposure in [18us, unlimited[
+        // FIXME: Not sure how to distinguish cameras programmatically, so we apply the same exposure interval - will fail if unsupported
+        PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", 18.0e-6f, 3600*24, 1, false);
+    }
+    else
+    {
+        // ACIS, 4xxEX, One 6/9, 11000, Titan, 4000, 420, 450 and 314L+ have exposures in [0.001s, unlimited[
+        // GP has exposure in [0.001s, 5s]
+        // Infinity has exposure in [0.001s, 120s]
+        // 383L+ and 16200 have exposure in [0.2s, unlimited[
+        // FIXME: Not sure how to distinguish cameras programmatically, so we apply the same exposure interval - will fail if unsupported
+        PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", 0.001, 3600*24, 1, false);
     }
 
     // Create imaging thread

--- a/indi-atik/atik_ccd.h
+++ b/indi-atik/atik_ccd.h
@@ -96,6 +96,12 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
             ID_AtikHorizonGOPresetHigh,
             ID_AtikHorizonGOCustomGain,
             ID_AtikHorizonGOCustomOffset,
+            ID_AtikHorizonEvenIllumiation = 12,
+            ID_AtikHorizonPadData,
+            ID_AtikHorizonExposureSpeed,
+            ID_AtikHorizonBitSendMode,
+            ID_AtikHorizonFX3Version = 200,
+            ID_AtikHorizonFPGAVersion,
         };
 
         typedef enum AtikGuideDirection
@@ -173,6 +179,42 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
             PRESET_HIGH,
         };
 
+        // Pad data from 12 to 16 bits
+        ISwitch PadDataS[2];
+        ISwitchVectorProperty PadDataSP;
+        enum
+        {
+            PADDATA_ON,
+            PADDATA_OFF
+        };
+
+        // Even illumination
+        ISwitch EvenIlluminationS[2];
+        ISwitchVectorProperty EvenIlluminationSP;
+        enum
+        {
+            EVENILLUMINATION_ON,
+            EVENILLUMINATION_OFF
+        };
+
+        // Gain & Offset Presets
+        ISwitch FastModeS[4];
+        ISwitchVectorProperty FastModeSP;
+        enum
+        {
+            FASTMODE_POWERSAVE,
+            FASTMODE_NORMAL,
+            FASTMODE_FAST,
+        };
+
+        // Bit send
+        ISwitch BitSendS[2];
+        ISwitchVectorProperty BitSendSP;
+        enum
+        {
+            BITSEND_16BITS,
+            BITSEND_12BITS
+        };
 
         // API & Firmware Version
         IText VersionInfoS[2] = {};

--- a/indi-atik/atik_ccd.h
+++ b/indi-atik/atik_ccd.h
@@ -96,7 +96,7 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
             ID_AtikHorizonGOPresetHigh,
             ID_AtikHorizonGOCustomGain,
             ID_AtikHorizonGOCustomOffset,
-            ID_AtikHorizonEvenIllumiation = 12,
+            ID_AtikHorizonEvenIllumination = 12,
             ID_AtikHorizonPadData,
             ID_AtikHorizonExposureSpeed,
             ID_AtikHorizonBitSendMode,
@@ -138,6 +138,11 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
          * @brief setupParams get initial camera parameters
          */
         bool setupParams();
+
+        /**
+         * @brief setupGainOffset read gain and offset parameters
+         */
+        void updateGainOffset();
 
         /**
          * @brief activateCooler Turn on/off cooler
@@ -184,8 +189,8 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         ISwitchVectorProperty PadDataSP;
         enum
         {
-            PADDATA_ON,
-            PADDATA_OFF
+            PADDATA_OFF = 0,
+            PADDATA_ON
         };
 
         // Even illumination
@@ -193,8 +198,8 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         ISwitchVectorProperty EvenIlluminationSP;
         enum
         {
-            EVENILLUMINATION_ON,
-            EVENILLUMINATION_OFF
+            EVENILLUMINATION_OFF = 0,
+            EVENILLUMINATION_ON
         };
 
         // Gain & Offset Presets
@@ -202,7 +207,7 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         ISwitchVectorProperty FastModeSP;
         enum
         {
-            FASTMODE_POWERSAVE,
+            FASTMODE_POWERSAVE = 0,
             FASTMODE_NORMAL,
             FASTMODE_FAST,
         };
@@ -212,7 +217,7 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         ISwitchVectorProperty BitSendSP;
         enum
         {
-            BITSEND_16BITS,
+            BITSEND_16BITS = 0,
             BITSEND_12BITS
         };
 


### PR DESCRIPTION
This PR brings support for the following features of Atik CMOS cameras:

- Even Illumination: clears the sensor buffers before exposing, avoids gradient artifacts at the expense of some read noise.
- Exposure Speed: allows choosing between PowerSave (lowest noise) and Normal buffer reading.
- Gain/Offset Presets: allows choosing between Custom, LowGain, MediumGain and HighGain gain/offset presets.
- Pad Data: shift pixel values by 4 bits so that the full dynamic range spans [0,65535] instead of [0,4095].

Note that some properties are stored in the camera itself, and will still be configured after a hardware power cycle. There is no known way to reset the hardware to defaults.

You would want Even Illumination enabled to avoid gradients, especially when doing short exposures (flats for instance).

You would want Exposure Speed set to PowerSave for normal low-noise usage. Note that Fast Mode is not implemented yet in this version. This feature will bring streaming support.

You would want Pad Data enabled for your frame calibration ADUs to match a percentage of the full dynamic range, instead of hitting the high limit around 6% (4096).

**Note about Gain/Offset**: For usability reasons, setting Custom Gain/Offset properties will automatically switch the driver to use the Gain/Offset Preset "Custom". In the same logic, the Gain/Offset Preset property will cause the values of the Custom Gain/Offset properties to be read from the camera and updated. However, only the Gain/Offset Preset "Custom" will cause Custom Gain/Offset properties to be loaded from a configuration file. In other words preset "Custom" writes "Gain/Offset" and any other preset value reads "Gain/Offset". Remember this when setting your capture properties.

**Change applying to both CMOS and CCD**: there is no way to obtain the actual possible exposure range from the SDK. This PR adjusts the default range so that all Atik cameras may be used with their exposure specifications, at the expense of failures when trying to use an unsupported exposure duration. Based on official camera specifications, now CMOS cameras get 18us minimal exposure, CCD cameras get 1ms minimal exposure, and all cameras get 24-hour maximum exposure. Please check your hardware documentation for the available exposure range.
