### PR TITLE
Correct fix status check for new gpsd

### DIFF
--- a/indi-gpsd/gps_driver.cpp
+++ b/indi-gpsd/gps_driver.cpp
@@ -214,9 +214,6 @@ IPState GPSD::updateGPS()
         IDSetSwitch(&RefreshSP, nullptr);
     }
 
-#if GPSD_API_MAJOR_VERSION >= 10
-    struct gps_fix_t *gpsFix;
-#endif
     struct gps_data_t *gpsData;
     time_t raw_time;
 
@@ -283,7 +280,7 @@ IPState GPSD::updateGPS()
     }
 
 #if GPSD_API_MAJOR_VERSION >= 10
-    if (gpsFix->status == STATUS_NO_FIX)
+    if (gpsData->fix.status == STATUS_NO_FIX)
 #else  
     if (gpsData->status == STATUS_NO_FIX)
 #endif


### PR DESCRIPTION
Previous fix was totally bogus as it just dereferenced an uninitialized pointer.