### PR TITLE
SV305PRO detection fixed

### DIFF
--- a/debian/indi-sv305/changelog
+++ b/debian/indi-sv305/changelog
@@ -1,3 +1,9 @@
+indi-sv305 (1.2.2) bionic; urgency=low
+
+  * SV305PRO detection fixed
+
+ -- Blaise-Florentin Collin <thx8411@yahoo.fr>  Mon, 2 Nov 2020 16:00:00 +0300
+
 indi-sv305 (1.2.1) bionic; urgency=low
 
   * Camera gain issue fixed

--- a/indi-sv305/CMakeLists.txt
+++ b/indi-sv305/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SV305_VERSION_MAJOR 1)
 set (SV305_VERSION_MINOR 2)
-set (SV305_VERSION_PATCH 1)
+set (SV305_VERSION_PATCH 2)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-sv305/README
+++ b/indi-sv305/README
@@ -49,6 +49,7 @@ Features
 	+ Subframing
 	+ Software binning
 	+ Streaming
+	+ SV305PRO ST4 port supported
 
 Known issues
 ============
@@ -60,11 +61,11 @@ Limitations
 
 	+ Subframing and binning doesn't work in liveview
         + Can't abort long exposure yet
-	+ Should support the SV305 PRO aswell, but not tested yet
 
 Changelog
 =========
 
+	+ 1.2.2 : Fix SV305PRO detection
 	+ 1.2.1 : Camera gain issue fixed
 	+ 1.2 : Updated with the last SDK (20200812)
 	+ 1.1 : Ability to stretch camera's 12 bits pixel depth to 16 bits

--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -246,8 +246,7 @@ bool Sv305CCD::initProperties()
     uint32_t cap = /* CCD_CAN_ABORT | */ CCD_HAS_BAYER | CCD_CAN_SUBFRAME | CCD_CAN_BIN | CCD_HAS_STREAMING;
 
     // SV305 Pro has an ST4 port
-    /* TODO : fix with real value */
-    if(strcmp(cameraInfo.FriendlyName, "SVBONY SV305 PRO")==0)
+    if(strcmp(cameraInfo.FriendlyName, "SVBONY SV305PRO")==0)
     {
         cap|= CCD_HAS_ST4_PORT;
     }


### PR DESCRIPTION
Hello,

The SV305 PRO detection is fixed.
The camera is now able to guide using the ST4 port.

Best regards,

Blaise