### PR TITLE
LOGF_ERROR macro is expecting a char* but receiving an std::string

### DIFF
--- a/indi-pentax/pentax_ccd.cpp
+++ b/indi-pentax/pentax_ccd.cpp
@@ -529,7 +529,7 @@ void PentaxCCD::updateCaptureSetting(CaptureSetting *setting, string newval) {
             return;
         }
     }
-    LOGF_ERROR("Error setting %S to %s: not supported in current camera mode", setting->getName(), newval.c_str());
+    LOGF_ERROR("Error setting %S to %s: not supported in current camera mode", setting->getName().c_str(), newval.c_str());
 }
 
 bool PentaxCCD::ISNewSwitch(const char * dev, const char * name, ISState * states, char * names[], int n)


### PR DESCRIPTION
The LOGF_ERROR macro is using the `INDI::Logger::print()` function through the DEBUGF macro. `print()` expects a `char *` as message (see [indilogger.h](https://github.com/indilib/indi/blob/91bcd531c4631805d24d38343692fb8acf8fff6a/libs/indibase/indilogger.h#L250))

Right now this leads me to : `pentax_ccd.cpp:532: error: cannot pass object of non-trivial type 'const std::string' (aka 'const basic_string<char>') through variadic method; call will abort at runtime`

Using c_str() fixes this.