### PR TITLE
FIX: Parse correctly Fuji shutterspeed given in minutes.

### DIFF
--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -483,6 +483,11 @@ static double *parse_shutterspeed(gphoto_driver *gphoto, gphoto_widget *widget)
         }
         else if ((val = strtod(widget->choices[i], nullptr)))
         {
+            // Fuji returns long exposure values ( > 60s) with m postfix
+            if (widget->choices[i][strlen(widget->choices[i]) - 1] == 'm')
+            {
+                val = val * 60;
+            }
             exposure[i] = val;
             DEBUGFDEVICE(device, INDI::Logger::DBG_DEBUG, "exposure[%d]=%g seconds", i, exposure[i]);
         }


### PR DESCRIPTION
Libgphoto2 does not support bulb mode on Fuji cameras. As of versions 2.5.25 fixed shutterspeed >60s are reportet in minutes (1m, 2m, 4m etc.).

The 'm' postfix ist just ignored by indi_gphoto_ccd. This is fixed in this patch.

I've sucessfully tested it on my X-T2 with exposure times up to 15 minutes.