### PR TITLE
Check DSI camera name to determine model for DSI Pro

### DIFF
--- a/indi-dsi/DsiDeviceFactory.cpp
+++ b/indi-dsi/DsiDeviceFactory.cpp
@@ -34,9 +34,10 @@ DSI::Device *DSI::DeviceFactory::getInstance(const char *devname)
     std::cerr << "Found Camera " << tmp->getCameraName() << std::endl << "Found CCD " << tmp->getCcdChipName() << std::endl;
 
     std::string ccdChipName = tmp->getCcdChipName();
+    std::string cameraName = tmp->getCameraName();
     delete tmp;
 
-    if (ccdChipName == "ICX254AL")
+    if (ccdChipName == "ICX254AL" || cameraName == "DSI Pro")
         return new DSI::DsiPro(devname);
 
     if (ccdChipName == "ICX404AK")


### PR DESCRIPTION
This change was made to support a camera that had the CCD name programmed incorrectly. This was debugged in [this thread](https://www.indilib.org/forum/ccds-dslrs/6570-driver-for-old-meade-dsi-1-pro.html?start=0)