### PR TITLE
Allow calibrating of ZWO EFW

### DIFF
--- a/indi-asi/asi_wheel.h
+++ b/indi-asi/asi_wheel.h
@@ -55,8 +55,13 @@ class ASIWHEEL : public INDI::FilterWheel
 
     private:
 
+        // Unidirectional
         ISwitchVectorProperty UniDirectionalSP;
         ISwitch UniDirectionalS[2];
+
+        // Calibrate
+        ISwitchVectorProperty CalibrateSP;
+        ISwitch CalibrateS[1];
 
     private:
         int fw_id = -1;

--- a/indi-asi/asi_wheel.h
+++ b/indi-asi/asi_wheel.h
@@ -62,9 +62,10 @@ class ASIWHEEL : public INDI::FilterWheel
         ISwitch UniDirectionalS[2];
 
         // Calibrate
+        static void TimerHelperCalibrate(void *context);
+        void TimerCalibrate();
         ISwitchVectorProperty CalibrateSP;
         ISwitch CalibrateS[1];
-        virtual bool Calibrate();
 
     private:
         int fw_id = -1;

--- a/indi-asi/asi_wheel.h
+++ b/indi-asi/asi_wheel.h
@@ -28,6 +28,8 @@
 
 #include <indifilterwheel.h>
 
+#define EFW_IS_MOVING -1
+
 class ASIWHEEL : public INDI::FilterWheel
 {
     public:
@@ -62,6 +64,7 @@ class ASIWHEEL : public INDI::FilterWheel
         // Calibrate
         ISwitchVectorProperty CalibrateSP;
         ISwitch CalibrateS[1];
+        virtual bool Calibrate();
 
     private:
         int fw_id = -1;


### PR DESCRIPTION
Adding the ability to calibrate the ZWO EFW

Have tested this with my own EFW, it does run the calibration, though the calibration is an async process so the call to the `libasi` call just returns success. From the sound of the EFW the calibration takes 10-15 secs (the ZWO docs say it could take 60 secs), might have to check if the status of the EFW to see if it's moving and only after it has stopped that I could say that the calibration is done.

The motivation for this change was that I need to calibrate the EFW but didn't have a windows machine to setup the ASCOM driver to run the calibration.  I used the `gpsd` refresh functionality as a basis for what was needed to allow this functionality.