### PR TITLE
Adding Simulation Capabilities to gpsd

### DIFF
--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -127,6 +127,15 @@ bool GPSD::initProperties()
     IUFillSwitchVector(&TimeSourceSP, TimeSourceS, 2, getDeviceName(), "GPS_TIME_SOURCE", "Time Source",
                        OPTIONS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
+    // Location to be used if no GPS is available
+    IUFillNumber(&SimLocationN[LOCATION_LATITUDE], "SIM_LAT", "Lat (dd:mm:ss)", "%010.6m", -90, 90, 0, 29.1);
+    IUFillNumber(&SimLocationN[LOCATION_LONGITUDE], "SIM_LONG", "Lon (dd:mm:ss)", "%010.6m", 0, 360, 0, 48.5);
+    IUFillNumber(&SimLocationN[LOCATION_ELEVATION], "SIM_ELEV", "Elevation (m)", "%g", -200, 10000, 0, 12);
+    IUFillNumberVector(&SimLocationNP, SimLocationN, 3, getDeviceName(), "SIM_GEOGRAPHIC_COORD", "Simulated Location", OPTIONS_TAB,
+                       IP_RW, 60, IPS_IDLE);
+
+    addAuxControls();
+
     setDriverInterface(GPS_INTERFACE | AUX_INTERFACE);
 
     return true;
@@ -142,6 +151,7 @@ bool GPSD::updateProperties()
         defineText(&GPSstatusTP);
         defineNumber(&PolarisNP);
         defineSwitch(&TimeSourceSP);
+        defineNumber(&SimLocationNP);
     }
     else
     {
@@ -149,6 +159,7 @@ bool GPSD::updateProperties()
         deleteProperty(GPSstatusTP.name);
         deleteProperty(PolarisNP.name);
         deleteProperty(TimeSourceSP.name);
+        deleteProperty(SimLocationNP.name);
     }
     return true;
 }
@@ -206,7 +217,7 @@ IPState GPSD::updateGPS()
     struct gps_data_t *gpsData;
     time_t raw_time;
 
-    if (IUFindOnSwitchIndex(&TimeSourceSP) == TS_SYSTEM)
+    if (isSimulation() || IUFindOnSwitchIndex(&TimeSourceSP) == TS_SYSTEM)
     {
         // Update time regardless having gps fix.
         // We are using system time assuming the system is synced with the gps
@@ -232,7 +243,19 @@ IPState GPSD::updateGPS()
         TimeTP.s = IPS_OK;
     }
 
-    if (!gps->waiting(100000))
+    if (isSimulation())
+    {
+        LocationNP.s                        = IPS_OK;
+        LocationN[LOCATION_LATITUDE].value  = SimLocationN[LOCATION_LATITUDE].value;
+        LocationN[LOCATION_LONGITUDE].value = SimLocationN[LOCATION_LONGITUDE].value;
+        LocationN[LOCATION_ELEVATION].value = SimLocationN[LOCATION_ELEVATION].value;
+
+        IDSetNumber(&LocationNP, nullptr);
+
+        return IPS_OK;
+    }
+
+    if (!gps->waiting(1000))
     {
         if (GPSstatusTP.s != IPS_BUSY)
         {
@@ -241,20 +264,20 @@ IPState GPSD::updateGPS()
         }
         return IPS_BUSY;
     }
- 
-    // Empty the buffer and keep only the last data block
+
     while (1)
-    { 
-      if ((gpsData = gps->read()) == nullptr)
-      {
-          LOG_ERROR("GPSD read error.");
-          IDSetText(&GPSstatusTP, nullptr);
-          return IPS_ALERT;
-      }
-      // Exit the loop if there is no more data in the buffer
-      if (!gps->waiting(0))
-          break;
+    {
+        if ((gpsData = gps->read()) == nullptr)
+        {
+            LOG_ERROR("GPSD read error.");
+            IDSetText(&GPSstatusTP, nullptr);
+            return IPS_ALERT;
+        }
+
+        if (!gps->waiting(0))
+            break;
     }
+
 
     if (gpsData->status == STATUS_NO_FIX)
     {
@@ -396,11 +419,49 @@ bool GPSD::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
     return INDI::GPS::ISNewSwitch(dev, name, states, names, n);
 }
 
+bool GPSD::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+{
+    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
+    {
+        ///////////////////////////////////
+        // Geographic Coords
+        ///////////////////////////////////
+        if (strcmp(name, "SIM_GEOGRAPHIC_COORD") == 0)
+        {
+            int latindex       = IUFindIndex("SIM_LAT",  names, n);
+            int longindex      = IUFindIndex("SIM_LONG", names, n);
+            int elevationindex = IUFindIndex("SIM_ELEV", names, n);
+
+            if (latindex == -1 || longindex == -1 || elevationindex == -1)
+            {
+                SimLocationNP.s = IPS_ALERT;
+                IDSetNumber(&SimLocationNP, "Location data missing or corrupted.");
+            }
+
+            double latitude  = values[latindex];
+            double longitude = values[longindex];
+            double elevation = values[elevationindex];
+
+            SimLocationNP.s                        = IPS_OK;
+            SimLocationN[LOCATION_LATITUDE].value  = latitude;
+            SimLocationN[LOCATION_LONGITUDE].value = longitude;
+            SimLocationN[LOCATION_ELEVATION].value = elevation;
+
+            //  Update client display
+            IDSetNumber(&SimLocationNP, nullptr);
+        }
+    }
+
+    return INDI::GPS::ISNewNumber(dev, name, values, names, n);
+}
+
+
 bool GPSD::saveConfigItems(FILE *fp)
 {
     INDI::GPS::saveConfigItems(fp);
 
     IUSaveConfigSwitch(fp, &TimeSourceSP);
+    IUSaveConfigNumber(fp, &SimLocationNP);
 
     return true;
 }

--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -265,6 +265,7 @@ IPState GPSD::updateGPS()
         return IPS_BUSY;
     }
 
+    // Empty the buffer and keep only the last data block
     while (1)
     {
         if ((gpsData = gps->read()) == nullptr)
@@ -273,7 +274,7 @@ IPState GPSD::updateGPS()
             IDSetText(&GPSstatusTP, nullptr);
             return IPS_ALERT;
         }
-
+        // Exit the loop if there is no more data in the buffer
         if (!gps->waiting(0))
             break;
     }

--- a/indi-gpsd/gps_driver.h
+++ b/indi-gpsd/gps_driver.h
@@ -39,6 +39,7 @@ class GPSD : public INDI::GPS
         virtual bool updateProperties() override;
 
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool setSystemTime(time_t& raw_time);
     protected:
         virtual bool Connect() override;
@@ -59,10 +60,14 @@ class GPSD : public INDI::GPS
 
         ISwitchVectorProperty TimeSourceSP;
         ISwitch TimeSourceS[2];
+
+        //  A number vector that stores default lattitude and longitude
+        INumberVectorProperty SimLocationNP;
+        INumber SimLocationN[3];
+
         enum
         {
             TS_GPS,
             TS_SYSTEM
         };
-
 };


### PR DESCRIPTION
This allows to have coordinates without exchanging the driver even though the GPS is not connected