### PR TITLE
Spec update for newer Fedora

### DIFF
--- a/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
+++ b/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-aagcloudwatcher-ng
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-ahp-correlator/indi-ahp-correlator.spec
+++ b/indi-ahp-correlator/indi-ahp-correlator.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-ahp-correlator
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-aok/indi-aok.spec
+++ b/indi-aok/indi-aok.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-aok
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-apogee/indi-apogee.spec
+++ b/indi-apogee/indi-apogee.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-apogee
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-armadillo-platypus/indi-armadillo-platypus.spec
+++ b/indi-armadillo-platypus/indi-armadillo-platypus.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-armadillo-platypus
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-asi/indi-asi.spec
+++ b/indi-asi/indi-asi.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-asi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-astrolink4/indi-astrolink4.spec
+++ b/indi-astrolink4/indi-astrolink4.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-astrolink4
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-astromechfoc/indi-astromechfoc.spec
+++ b/indi-astromechfoc/indi-astromechfoc.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-astromechfoc
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-atik/indi-atik.spec
+++ b/indi-atik/indi-atik.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-atik
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-avalon/indi-avalon.spec
+++ b/indi-avalon/indi-avalon.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-avalon
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-beefocus/indi-beefocus.spec
+++ b/indi-beefocus/indi-beefocus.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-beefocus
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-celestronaux/indi-celestronaux.spec
+++ b/indi-celestronaux/indi-celestronaux.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-celestronaux
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-dreamfocuser/indi-dreamfocuser.spec
+++ b/indi-dreamfocuser/indi-dreamfocuser.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-dreamfocuser
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-dsi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-duino/indi-duino.spec
+++ b/indi-duino/indi-duino.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-duino
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-eqmod/indi-eqmod.spec
+++ b/indi-eqmod/indi-eqmod.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-eqmod
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-ffmv/indi-ffmv.spec
+++ b/indi-ffmv/indi-ffmv.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-ffmv
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-gphoto/indi-gphoto.spec
+++ b/indi-gphoto/indi-gphoto.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-gphoto
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-gpsd/indi-gpsd.spec
+++ b/indi-gpsd/indi-gpsd.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-gpsd
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-gpsnmea/indi-gpsnmea.spec
+++ b/indi-gpsnmea/indi-gpsnmea.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-gpsnmea
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-inovaplx/indi-inovaplx.spec
+++ b/indi-inovaplx/indi-inovaplx.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-inovaplx
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-maxdomeii/indi-maxdomeii.spec
+++ b/indi-maxdomeii/indi-maxdomeii.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-maxdomeii
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-mgen/indi-mgen.spec
+++ b/indi-mgen/indi-mgen.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-mgen
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-mi/indi-mi.spec
+++ b/indi-mi/indi-mi.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-mi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-nexdome/indi-nexdome.spec
+++ b/indi-nexdome/indi-nexdome.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-nexdome
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-nexstarevo/indi-nexstarevo.spec
+++ b/indi-nexstarevo/indi-nexstarevo.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-nexstarevo
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-nightscape/indi-nightscape.spec
+++ b/indi-nightscape/indi-nightscape.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-nightscape
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-pentax/indi-pentax.spec
+++ b/indi-pentax/indi-pentax.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-pentax
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-qhy/indi-qhy.spec
+++ b/indi-qhy/indi-qhy.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-qhy
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-qsi/indi-qsi.spec
+++ b/indi-qsi/indi-qsi.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-qsi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-rtklib/indi-rtklib.spec
+++ b/indi-rtklib/indi-rtklib.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-rtklib
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-rtlsdr/indi-rtlsdr.spec
+++ b/indi-rtlsdr/indi-rtlsdr.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-rtlsdr
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-sbig/indi-sbig.spec
+++ b/indi-sbig/indi-sbig.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-sbig
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-shelyak/indi-shelyak.spec
+++ b/indi-shelyak/indi-shelyak.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-shelyak
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-spectracyber/indi-spectracyber.spec
+++ b/indi-spectracyber/indi-spectracyber.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-spectracyber
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-starbook/indi-starbook.spec
+++ b/indi-starbook/indi-starbook.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-starbook
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-sv305/indi-sv305.spec
+++ b/indi-sv305/indi-sv305.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-sv305
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-sx/indi-sx.spec
+++ b/indi-sx/indi-sx.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-sx
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-toupbase/indi-toupbase.spec
+++ b/indi-toupbase/indi-toupbase.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-toupbase
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/indi-webcam/indi-webcam.spec
+++ b/indi-webcam/indi-webcam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: indi-webcam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libahp_xc/libahp_xc.spec
+++ b/libahp_xc/libahp_xc.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libahp_xc
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libaltaircam/libaltaircam.spec
+++ b/libaltaircam/libaltaircam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libaltaircam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libapogee
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libasi/libasi.spec
+++ b/libasi/libasi.spec
@@ -1,3 +1,5 @@
+%define __cmake_in_source_build %{_vpath_builddir}
+
 Name: libasi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libatik/libatik.spec
+++ b/libatik/libatik.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libatik
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libfishcamp/libfishcamp.spec
+++ b/libfishcamp/libfishcamp.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libfishcamp
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libinovasdk/libinovasdk.spec
+++ b/libinovasdk/libinovasdk.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libinovasdk
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libmallincam/libmallincam.spec
+++ b/libmallincam/libmallincam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libmallincam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libmicam/libmicam.spec
+++ b/libmicam/libmicam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libmicam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libnncam/libnncam.spec
+++ b/libnncam/libnncam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libnncam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libpktriggercord/libpktriggercord.spec
+++ b/libpktriggercord/libpktriggercord.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libpktriggercord
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libqhy
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libqsi/libqsi.spec
+++ b/libqsi/libqsi.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libqsi
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libricohcamerasdk/libricohcamerasdk.spec
+++ b/libricohcamerasdk/libricohcamerasdk.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libricohcamerasdk
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libsbig/libsbig.spec
+++ b/libsbig/libsbig.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libsbig
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libstarshootg/libstarshootg.spec
+++ b/libstarshootg/libstarshootg.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libstarshootg
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libsv305/libsv305.spec
+++ b/libsv305/libsv305.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libsv305
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}

--- a/libtoupcam/libtoupcam.spec
+++ b/libtoupcam/libtoupcam.spec
@@ -1,3 +1,4 @@
+%define __cmake_in_source_build %{_vpath_builddir}
 Name: libtoupcam
 Version: 1.8.7.git
 Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}


### PR DESCRIPTION
This PR updates existing spec files to be able to build on F33 and rawhide as well as F31 and F32 as before.