### PR TITLE
Fix race in ASICCD::StopStreaming

### DIFF
--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -901,6 +901,8 @@ bool ASICCD::StopStreaming()
 
     setThreadRequest(StateAbort);
 
+    waitUntil(StateIdle);
+
     //    pthread_mutex_lock(&condMutex);
     //    threadRequest = StateAbort;
     //    pthread_cond_signal(&cv);


### PR DESCRIPTION
I got some crashes on stopping streaming with 1sec exposure.
I think this change fixes it.
