### PR TITLE
Add .spec files for building RPMs

### DIFF
--- a/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
+++ b/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
@@ -1,0 +1,73 @@
+Name: indi-aagcloudwatcher-ng
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+%define _lto_cflags %{nil}
+
+cd indi-aagcloudwatcher-ng
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-aagcloudwatcher-ng
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Wed Jul 29 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-ahp-correlator/indi-ahp-correlator.spec
+++ b/indi-ahp-correlator/indi-ahp-correlator.spec
@@ -1,0 +1,76 @@
+Name: indi-ahp-correlator
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-ahp-correlator
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-ahp-correlator
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-aok/indi-aok.spec
+++ b/indi-aok/indi-aok.spec
@@ -1,0 +1,77 @@
+Name: indi-aok
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-aok
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-aok
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-apogee/indi-apogee.spec
+++ b/indi-apogee/indi-apogee.spec
@@ -1,0 +1,83 @@
+Name: indi-apogee
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libapogee
+BuildRequires: libapogee-devel
+
+Requires: libapogee
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-apogee
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-apogee
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%doc indi-apogee/AUTHORS indi-apogee/README
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-armadillo-platypus/indi-armadillo-platypus.spec
+++ b/indi-armadillo-platypus/indi-armadillo-platypus.spec
@@ -1,0 +1,79 @@
+Name: indi-armadillo-platypus
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-armadillo-platypus
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-armadillo-platypus
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%doc indi-armadillo-platypus/AUTHORS indi-armadillo-platypus/README
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/99-armadilloplatypus.rules
+
+
+%changelog
+* Wed Jul 29 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files

--- a/indi-asi/indi-asi.spec
+++ b/indi-asi/indi-asi.spec
@@ -1,0 +1,78 @@
+Name: indi-asi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Requires: libasi
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-asi
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-asi
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-astrolink4/indi-astrolink4.spec
+++ b/indi-astrolink4/indi-astrolink4.spec
@@ -1,0 +1,77 @@
+Name: indi-astrolink4
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-astrolink4
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-astrolink4
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-astromechfoc/indi-astromechfoc.spec
+++ b/indi-astromechfoc/indi-astromechfoc.spec
@@ -1,0 +1,76 @@
+Name: indi-astromechfoc
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-astromechfoc
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-astromechfoc
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-atik/indi-atik.spec
+++ b/indi-atik/indi-atik.spec
@@ -1,0 +1,81 @@
+Name: indi-atik
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libatik
+
+Requires: libatik
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-atik
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-atik
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-avalon/indi-avalon.spec
+++ b/indi-avalon/indi-avalon.spec
@@ -1,0 +1,76 @@
+Name: indi-avalon
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-avalon
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-avalon
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-beefocus/indi-beefocus.spec
+++ b/indi-beefocus/indi-beefocus.spec
@@ -1,0 +1,77 @@
+Name: indi-beefocus
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-beefocus
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-beefocus
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-celestronaux/indi-celestronaux.spec
+++ b/indi-celestronaux/indi-celestronaux.spec
@@ -1,0 +1,78 @@
+Name: indi-celestronaux
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-celestronaux
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-celestronaux
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%{_bindir}/*
+%{_datadir}/indi/indi_celestronaux.xml
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-dreamfocuser/indi-dreamfocuser.spec
+++ b/indi-dreamfocuser/indi-dreamfocuser.spec
@@ -1,0 +1,77 @@
+Name: indi-dreamfocuser
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-dreamfocuser
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-dreamfocuser
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -1,0 +1,80 @@
+Name: indi-dsi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-dsi
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-dsi
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+/etc/udev/rules.d/99-meadedsi.rules
+/lib/firmware/meade-deepskyimager.hex
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-duino/indi-duino.spec
+++ b/indi-duino/indi-duino.spec
@@ -1,0 +1,79 @@
+Name: indi-duino
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-duino
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-duino
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%doc indi-duino/README
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-eqmod/indi-eqmod.spec
+++ b/indi-eqmod/indi-eqmod.spec
@@ -1,0 +1,79 @@
+Name: indi-eqmod
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-eqmod
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-eqmod
+make DESTDIR=%{buildroot} install
+
+%files
+%license indi-eqmod/COPYING LICENSE
+%doc indi-eqmod/AUTHORS indi-eqmod/README
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-ffmv/indi-ffmv.spec
+++ b/indi-ffmv/indi-ffmv.spec
@@ -1,0 +1,78 @@
+Name: indi-ffmv
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-ffmv
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-ffmv
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/99-fireflymv.rules
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-gphoto/indi-gphoto.spec
+++ b/indi-gphoto/indi-gphoto.spec
@@ -1,0 +1,80 @@
+Name: indi-gphoto
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-gphoto
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-gphoto
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%doc indi-gphoto/AUTHORS indi-gphoto/README
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/85-disable-dslr-automout.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-gpsd/indi-gpsd.spec
+++ b/indi-gpsd/indi-gpsd.spec
@@ -1,0 +1,77 @@
+Name: indi-gpsd
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-gpsd
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-gpsd
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-gpsnmea/indi-gpsnmea.spec
+++ b/indi-gpsnmea/indi-gpsnmea.spec
@@ -1,0 +1,77 @@
+Name: indi-gpsnmea
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-gpsnmea
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-gpsnmea
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-inovaplx/indi-inovaplx.spec
+++ b/indi-inovaplx/indi-inovaplx.spec
@@ -1,0 +1,78 @@
+Name: indi-inovaplx
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libinovasdk
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-inovaplx
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-inovaplx
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-maxdomeii/indi-maxdomeii.spec
+++ b/indi-maxdomeii/indi-maxdomeii.spec
@@ -1,0 +1,77 @@
+Name: indi-maxdomeii
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-maxdomeii
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-maxdomeii
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-mgen/indi-mgen.spec
+++ b/indi-mgen/indi-mgen.spec
@@ -1,0 +1,77 @@
+Name: indi-mgen
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-mgen
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-mgen
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-mi/indi-mi.spec
+++ b/indi-mi/indi-mi.spec
@@ -1,0 +1,80 @@
+Name: indi-mi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libmicam
+
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-mi
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-mi
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-nexdome/indi-nexdome.spec
+++ b/indi-nexdome/indi-nexdome.spec
@@ -1,0 +1,77 @@
+Name: indi-nexdome
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-nexdome
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-nexdome
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-nexstarevo/indi-nexstarevo.spec
+++ b/indi-nexstarevo/indi-nexstarevo.spec
@@ -1,0 +1,77 @@
+Name: indi-nexstarevo
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-nexstarevo
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-nexstarevo
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-nightscape/indi-nightscape.spec
+++ b/indi-nightscape/indi-nightscape.spec
@@ -1,0 +1,78 @@
+Name: indi-nightscape
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-nightscape
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-nightscape
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/99-nightscape.rules
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-pentax/indi-pentax.spec
+++ b/indi-pentax/indi-pentax.spec
@@ -1,0 +1,79 @@
+Name: indi-pentax
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libricohcamerasdk 
+buildRequires: libpktriggercord
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-pentax
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-pentax
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-qhy/indi-qhy.spec
+++ b/indi-qhy/indi-qhy.spec
@@ -1,0 +1,78 @@
+Name: indi-qhy
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libqhy
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-qhy
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-qhy
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-qsi/indi-qsi.spec
+++ b/indi-qsi/indi-qsi.spec
@@ -1,0 +1,80 @@
+Name: indi-qsi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libqsi
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-qsi
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-qsi
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/99-qsi.rules
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-rtklib/indi-rtklib.spec
+++ b/indi-rtklib/indi-rtklib.spec
@@ -1,0 +1,77 @@
+Name: indi-rtklib
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-rtklib
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-rtklib
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-rtlsdr/indi-rtlsdr.spec
+++ b/indi-rtlsdr/indi-rtlsdr.spec
@@ -1,0 +1,78 @@
+Name: indi-rtlsdr
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: rtl-sdr-devel
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-rtlsdr
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-rtlsdr
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-sbig/indi-sbig.spec
+++ b/indi-sbig/indi-sbig.spec
@@ -1,0 +1,79 @@
+Name: indi-sbig
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libsbig
+Requires: libsbig
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-sbig
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-sbig
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-shelyak/indi-shelyak.spec
+++ b/indi-shelyak/indi-shelyak.spec
@@ -1,0 +1,77 @@
+Name: indi-shelyak
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-shelyak
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-shelyak
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-spectracyber/indi-spectracyber.spec
+++ b/indi-spectracyber/indi-spectracyber.spec
@@ -1,0 +1,77 @@
+Name: indi-spectracyber
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-spectracyber
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-spectracyber
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-starbook/indi-starbook.spec
+++ b/indi-starbook/indi-starbook.spec
@@ -1,0 +1,79 @@
+Name: indi-starbook
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libnova
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-starbook
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-starbook
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-sv305/indi-sv305.spec
+++ b/indi-sv305/indi-sv305.spec
@@ -1,0 +1,80 @@
+Name: indi-sv305
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libsv305
+Requires: libsv305
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-sv305
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-sv305
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Wed Jul 29 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-sx/indi-sx.spec
+++ b/indi-sx/indi-sx.spec
@@ -1,0 +1,78 @@
+Name: indi-sx
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-sx
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-sx
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+/lib/udev/rules.d/99-sx.rules
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-toupbase/indi-toupbase.spec
+++ b/indi-toupbase/indi-toupbase.spec
@@ -1,0 +1,83 @@
+Name: indi-toupbase
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+BuildRequires: libasi
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+BuildRequires: libaltaircam
+BuildRequires: libtoupcam
+BuildRequires: libstarshootg
+BuildRequires: libnncam
+BuildRequires: libmallincam
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-toupbase
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-toupbase
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_datadir}/indi
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/indi-webcam/indi-webcam.spec
+++ b/indi-webcam/indi-webcam.spec
@@ -1,0 +1,78 @@
+Name: indi-webcam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd indi-webcam
+%cmake -DINDI_DATA_DIR=/usr/share/indi .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd indi-webcam
+make DESTDIR=%{buildroot} install
+
+%files
+%license LICENSE
+%{_bindir}/*
+%{_datadir}/indi
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libaltaircam/libaltaircam.spec
+++ b/libaltaircam/libaltaircam.spec
@@ -1,0 +1,85 @@
+Name: libaltaircam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libaltaircam.so()(64bit)
+Provides: libaltaircam.so
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libaltaircam
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libaltaircam
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libaltaircam
+/lib/udev/rules.d/99-altaircam.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -1,0 +1,83 @@
+Name: libapogee
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libapogee
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libapogee
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libapogee
+%{_sysconfdir}/Apogee
+%{_sysconfdir}/udev/rules.d/99-apogee.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libasi/libasi.spec
+++ b/libasi/libasi.spec
@@ -1,0 +1,94 @@
+Name: libasi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+Provides: libASICamera2.so
+Provides: libEAFFocuser.so
+Provides: libEFWFilter.so
+Provides: libUSB2ST4Conv.so
+
+Provides: libASICamera2.so()(64bit)
+Provides: libEAFFocuser.so()(64bit)
+Provides: libEFWFilter.so()(64bit)
+Provides: libUSB2ST4Conv.so()(64bit)
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libasi
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libasi
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+/lib/udev/rules.d/99-asi.rules
+%{_libdir}/*
+%{_includedir}/libasi
+
+%license libasi/license.txt
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libatik/libatik.spec
+++ b/libatik/libatik.spec
@@ -1,0 +1,83 @@
+Name: libatik
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libatikcameras.so()(64bit)
+Provides: libflycapture.so.2()(64bit)
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libatik
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libatik
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libatik
+/lib/udev/rules.d/99-atik.rules
+
+%changelog
+* Mon Jul 27 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libfishcamp/libfishcamp.spec
+++ b/libfishcamp/libfishcamp.spec
@@ -1,0 +1,83 @@
+Name: libfishcamp
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libfishcamp
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libfishcamp
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libfishcamp
+/lib/firmware/Guider_mono_rev16_intel.srec
+/lib/firmware/gdr_usb.hex
+/lib/udev/rules.d/99-fishcamp.rules
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libinovasdk/libinovasdk.spec
+++ b/libinovasdk/libinovasdk.spec
@@ -1,0 +1,85 @@
+Name: libinovasdk
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libinovasdk.so.1()(64bit)
+Provides: libinovasdk.so
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libinovasdk
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libinovasdk
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/inovasdk
+/lib/udev/rules.d/99-inovaplx.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libmallincam/libmallincam.spec
+++ b/libmallincam/libmallincam.spec
@@ -1,0 +1,85 @@
+Name: libmallincam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libmallincam.so()(64bit)
+Provides: libmallincam.so
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libmallincam
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libmallincam
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libmallincam
+/lib/udev/rules.d/99-mallincam.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libmicam/libmicam.spec
+++ b/libmicam/libmicam.spec
@@ -1,0 +1,86 @@
+Name: libmicam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libgxccd.so()(64bit)
+Provides: libgxccd.so
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libmicam
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libmicam
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libmicam
+/lib/udev/rules.d/99-miccd.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libnncam/libnncam.spec
+++ b/libnncam/libnncam.spec
@@ -1,0 +1,85 @@
+Name: libnncam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libnncam.so()(64bit)
+Provides: libnncam.so
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libnncam
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libnncam
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libnncam
+/lib/udev/rules.d/99-nncam.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libpktriggercord/libpktriggercord.spec
+++ b/libpktriggercord/libpktriggercord.spec
@@ -1,0 +1,87 @@
+Name: libpktriggercord
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libpktriggercord.so.0()(64bit)
+Provides: libpktriggercord.so
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libpktriggercord
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libpktriggercord
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libpktriggercord
+/lib/udev/rules.d/95-pentax.rules
+/lib/udev/rules.d/95-samsung.rules
+/usr/share/pktriggercord/pentax_settings.json
+
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -1,0 +1,86 @@
+Name: libqhy
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+Provides: libqhyccd.so.20()(64bit)
+Provides: libqhyccd.so
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libqhy
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libqhy
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libqhy
+/lib/udev/rules.d/85-qhyccd.rules
+/lib/firmware/qhy
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libqsi/libqsi.spec
+++ b/libqsi/libqsi.spec
@@ -1,0 +1,85 @@
+Name: libqsi
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libqsiapi.so.7()(64bit)
+Provides: libqsiapi.so
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libqsi
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libqsi
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_bindir}/*
+%{_libdir}/*
+%{_includedir}/*
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libricohcamerasdk/libricohcamerasdk.spec
+++ b/libricohcamerasdk/libricohcamerasdk.spec
@@ -1,0 +1,87 @@
+Name: libricohcamerasdk
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libRicohCameraSDKCpp.so()(64bit)
+Provides: libRicohCameraSDKCpp.so
+Provides: libmtpricoh.so.9()(64bit)
+Provides: libmtpricoh.so.9
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libricohcamerasdk
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libricohcamerasdk
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libricohcamerasdk
+/lib/udev/rules.d/99-pentax.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libsbig/libsbig.spec
+++ b/libsbig/libsbig.spec
@@ -1,0 +1,87 @@
+Name: libsbig
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libsbig.so.4()(64bit)
+Provides: libsbig.so
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libsbig
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libsbig
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libsbig
+/lib/firmware/*
+/lib/udev/rules.d/51-sbig-debian.rules
+
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libstarshootg/libstarshootg.spec
+++ b/libstarshootg/libstarshootg.spec
@@ -1,0 +1,84 @@
+Name: libstarshootg
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libstarshootg.so()(64bit)
+Provides: libstarshootg.so
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libstarshootg
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libstarshootg
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libstarshootg
+/lib/udev/rules.d/99-starshootg.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libsv305/libsv305.spec
+++ b/libsv305/libsv305.spec
@@ -1,0 +1,87 @@
+Name: libsv305
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+Provides: libCKCameraSDK_x64.so()(64bit)
+Provides: libCKCameraSDK_x64.so
+Provides: libSVBCameraSDK.so()(64bit)
+Provides: libSVBCameraSDK.so
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libsv305
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libsv305
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libsv305
+/lib/udev/rules.d/90-svbonyusb.rules
+
+
+%changelog
+* Wed Jul 29 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+

--- a/libtoupcam/libtoupcam.spec
+++ b/libtoupcam/libtoupcam.spec
@@ -1,0 +1,85 @@
+Name: libtoupcam
+Version: 1.8.7.git
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
+Summary: Instrument Neutral Distributed Interface 3rd party drivers
+
+License: LGPLv2
+# See COPYRIGHT file for a description of the licenses and files covered
+
+URL: https://indilib.org
+Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
+
+%global debug_package %{nil}
+%define __find_requires %{nil}
+
+BuildRequires: cmake
+BuildRequires: libfli-devel
+BuildRequires: libnova-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: systemd
+BuildRequires: gphoto2-devel
+BuildRequires: LibRaw-devel
+BuildRequires: indi-libs
+BuildRequires: indi-devel
+BuildRequires: libtiff-devel
+BuildRequires: cfitsio-devel
+BuildRequires: zlib-devel
+BuildRequires: gsl-devel
+BuildRequires: libcurl-devel
+BuildRequires: libjpeg-turbo-devel
+BuildRequires: fftw-devel
+BuildRequires: libftdi-devel
+BuildRequires: gpsd-devel
+BuildRequires: libdc1394-devel
+BuildRequires: boost-devel
+BuildRequires: boost-regex
+
+BuildRequires: gmock
+
+BuildRequires: pkgconfig(fftw3)
+BuildRequires: pkgconfig(cfitsio)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: pkgconfig(gsl)
+BuildRequires: pkgconfig(libjpeg)
+BuildRequires: pkgconfig(libusb-1.0)
+BuildRequires: pkgconfig(zlib)
+
+Provides: libtoupcam.so()(64bit)
+Provides: libtoupcam.so
+
+
+%description
+INDI is a distributed control protocol designed to operate
+astronomical instrumentation. INDI is small, flexible, easy to parse,
+and scalable. It supports common DCS functions such as remote control,
+data acquisition, monitoring, and a lot more. This is a 3rd party driver.
+
+
+%prep -v
+%setup -n indi-3rdparty-master
+
+%build
+# This package tries to mix and match PIE and PIC which is wrong and will
+# trigger link errors when LTO is enabled.
+# Disable LTO
+%define _lto_cflags %{nil}
+
+cd libtoupcam
+%cmake .
+make VERBOSE=1 %{?_smp_mflags} -j4
+
+%install
+cd libtoupcam
+find %buildroot -type f \( -name '*.so' -o -name '*.so.*' \) -exec chmod 755 {} +
+make DESTDIR=%{buildroot} install
+
+%files
+%{_libdir}/*
+%{_includedir}/libtoupcam
+/lib/udev/rules.d/99-toupcam.rules
+
+
+%changelog
+* Sun Jul 19 2020 Jim Howard <jh.xsnrg+fedora@gmail.com> 1.8.7.git-1
+- update to build from git for copr, credit to Sergio Pascual and Christian Dersch for prior work on spec files
+


### PR DESCRIPTION
This PR adds the .spec files for each of the drivers and libraries that can be made into an RPM currently. These spec files are already in use in my fork of indi-3rdparty, and are building packages published at Copr. This PR will move the spec files and their maintenance into the upstream repo and allow automated builds of 3rd party drivers and libraries based on pushes to this repo.