### PR TITLE
Added extra paths for finding header files.

### DIFF
--- a/cmake_modules/FindINDI.cmake
+++ b/cmake_modules/FindINDI.cmake
@@ -176,7 +176,7 @@ endif(NOT ${INDI_PUBLIC_VAR_NS}_FIND_COMPONENTS)
 find_path(
     ${INDI_PUBLIC_VAR_NS}_INCLUDE_DIR
     indidevapi.h
-    PATH_SUFFIXES libindi
+    PATH_SUFFIXES libindi include/libindi
     ${PC_INDI_INCLUDE_DIR}
     ${_obIncDir}
     ${GNUWIN32_DIR}/include

--- a/indi-rpicam/TODO
+++ b/indi-rpicam/TODO
@@ -1,3 +1,4 @@
+- Make sure indi_rpicam does not break building whole indi_3rdparty
 - Try using encoding MMAL_ENCODING_BAYER_SBGGR12P if that works and is even faster.
 - Don't start from x=0 on subframes..
 - Exposure time does not seem to affect exposure now. printf(stderr from mmalcamera does not get output anywhere.


### PR DESCRIPTION
If libindi is compiled and installed to a non-standard path, just setting INDI_ROOT
is not enough and cmake will not find correct files from that installation without
this extra path.