### PR TITLE
Added Star Adventurer (mount code 0x0A - 1 snap port)

### DIFF
--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -440,6 +440,9 @@ void Skywatcher::InquireBoardVersion(ITextVectorProperty *boardTP)
         case 0x06:
             strcpy(boardinfo[0], "AZEQ5");
             break;
+        case 0x0A:
+            strcpy(boardinfo[0], "Star Adventurer");
+            break;
         case 0x20:
             strcpy(boardinfo[0], "EQ8-R Pro");
             break;
@@ -563,7 +566,7 @@ bool Skywatcher::HasPPEC()
 
 bool Skywatcher::HasSnapPort1()
 {
-    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06 ||  MountCode == 0x23 || MountCode == 0xA5;
+    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06 ||  MountCode == 0x0A || MountCode == 0x23 || MountCode == 0xA5;
 }
 
 bool Skywatcher::HasSnapPort2()


### PR DESCRIPTION
Added Star Adventurer mount code (0x0A) to eqmod driver, and updated HasSnapPort1() appropriately.

Tested with my Star Adventurer 2i.