### PR TITLE
min/max exposure fix

### DIFF
--- a/debian/indi-sv305/changelog
+++ b/debian/indi-sv305/changelog
@@ -1,3 +1,9 @@
+indi-sv305 (1.2.3) bionic; urgency=low
+
+  * min/max exposure values fix
+
+ -- Blaise-Florentin Collin <thx8411@yahoo.fr>  Thu, 21 Jan 2021 16:00:00 +0300
+
 indi-sv305 (1.2.2) bionic; urgency=low
 
   * SV305PRO detection fixed

--- a/indi-sv305/CMakeLists.txt
+++ b/indi-sv305/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SV305_VERSION_MAJOR 1)
 set (SV305_VERSION_MINOR 2)
-set (SV305_VERSION_PATCH 2)
+set (SV305_VERSION_PATCH 3)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-sv305/README
+++ b/indi-sv305/README
@@ -65,6 +65,7 @@ Limitations
 Changelog
 =========
 
+	+ 1.2.3 : min/max exposure values fix
 	+ 1.2.2 : Fix SV305PRO detection
 	+ 1.2.1 : Camera gain issue fixed
 	+ 1.2 : Updated with the last SDK (20200812)

--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -390,8 +390,9 @@ bool Sv305CCD::Connect()
          {
              case SVB_EXPOSURE :
                  // Exposure
-                 minExposure = caps.MinValue / 1000000;
-                 maxExposure = caps.MaxValue / 1000000;
+                 minExposure = (double)caps.MinValue / 1000000.0;
+                 maxExposure = (double)caps.MaxValue / 1000000.0;
+                 PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", minExposure, maxExposure, 1, true);
                  break;
 
              case SVB_GAIN :


### PR DESCRIPTION
Hi,

The min and max exposure values exposed by the SDk where not properly handled by the driver.

Best regards,

