### PR TITLE
follow the split of LX200Format into EquatorialFormat and GeographicFormat in indilib core PR1296

### DIFF
--- a/indi-aok/lx200aok.cpp
+++ b/indi-aok/lx200aok.cpp
@@ -464,7 +464,7 @@ void LX200Skywalker::getBasicData()
     LOG_DEBUG(__FUNCTION__);
     if (!isSimulation())
     {
-        checkLX200Format();
+        checkLX200EquatorialFormat();
 
         if (INDI::Telescope::capability & TELESCOPE_CAN_PARK)
         {
@@ -1091,7 +1091,7 @@ bool LX200Skywalker::transmit(const char* buffer)
     return true;
 }
 
-bool LX200Skywalker::checkLX200Format()
+bool LX200Skywalker::checkLX200EquatorialFormat()
 {
     LOG_DEBUG(__FUNCTION__);
     char response[TCS_RESPONSE_BUFFER_LENGTH];

--- a/indi-aok/lx200aok.h
+++ b/indi-aok/lx200aok.h
@@ -156,7 +156,7 @@ class LX200Skywalker : public LX200Telescope
         virtual bool setSiteLatitude(double Lat);
         virtual bool setSiteLongitude(double Long);
 
-        bool checkLX200Format();
+        bool checkLX200EquatorialFormat();
         // Guide Commands
         virtual IPState GuideNorth(uint32_t ms) override;
         virtual IPState GuideSouth(uint32_t ms) override;

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -710,7 +710,7 @@ void LX200StarGo::getBasicData()
     LOG_DEBUG(__FUNCTION__);
     if (!isSimulation())
     {
-        checkLX200Format();
+        checkLX200EquatorialFormat();
 
         if (genericCapability & LX200_HAS_ALIGNMENT_TYPE)
             getAlignment();
@@ -1870,7 +1870,7 @@ bool LX200StarGo::SetTrackMode(uint8_t mode)
     return true;
 }
 
-bool LX200StarGo::checkLX200Format()
+bool LX200StarGo::checkLX200EquatorialFormat()
 {
     LOG_DEBUG(__FUNCTION__);
     char response[AVALON_RESPONSE_BUFFER_LENGTH];

--- a/indi-avalon/lx200stargo.h
+++ b/indi-avalon/lx200stargo.h
@@ -218,7 +218,7 @@ class LX200StarGo : public LX200Telescope
 
         // meridian flip
         virtual bool syncSideOfPier();
-        bool checkLX200Format();
+        bool checkLX200EquatorialFormat();
 
         // Guide Commands
         virtual IPState GuideNorth(uint32_t ms) override;


### PR DESCRIPTION
This goes with https://github.com/indilib/indi/pull/1296 # use d m s.f with f being tenths for LX200_GEO_LONGER_FORMAT