### PR TITLE
Fixe for the SDK gain setting issue

### DIFF
--- a/debian/indi-sv305/changelog
+++ b/debian/indi-sv305/changelog
@@ -1,3 +1,9 @@
+indi-sv305 (1.2.1) bionic; urgency=low
+
+  * Camera gain issue fixed
+
+ -- Blaise-Florentin Collin <thx8411@yahoo.fr>  Wed, 13 Spt 2020 16:00:00 +0300
+
 indi-sv305 (1.2) bionic; urgency=low
 
   * Camera name fix

--- a/indi-sv305/CMakeLists.txt
+++ b/indi-sv305/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SV305_VERSION_MAJOR 1)
 set (SV305_VERSION_MINOR 2)
-set (SV305_VERSION_PATCH 0)
+set (SV305_VERSION_PATCH 1)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-sv305/README
+++ b/indi-sv305/README
@@ -53,7 +53,7 @@ Features
 Known issues
 ============
 
-	+ Initial gain setting sometime fails (SDK issue ?)
+	+ None
 
 Limitations
 ===========
@@ -65,7 +65,8 @@ Limitations
 Changelog
 =========
 
-	+ 1.1.1 : Updated with the last SDK (20200812)
+	+ 1.2.1 : Camera gain issue fixed
+	+ 1.2 : Updated with the last SDK (20200812)
 	+ 1.1 : Ability to stretch camera's 12 bits pixel depth to 16 bits
 	+ 1.0 : Refactoring with the new SVBony SDK (1.6.1)
 	+ 0.9 : First version, with the CKCamera SDK

--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -1050,6 +1050,7 @@ bool Sv305CCD::updateControl(int ControlType, SVB_CONTROL_TYPE SVB_Control, doub
     if(status != SVB_SUCCESS)
     {
         LOGF_ERROR("Error, camera set control %d failed\n", ControlType);
+        return false;
     }
     LOGF_INFO("Camera control %d to %.f\n", ControlType, ControlsN[ControlType].value);
 

--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -341,6 +341,9 @@ bool Sv305CCD::Connect()
         return false;
     }
 
+    // wait a bit for the camera to get ready
+    usleep(0.5 * 1e6);
+
     // get camera properties
     status = SVBGetCameraProperty(cameraID, &cameraProperty);
     if (status != SVB_SUCCESS)
@@ -367,6 +370,10 @@ bool Sv305CCD::Connect()
         pthread_mutex_unlock(&cameraID_mutex);
         return false;
     }
+
+    // fix for SDK gain error issue
+    // set exposure time
+    SVBSetControlValue(cameraID, SVB_EXPOSURE , (double)(1 * 1000000), SVB_FALSE);
 
     // read controls and feed UI
     for(int i=0; i<controlsNum; i++)

--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -667,7 +667,7 @@ bool Sv305CCD::StartExposure(float duration)
     ExposureRequest = duration;
 
     gettimeofday(&ExpStart, nullptr);
-    LOGF_INFO("Taking a %g seconds frame...\n", ExposureRequest);
+    LOGF_DEBUG("Taking a %g seconds frame...\n", ExposureRequest);
 
     InExposure = true;
 
@@ -992,7 +992,7 @@ void Sv305CCD::TimerHit()
                         usleep(100000);
                         pthread_mutex_lock(&cameraID_mutex);
 			status = SVBGetVideoData(cameraID, imageBuffer, PrimaryCCD.getFrameBufferSize(), 100 );
-                        LOG_INFO("Wait...");
+                        LOG_DEBUG("Wait...");
                     }
 
                     pthread_mutex_unlock(&cameraID_mutex);


### PR DESCRIPTION
Hello,

Sarwar did the trick.
The "gain setting" issue is fixed.
Waiting a bit and triggering a first "blank" frame avoid the gain setting error.

Best regards,

Blaise
