### PR TITLE
Fix regression on Bayer pattern property for DSI sensors.

### DIFF
--- a/indi-dsi/dsi_ccd.cpp
+++ b/indi-dsi/dsi_ccd.cpp
@@ -223,14 +223,6 @@ bool DSICCD::initProperties()
 
     setDefaultPollingPeriod(250);
 
-    if (dsi->getCcdChipName() == "ICX285AQ")
-    {
-        // DSI III has a RGB color matrix
-        IUSaveText(&BayerT[0], "0");
-        IUSaveText(&BayerT[1], "0");
-        IUSaveText(&BayerT[2], "GBRG");
-    }
-
     return true;
 }
 
@@ -277,6 +269,8 @@ void DSICCD::setupParams()
 
     /* calculate how much memory we need for the primary CCD buffer */
     PrimaryCCD.setFrameBufferSize(PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * PrimaryCCD.getBPP() / 8);
+
+    UpdateCCDBin(PrimaryCCD.getBinX(), PrimaryCCD.getBinY());
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This PR fixes the Bayer pattern property configuration, which was constrained by a DSI property which did not exist at that time.

The property is now set when the device is successfully connected to.