### PR TITLE
Optionally clear CMOS before exposure

### DIFF
--- a/debian/indi-asi/changelog
+++ b/debian/indi-asi/changelog
@@ -1,3 +1,9 @@
+indi-asi (1.8) bionic; urgency=low
+
+  * Fix configuration save issue.
+
+ -- Konstantin Baranov <const@mimas.ru>  Fri, 14 Aug 2020 11:00:00 -0700
+
 indi-asi (1.7) bionic; urgency=medium
 
   * Fix configuration save issue.

--- a/indi-asi/CMakeLists.txt
+++ b/indi-asi/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(ASI_VERSION_MAJOR 1)
-set(ASI_VERSION_MINOR 7)
+set(ASI_VERSION_MINOR 8)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_asi.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_asi.xml)

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -263,7 +263,8 @@ bool ASICCD::initProperties()
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     IUFillNumber(&BlinkN[0], "BLINK_TIMES", "Blinks before exposure", "%2.0f", 0, 100, 1, 0);
-    IUFillNumberVector(&BlinkNP, BlinkN, 1, getDeviceName(), "BLINK", "Blink", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    IUFillNumber(&BlinkN[1], "BLINK_DURATION", "Blink duration", "%2.3f", 0, 60, 0.001, 0);
+    IUFillNumberVector(&BlinkNP, BlinkN, NARRAY(BlinkN), getDeviceName(), "BLINK", "Blink", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     IUSaveText(&BayerT[2], getBayerString());
 
@@ -1041,7 +1042,7 @@ bool ASICCD::StartExposure(float duration)
     {
         LOGF_INFO("Blinking %ld time(s) before exposure", blinks);
 
-        const long duration = 0;
+        const long duration = BlinkN[1].value * 1000000.0;
         errCode = ASISetControlValue(m_camInfo->CameraID, ASI_EXPOSURE, duration, ASI_FALSE);
         if (errCode != ASI_SUCCESS)
         {
@@ -1072,7 +1073,7 @@ bool ASICCD::StartExposure(float duration)
                     break;
                 }
             }
-            while (blinks-- > 0);
+            while (--blinks > 0);
         }
 
         if (blinks > 0)
@@ -2218,6 +2219,9 @@ bool ASICCD::saveConfigItems(FILE *fp)
 
     if (VideoFormatSP.nsp > 0)
         IUSaveConfigSwitch(fp, &VideoFormatSP);
+
+    if (BlinkNP.nnp > 0)
+        IUSaveConfigNumber(fp, &BlinkNP);
 
     return true;
 }

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -262,6 +262,9 @@ bool ASICCD::initProperties()
     IUFillSwitchVector(&VideoFormatSP, nullptr, 0, getDeviceName(), "CCD_VIDEO_FORMAT", "Format", CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
+    IUFillNumber(&BlinkN[0], "BLINK_TIMES", "Blinks before exposure", "%2.0f", 0, 100, 1, 0);
+    IUFillNumberVector(&BlinkNP, BlinkN, 1, getDeviceName(), "BLINK", "Blink", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     IUSaveText(&BayerT[2], getBayerString());
 
     IUFillNumber(&ADCDepthN, "BITS", "Bits", "%2.0f", 0, 32, 1, 0);
@@ -373,6 +376,8 @@ bool ASICCD::updateProperties()
             }
         }
 
+        defineNumber(&BlinkNP);
+
         defineNumber(&ADCDepthNP);
         defineText(&SDKVersionSP);
     }
@@ -395,6 +400,7 @@ bool ASICCD::updateProperties()
         if (VideoFormatSP.nsp > 0)
             deleteProperty(VideoFormatSP.name);
 
+        deleteProperty(BlinkNP.name);
         deleteProperty(SDKVersionSP.name);
         deleteProperty(ADCDepthNP.name);
     }
@@ -753,6 +759,13 @@ bool ASICCD::ISNewNumber(const char *dev, const char *name, double values[], cha
             IDSetNumber(&ControlNP, nullptr);
             return true;
         }
+
+        if (!strcmp(name, BlinkNP.name))
+        {
+            BlinkNP.s = IUUpdateNumber(&BlinkNP, values, names, n) < 0 ? IPS_ALERT : IPS_OK;
+            IDSetNumber(&BlinkNP, nullptr);
+            return true;
+        }
     }
 
     return INDI::CCD::ISNewNumber(dev, name, values, names, n);
@@ -1022,6 +1035,51 @@ bool ASICCD::activateCooler(bool enable)
 bool ASICCD::StartExposure(float duration)
 {
     ASI_ERROR_CODE errCode = ASI_SUCCESS;
+
+    long blinks = BlinkN[0].value;
+    if (blinks > 0)
+    {
+        LOGF_INFO("Blinking %ld time(s) before exposure", blinks);
+
+        const long duration = 0;
+        errCode = ASISetControlValue(m_camInfo->CameraID, ASI_EXPOSURE, duration, ASI_FALSE);
+        if (errCode != ASI_SUCCESS)
+        {
+            LOGF_ERROR("Failed to set blink exposure to %ldus, error %d", duration, errCode);
+        }
+        else
+        {
+            do
+            {
+                errCode = ASIStartExposure(m_camInfo->CameraID, ASI_TRUE);
+                if (errCode != ASI_SUCCESS)
+                {
+                    LOGF_ERROR("Failed to start blink exposure, error %d", errCode);
+                    break;
+                }
+
+                ASI_EXPOSURE_STATUS expStatus;
+                do
+                {
+                    usleep(100000);
+                    errCode = ASIGetExpStatus(m_camInfo->CameraID, &expStatus);
+                }
+                while (errCode == ASI_SUCCESS && expStatus == ASI_EXP_WORKING);
+
+                if (errCode != ASI_SUCCESS || expStatus != ASI_EXP_SUCCESS)
+                {
+                    LOGF_ERROR("Blink exposure failed, error %d, status %d", errCode, expStatus);
+                    break;
+                }
+            }
+            while (blinks-- > 0);
+        }
+
+        if (blinks > 0)
+        {
+            LOGF_WARN("%ld blink exposure(s) NOT done", blinks);
+        }
+    }
 
     PrimaryCCD.setExposureDuration(duration);
     ExposureRequest = duration;

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -262,8 +262,8 @@ bool ASICCD::initProperties()
     IUFillSwitchVector(&VideoFormatSP, nullptr, 0, getDeviceName(), "CCD_VIDEO_FORMAT", "Format", CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&BlinkN[0], "BLINK_TIMES", "Blinks before exposure", "%2.0f", 0, 100, 1, 0);
-    IUFillNumber(&BlinkN[1], "BLINK_DURATION", "Blink duration", "%2.3f", 0, 60, 0.001, 0);
+    IUFillNumber(&BlinkN[BLINK_COUNT], "BLINK_COUNT", "Blinks before exposure", "%2.0f", 0, 100, 1, 0);
+    IUFillNumber(&BlinkN[BLINK_DURATION], "BLINK_DURATION", "Blink duration", "%2.3f", 0, 60, 0.001, 0);
     IUFillNumberVector(&BlinkNP, BlinkN, NARRAY(BlinkN), getDeviceName(), "BLINK", "Blink", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     IUSaveText(&BayerT[2], getBayerString());
@@ -1037,12 +1037,12 @@ bool ASICCD::StartExposure(float duration)
 {
     ASI_ERROR_CODE errCode = ASI_SUCCESS;
 
-    long blinks = BlinkN[0].value;
+    long blinks = BlinkN[BLINK_COUNT].value;
     if (blinks > 0)
     {
         LOGF_INFO("Blinking %ld time(s) before exposure", blinks);
 
-        const long duration = BlinkN[1].value * 1000000.0;
+        const long duration = BlinkN[BLINK_DURATION].value * 1000000.0;
         errCode = ASISetControlValue(m_camInfo->CameraID, ASI_EXPOSURE, duration, ASI_FALSE);
         if (errCode != ASI_SUCCESS)
         {
@@ -2220,8 +2220,7 @@ bool ASICCD::saveConfigItems(FILE *fp)
     if (VideoFormatSP.nsp > 0)
         IUSaveConfigSwitch(fp, &VideoFormatSP);
 
-    if (BlinkNP.nnp > 0)
-        IUSaveConfigNumber(fp, &BlinkNP);
+    IUSaveConfigNumber(fp, &BlinkNP);
 
     return true;
 }

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -154,6 +154,9 @@ class ASICCD : public INDI::CCD
         uint8_t rememberVideoFormat = { 0 };
         ASI_IMG_TYPE currentVideoFormat;
 
+        INumber BlinkN[1];
+        INumberVectorProperty BlinkNP;
+
         INumber ADCDepthN;
         INumberVectorProperty ADCDepthNP;
 

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -154,6 +154,11 @@ class ASICCD : public INDI::CCD
         uint8_t rememberVideoFormat = { 0 };
         ASI_IMG_TYPE currentVideoFormat;
 
+        enum {
+                BLINK_COUNT,
+                BLINK_DURATION
+        };
+
         INumber BlinkN[2];
         INumberVectorProperty BlinkNP;
 

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -154,7 +154,7 @@ class ASICCD : public INDI::CCD
         uint8_t rememberVideoFormat = { 0 };
         ASI_IMG_TYPE currentVideoFormat;
 
-        INumber BlinkN[1];
+        INumber BlinkN[2];
         INumberVectorProperty BlinkNP;
 
         INumber ADCDepthN;


### PR DESCRIPTION
CMOS is normally reset just before every exposure. But sometimes residual charge may remain
and pollute new image. Running dummy short exposures just before starting a real one is found
to help in some situations. For example, it reduces ghosts of stars after dithering.
Disabled by default, user may choose to blink any number of times.

Validated on my ASI294MC Pro. Each blink takes about 300-400ms of extra time.

See extensive discussion here: https://www.cloudynights.com/topic/662887-not-rbi-on-cmos-but-this-looks-similar/