### PR TITLE
Fix data pile-up in gpsd

### DIFF
--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -241,12 +241,19 @@ IPState GPSD::updateGPS()
         }
         return IPS_BUSY;
     }
-
-    if ((gpsData = gps->read()) == nullptr)
-    {
-        LOG_ERROR("GPSD read error.");
-        IDSetText(&GPSstatusTP, nullptr);
-        return IPS_ALERT;
+ 
+    // Empty the buffer and keep only the last data block
+    while (1)
+    { 
+      if ((gpsData = gps->read()) == nullptr)
+      {
+          LOG_ERROR("GPSD read error.");
+          IDSetText(&GPSstatusTP, nullptr);
+          return IPS_ALERT;
+      }
+      // Exit the loop if there is no more data in the buffer
+      if (!gps->waiting(0))
+          break;
     }
 
     if (gpsData->status == STATUS_NO_FIX)


### PR DESCRIPTION
Empty the buffer of gpsd daemon and keep just last segment of data. Fix suggested by @rtlprmft in https://github.com/indilib/indi-3rdparty/issues/180