### PR TITLE
Indi qhy streaming work

### DIFF
--- a/indi-qhy/CMakeLists.txt
+++ b/indi-qhy/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(INDI_QHY_VERSION_MAJOR 2)
-set(INDI_QHY_VERSION_MINOR 7)
+set(INDI_QHY_VERSION_MINOR 8)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_qhy.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_qhy.xml )

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -860,18 +860,24 @@ bool QHYCCD::Connect()
         {
             readModeInfo[rm].id = rm;
             ret = GetQHYCCDReadModeName(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].label[0]);
-            if (ret == QHYCCD_SUCCESS) {
+            if (ret == QHYCCD_SUCCESS)
+            {
                 LOGF_INFO("Mode %d: %s\n", readModeInfo[rm].id, readModeInfo[rm].label);
-            } else {
+            }
+            else
+            {
                 LOGF_INFO("Failed to obtain read mode name for modeNumber: %d\n", readModeInfo[rm].id);
                 strcpy(readModeInfo[rm].label, "UNKNOWN");
             }
             ret = GetQHYCCDReadModeResolution(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].subW,
-                &readModeInfo[rm].subH);
-            if (ret == QHYCCD_SUCCESS) {
+                                              &readModeInfo[rm].subH);
+            if (ret == QHYCCD_SUCCESS)
+            {
                 LOGF_INFO("Sensor resolution for mode %s: %dx%d px\n", readModeInfo[rm].label,
-                    readModeInfo[rm].subW, readModeInfo[rm].subH);
-            } else {
+                          readModeInfo[rm].subW, readModeInfo[rm].subH);
+            }
+            else
+            {
                 LOGF_WARN("Failed to read mode resolution name for modeNumber: %d\n", readModeInfo[rm].id);
                 readModeInfo[rm].subW = readModeInfo[rm].subH = 0;
             }
@@ -882,7 +888,7 @@ bool QHYCCD::Connect()
         if (ret == QHYCCD_SUCCESS && numReadModes > 1)
         {
             LOGF_INFO("Current read mode: %s (%dx%d)\n", readModeInfo[currentQHYReadMode].label,
-                readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
+                      readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
         }
 
         ////////////////////////////////////////////////////////////////////
@@ -1189,7 +1195,7 @@ bool QHYCCD::setupParams()
 
     LOG_DEBUG("setup params\n");
 
-   //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
+    //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
     uint32_t nbuf, bpp;
     double chipw, chiph, pixelw, pixelh;
 
@@ -1302,15 +1308,15 @@ bool QHYCCD::StartExposure(float duration)
     // Set streaming mode and re-initialize camera
     if (currentQHYStreamMode == 1 && !isSimulation())
     {
-    	currentQHYStreamMode = 0;
-    	SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
-    	ret = InitQHYCCD(m_CameraHandle);
-    	if(ret != QHYCCD_SUCCESS)
-    	{
-      		LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
-      		return false;
-    	}
-	}
+        currentQHYStreamMode = 0;
+        SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+        ret = InitQHYCCD(m_CameraHandle);
+        if(ret != QHYCCD_SUCCESS)
+        {
+            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+            return false;
+        }
+    }
 
 
     m_ImageFrameType = PrimaryCCD.getFrameType();
@@ -2084,12 +2090,12 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
                     currentQHYReadMode = newReadMode;
 
                     LOGF_INFO("Current read mode: %s (%dx%d)", readModeInfo[currentQHYReadMode].label,
-                        readModeInfo[currentQHYReadMode].subW,readModeInfo[currentQHYReadMode].subH);
+                              readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
 
                     //reinitialized the camera paramters...
                     QHYCCD::setupParams();
-                    ReadModeNP.s = IPS_OK;
                     saveConfig(true, ReadModeNP.name);
+                    ReadModeNP.s = IPS_OK;
                 }
                 else
                 {
@@ -2099,6 +2105,13 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
                     ReadModeN[0].value = newReadMode;
                     LOGF_ERROR("Failed to update read mode: %d", rc);
                 }
+            }
+            else
+            {
+                //reinitialized the camera paramters...
+                QHYCCD::setupParams();
+                saveConfig(true, ReadModeNP.name);
+                ReadModeNP.s = IPS_OK;
             }
 
             IDSetNumber(&ReadModeNP, nullptr);
@@ -2373,17 +2386,15 @@ bool QHYCCD::StartStreaming()
     {
         //LOG_INFO("Start streaming\n"); //DEBUG
         currentQHYStreamMode = 1;
-    	SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
-        // FIX: some cameras may need init again to start streaming,.
-        // This code structure was also updated in SDK 21.02.01
-    	ret = InitQHYCCD(m_CameraHandle);
-    	if(ret != QHYCCD_SUCCESS)
-    	{
+        SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+        ret = InitQHYCCD(m_CameraHandle);
+        if(ret != QHYCCD_SUCCESS)
+        {
             currentQHYStreamMode = 0;
-      		LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
-      		return false;
-    	}
-	}
+            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+            return false;
+        }
+    }
 
     // Set binning mode
     if (isSimulation())
@@ -2573,8 +2584,8 @@ void QHYCCD::streamVideo()
             //DEBUG 
             if(!frames)
                 LOG_INFO("Receiving frames ...");
-            if(!(++frames%30))
-                LOGF_DEBUG("Frames received: %d (%.1f fps)", frames, 1.0*frames/(time(NULL) - t_start));
+            if(!(++frames % 30))
+                LOGF_DEBUG("Frames received: %d (%.1f fps)", frames, 1.0 * frames / (time(NULL) - t_start));
         }
         pthread_mutex_lock(&condMutex);
     }

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -574,54 +574,13 @@ bool QHYCCD::updateProperties()
             }
             else
             {
-
                 ReadModeN[0].min  = 0;
-
-                ////////////////////////////////////////////////////////////////////
-                /// Read Modes
-                ////////////////////////////////////////////////////////////////////
-                int ret;
-                uint32_t maxNumOfReadModes = 0;
-                ret = GetQHYCCDNumberOfReadModes(m_CameraHandle, &maxNumOfReadModes);
-                if (ret == QHYCCD_SUCCESS && maxNumOfReadModes > 0)
-                {
-                    ReadModeN[0].max  = maxNumOfReadModes - 1;
-                }
-                else
-                {
-                    ReadModeN[0].max = 0;
-                }
-
+                ReadModeN[0].max = (numReadModes > 0 ? numReadModes - 1 : 0);
                 ReadModeN[0].step = 1;
-
-                uint32_t currentReadMode = 0;
-
-                ret = GetQHYCCDReadMode(m_CameraHandle, &currentReadMode);
-                if (ret == QHYCCD_SUCCESS)
-                {
-                    ReadModeN[0].value = currentReadMode;
-
-                    //NEW CODE - Query and display read mode name for more informative console output
-                    char currentReadModeName[255] = {0};
-                    int retVal = GetQHYCCDReadModeName(m_CameraHandle, currentReadMode, currentReadModeName);
-                    if (retVal == QHYCCD_SUCCESS)
-                    {
-                        LOGF_INFO("Current read mode is: %s", currentReadModeName);
-                    }
-                    else
-                    {
-                        LOGF_INFO("Current read mode is: %u", currentReadMode);
-                    }
-                }
-                else
-                {
-                    //NEW CODE - format modifier %zu --> %u
-                    LOGF_INFO("Using default read mode (error reading it): %u", currentReadMode);
-                }
+                ReadModeN[0].value = currentQHYReadMode;
             }
             defineProperty(&ReadModeNP);
         }
-        // ---
 
         if (HasGain)
         {
@@ -822,7 +781,6 @@ bool QHYCCD::updateProperties()
 bool QHYCCD::Connect()
 {
     uint32_t cap;
-    uint32_t readModes = 0;
 
 
     if (isSimulation())
@@ -862,7 +820,8 @@ bool QHYCCD::Connect()
         cap = CCD_CAN_ABORT | CCD_CAN_SUBFRAME;
 
         // Disable the stream mode before connecting
-        uint32_t ret = SetQHYCCDStreamMode(m_CameraHandle, 0);
+        currentQHYStreamMode = 0;
+        uint32_t ret = SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
         if (ret != QHYCCD_SUCCESS)
         {
             LOGF_ERROR("Can not disable stream mode (%d)", ret);
@@ -887,12 +846,43 @@ bool QHYCCD::Connect()
         ////////////////////////////////////////////////////////////////////
         /// Read Modes
         ////////////////////////////////////////////////////////////////////
-        ret = GetQHYCCDNumberOfReadModes(m_CameraHandle, &readModes);
-        if (ret == QHYCCD_SUCCESS && readModes > 1)
+        ret = GetQHYCCDNumberOfReadModes(m_CameraHandle, &numReadModes);
+        if (ret == QHYCCD_SUCCESS && numReadModes > 1)
         {
             HasReadMode = true;
             //NEW CODE - format modifier %zu --> %u
-            LOGF_INFO("Number of read modes: %u", readModes);
+            LOGF_INFO("Number of read modes: %u", numReadModes);
+        }
+
+        readModeInfo = new QHYReadModeInfo[numReadModes];
+
+        for (uint32_t rm = 0; rm < numReadModes; rm++)
+        {
+            readModeInfo[rm].id = rm;
+            ret = GetQHYCCDReadModeName(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].label[0]);
+            if (ret == QHYCCD_SUCCESS) {
+                LOGF_INFO("Mode %d: %s\n", readModeInfo[rm].id, readModeInfo[rm].label);
+            } else {
+                LOGF_INFO("Failed to obtain read mode name for modeNumber: %d\n", readModeInfo[rm].id);
+                strcpy(readModeInfo[rm].label, "UNKNOWN");
+            }
+            ret = GetQHYCCDReadModeResolution(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].subW,
+                &readModeInfo[rm].subH);
+            if (ret == QHYCCD_SUCCESS) {
+                LOGF_INFO("Sensor resolution for mode %s: %dx%d px\n", readModeInfo[rm].label,
+                    readModeInfo[rm].subW, readModeInfo[rm].subH);
+            } else {
+                LOGF_WARN("Failed to read mode resolution name for modeNumber: %d\n", readModeInfo[rm].id);
+                readModeInfo[rm].subW = readModeInfo[rm].subH = 0;
+            }
+        }
+
+        //Correctly initialize current read mode
+        ret = GetQHYCCDReadMode(m_CameraHandle, &currentQHYReadMode);
+        if (ret == QHYCCD_SUCCESS && numReadModes > 1)
+        {
+            LOGF_INFO("Current read mode: %s (%dx%d)\n", readModeInfo[currentQHYReadMode].label,
+                readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
         }
 
         ////////////////////////////////////////////////////////////////////
@@ -1173,18 +1163,20 @@ bool QHYCCD::Disconnect()
     pthread_cond_signal(&cv);
     pthread_mutex_unlock(&condMutex);
     pthread_join(m_ImagingThread, nullptr);
-    tState = StateNone;
+    //tState = StateNone;
     if (isSimulation() == false)
     {
         if (tState == StateStream)
         {
-            SetQHYCCDStreamMode(m_CameraHandle, 0x0);
             StopQHYCCDLive(m_CameraHandle);
+            SetQHYCCDStreamMode(m_CameraHandle, 0x0);
         }
         else if (tState == StateExposure)
             CancelQHYCCDExposingAndReadout(m_CameraHandle);
         CloseQHYCCD(m_CameraHandle);
     }
+
+    tState = StateNone;
 
     LOG_INFO("Camera is offline.");
 
@@ -1195,14 +1187,15 @@ bool QHYCCD::setupParams()
 {
 
 
-    //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
+    LOG_DEBUG("setup params\n");
+
+   //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
     uint32_t nbuf, bpp;
     double chipw, chiph, pixelw, pixelh;
 
     //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
     //raw frame origin is always at (0,0)
     sensorROI.subX = sensorROI.subY = 0;
-
 
     if (isSimulation())
     {
@@ -1305,6 +1298,20 @@ bool QHYCCD::StartExposure(float duration)
         LOG_ERROR("Cannot take exposure while streaming/recording is active.");
         return false;
     }
+
+    // Set streaming mode and re-initialize camera
+    if (currentQHYStreamMode == 1 && !isSimulation())
+    {
+    	currentQHYStreamMode = 0;
+    	SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+    	ret = InitQHYCCD(m_CameraHandle);
+    	if(ret != QHYCCD_SUCCESS)
+    	{
+      		LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+      		return false;
+    	}
+	}
+
 
     m_ImageFrameType = PrimaryCCD.getFrameType();
 
@@ -1872,8 +1879,9 @@ bool QHYCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 SetCCDParams(effectiveROI.subW, effectiveROI.subH, PrimaryCCD.getBPP(), PrimaryCCD.getPixelSizeX(),
                              PrimaryCCD.getPixelSizeX());
 
-                //Image Settings
-                //The true frame origin is at (effectiveROI.subX ,effectiveROI.subY), need to correct for this offset when taking exposure or streaming.
+                // Image Settings
+                // The true frame origin is at (effectiveROI.subX ,effectiveROI.subY).
+                // This vector that needs to be used for offset-correction when taking exposures or streaming while ignoring overscan areas.
                 UpdateCCDFrame(0, 0, effectiveROI.subW, effectiveROI.subH);
 
             }
@@ -2052,97 +2060,45 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
         else if (!strcmp(name, ReadModeNP.name))
         {
             //NEW CODE - Fix read mode handling
-            uint32_t currentReadMode;
 
             IUUpdateNumber(&ReadModeNP, values, names, n);
-            uint32_t newReadMode = ReadModeN[0].value;
-
-            //Check if camera already is in the requested read mode
-            int rc = GetQHYCCDReadMode(m_CameraHandle, &currentReadMode);
-            if (rc == QHYCCD_SUCCESS)
-            {
-                if (newReadMode == currentReadMode)
-                {
-
-                    LOGF_INFO("Camera is already in read mode: %u", currentReadMode);
-                    return true;
-                }
-            }
+            uint32_t newReadMode = static_cast<uint32_t>(ReadModeN[0].value);
 
             // Set readout mode
-            rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
-            if (rc == QHYCCD_SUCCESS)
+            if (newReadMode != currentQHYReadMode)
             {
-
-                currentReadMode = newReadMode;
-
-                char currentReadModeName[255] = {0};
-                strcpy(currentReadModeName, "");
-                int retVal = GetQHYCCDReadModeName(m_CameraHandle, currentReadMode, currentReadModeName);
-                if (retVal == QHYCCD_SUCCESS)
+                int rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
+                if (rc == QHYCCD_SUCCESS)
                 {
-                    LOGF_INFO("Read mode is now updated to: %s", currentReadModeName);
-                }
-                else
-                {
-                    LOGF_INFO("Read mode is now updated to: %u", currentReadMode);
-                }
 
-                //Reinitialize camera to get new chip characteristics
-                rc = InitQHYCCD(m_CameraHandle);
-                if (rc != QHYCCD_SUCCESS)
-                {
-                    LOGF_ERROR("Init Camera failed (%d)", rc);
-                    return false;
-                }
-
-
-                //NEW CODE - Fix read mode handling, move to setupParams()
-#if 0
-                uint32_t nbuf, imagew, imageh, bpp;
-                if (isSimulation())
-                {
-                    pixelh = pixelw = 5.4;
-                    bpp             = 8;
-                }
-                else
-                {
-                    int ret = GetQHYCCDChipInfo(m_CameraHandle, &chipw, &chiph, &imagew, &imageh, &pixelw, &pixelh, &bpp);
-
-                    /* JM: We need GetQHYCCDErrorString(ret) to get the string description of the error, please implement this in the SDK */
-                    if (ret != QHYCCD_SUCCESS)
+                    //Reinitialize camera to get new chip characteristics
+                    rc = InitQHYCCD(m_CameraHandle);
+                    if (rc != QHYCCD_SUCCESS)
                     {
-                        LOGF_ERROR("Error: GetQHYCCDChipInfo() (%d)", ret);
+                        LOGF_ERROR("Init Camera failed (%d)", rc);
+                        SetQHYCCDReadMode(m_CameraHandle, currentQHYReadMode);
+                        IDSetNumber(&ReadModeNP, nullptr);
                         return false;
                     }
 
+                    currentQHYReadMode = newReadMode;
+
+                    LOGF_INFO("Current read mode: %s (%dx%d)", readModeInfo[currentQHYReadMode].label,
+                        readModeInfo[currentQHYReadMode].subW,readModeInfo[currentQHYReadMode].subH);
+
+                    //reinitialized the camera paramters...
+                    QHYCCD::setupParams();
+                    ReadModeNP.s = IPS_OK;
+                    saveConfig(true, ReadModeNP.name);
                 }
-
-                SetCCDParams(imageRMw, imageRMh, bpp, pixelw, pixelh);
-                nbuf = imageRMw * imageRMh * PrimaryCCD.getBPP() / 8;
-                PrimaryCCD.setFrameBufferSize(nbuf);
-
-                if (HasStreaming())
+                else
                 {
-                    Streamer->setPixelFormat(INDI_MONO);
-                    Streamer->setSize(imageRMw, imageRMh);
+                    ReadModeNP.s = IPS_ALERT;
+                    //TODO - currentReadMode?
+                    //ReadModeN[0].value = currentQHYReadMode;
+                    ReadModeN[0].value = newReadMode;
+                    LOGF_ERROR("Failed to update read mode: %d", rc);
                 }
-#endif
-
-                //reinitialized the camera paramters...
-                QHYCCD::setupParams();
-
-                ReadModeNP.s = IPS_OK;
-                saveConfig(true, ReadModeNP.name);
-
-            }
-            else
-            {
-                ReadModeNP.s = IPS_ALERT;
-                //TODO - currentReadMode?
-                //ReadModeN[0].value = currentReadMode;
-                ReadModeN[0].value = newReadMode;
-                LOGF_ERROR("Failed to update read mode: %d", rc);
             }
 
             IDSetNumber(&ReadModeNP, nullptr);
@@ -2411,8 +2367,21 @@ bool QHYCCD::StartStreaming()
         { "RGGB", INDI_BAYER_RGGB }
     };
 
-    // Set Stream Mode
-    SetQHYCCDStreamMode(m_CameraHandle, 1);
+    // Set Stream Mode and re-initialize camera
+    //SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+    if (currentQHYStreamMode == 0  && !isSimulation())
+    {
+        //LOG_INFO("Start streaming\n");
+        currentQHYStreamMode = 1;
+    	SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+    	ret = InitQHYCCD(m_CameraHandle);
+    	if(ret != QHYCCD_SUCCESS)
+    	{
+            currentQHYStreamMode = 0;
+      		LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+      		return false;
+    	}
+	}
 
     // Set binning mode
     if (isSimulation())
@@ -2447,8 +2416,6 @@ bool QHYCCD::StartStreaming()
 
     double uSecs = static_cast<long>(m_ExposureRequest * 950000.0);
 
-    LOGF_INFO("Starting video streaming with exposure %.f seconds (%.f FPS)", m_ExposureRequest, Streamer->getTargetFPS());
-
     SetQHYCCDParam(m_CameraHandle, CONTROL_EXPOSURE, uSecs);
 
     if (HasUSBSpeed)
@@ -2474,8 +2441,9 @@ bool QHYCCD::StartStreaming()
         Streamer->setPixelFormat(qhyFormat, PrimaryCCD.getBPP());
     }
 
+    //LOG_INFO("start live mode\n");
+    LOGF_INFO("Starting video streaming with exposure %.f seconds (%.f FPS)", m_ExposureRequest, Streamer->getTargetFPS());
     BeginQHYCCDLive(m_CameraHandle);
-
     pthread_mutex_lock(&condMutex);
     m_ThreadRequest = StateStream;
     pthread_cond_signal(&cv);
@@ -2494,13 +2462,18 @@ bool QHYCCD::StopStreaming()
         pthread_cond_wait(&cv, &condMutex);
     }
     pthread_mutex_unlock(&condMutex);
-
-    if (HasUSBSpeed)
-        SetQHYCCDParam(m_CameraHandle, CONTROL_SPEED, SpeedN[0].value);
-    if (HasUSBTraffic)
-        SetQHYCCDParam(m_CameraHandle, CONTROL_USBTRAFFIC, USBTrafficN[0].value);
-    SetQHYCCDStreamMode(m_CameraHandle, 0);
     StopQHYCCDLive(m_CameraHandle);
+    //LOG_INFO("stopped live mode\n");
+
+    //if (HasUSBSpeed)
+    //    SetQHYCCDParam(m_CameraHandle, CONTROL_SPEED, SpeedN[0].value);
+    //if (HasUSBTraffic)
+    //    SetQHYCCDParam(m_CameraHandle, CONTROL_USBTRAFFIC, USBTrafficN[0].value);
+
+    currentQHYStreamMode = 0;
+    SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
+    InitQHYCCD(m_CameraHandle);
+    //LOG_INFO("Stopped streaming\n");
 
     // Try to set 16bit mode if supported back.
     SetQHYCCDBitsMode(m_CameraHandle, 16);
@@ -2566,16 +2539,16 @@ void *QHYCCD::imagingThreadEntry()
 void QHYCCD::streamVideo()
 {
     uint32_t ret = 0, w, h, bpp, channels;
-
+    uint32_t t_start = time(NULL), frames = 0;
     while (m_ThreadRequest == StateStream)
     {
         pthread_mutex_unlock(&condMutex);
         uint32_t retries = 0;
         std::unique_lock<std::mutex> guard(ccdBufferLock);
         uint8_t *buffer = PrimaryCCD.getFrameBuffer();
-        //uint32_t size = PrimaryCCD.getFrameBufferSize();
         while (retries++ < 10)
         {
+
             ret = GetQHYCCDLiveFrame(m_CameraHandle, &w, &h, &bpp, &channels, buffer);
             if (ret == QHYCCD_ERROR)
                 usleep(1000);
@@ -2589,8 +2562,12 @@ void QHYCCD::streamVideo()
 
             if (HasGPS && GPSControlS[INDI_ENABLED].s == ISS_ON)
                 decodeGPSHeader();
-        }
 
+            if(!frames)
+                LOG_INFO("Receiving frames ...");
+            if(!(++frames%30))
+                LOGF_DEBUG("Frames received: %d (%.1f fps)", frames, 1.0*frames/(time(NULL) - t_start));
+        }
         pthread_mutex_lock(&condMutex);
     }
 }

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -1899,8 +1899,9 @@ bool QHYCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 SetCCDParams(effectiveROI.subW, effectiveROI.subH, PrimaryCCD.getBPP(), PrimaryCCD.getPixelSizeX(),
                              PrimaryCCD.getPixelSizeX());
 
-                //Image Settings
-                //The true frame origin is at (effectiveROI.subX ,effectiveROI.subY), need to correct for this offset when taking exposure or streaming.
+                // Image Settings
+                // The true frame origin is at (effectiveROI.subX ,effectiveROI.subY).
+                // This vector that needs to be used for offset-correction when taking exposures or streaming while ignoring overscan areas.
                 UpdateCCDFrame(0, 0, effectiveROI.subW, effectiveROI.subH);
 
             }
@@ -2080,23 +2081,10 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
         {
             //NEW CODE - Fix read mode handling
             IUUpdateNumber(&ReadModeNP, values, names, n);
-            uint32_t newReadMode = ReadModeN[0].value;
-
-            //Check if camera already is in the requested read mode
-            int rc = GetQHYCCDReadMode(m_CameraHandle, &currentReadMode);
-            if (rc == QHYCCD_SUCCESS)
-            {
-                if (newReadMode == currentReadMode)
-                {
-
-                    LOGF_INFO("Camera is already in read mode: %u", currentReadMode);
-                    return true;
-                }
-            }
+            uint32_t newReadMode = static_cast<uint32_t>(ReadModeN[0].value);
 
             // Set readout mode
-            rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
-            if (rc == QHYCCD_SUCCESS)
+            if (newReadMode != currentQHYReadMode)
             {
                 /* change readout mode */
                 int rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
@@ -2129,22 +2117,6 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
                     ReadModeN[0].value = currentQHYReadMode;
                     LOGF_ERROR("Failed to update read mode: %d", rc);
                 }
-#endif
-
-                //reinitialized the camera paramters...
-                QHYCCD::setupParams();
-
-                ReadModeNP.s = IPS_OK;
-                saveConfig(true, ReadModeNP.name);
-
-            }
-            else
-            {
-                ReadModeNP.s = IPS_ALERT;
-                //TODO - currentReadMode?
-                //ReadModeN[0].value = currentReadMode;
-                ReadModeN[0].value = newReadMode;
-                LOGF_ERROR("Failed to update read mode: %d", rc);
             }
             else
             {

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -862,23 +862,23 @@ bool QHYCCD::Connect()
             ret = GetQHYCCDReadModeName(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].label[0]);
             if (ret == QHYCCD_SUCCESS)
             {
-                LOGF_INFO("Mode %d: %s\n", readModeInfo[rm].id, readModeInfo[rm].label);
+                LOGF_INFO("Mode %d: %s", readModeInfo[rm].id, readModeInfo[rm].label);
             }
             else
             {
-                LOGF_INFO("Failed to obtain read mode name for modeNumber: %d\n", readModeInfo[rm].id);
+                LOGF_INFO("Failed to obtain read mode name for modeNumber: %d", readModeInfo[rm].id);
                 strcpy(readModeInfo[rm].label, "UNKNOWN");
             }
             ret = GetQHYCCDReadModeResolution(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].subW,
                                               &readModeInfo[rm].subH);
             if (ret == QHYCCD_SUCCESS)
             {
-                LOGF_INFO("Sensor resolution for mode %s: %dx%d px\n", readModeInfo[rm].label,
+                LOGF_INFO("Sensor resolution for mode %s: %dx%d px", readModeInfo[rm].label,
                           readModeInfo[rm].subW, readModeInfo[rm].subH);
             }
             else
             {
-                LOGF_WARN("Failed to read mode resolution name for modeNumber: %d\n", readModeInfo[rm].id);
+                LOGF_WARN("Failed to read mode resolution name for modeNumber: %d", readModeInfo[rm].id);
                 readModeInfo[rm].subW = readModeInfo[rm].subH = 0;
             }
         }
@@ -887,7 +887,7 @@ bool QHYCCD::Connect()
         ret = GetQHYCCDReadMode(m_CameraHandle, &currentQHYReadMode);
         if (ret == QHYCCD_SUCCESS && numReadModes > 1)
         {
-            LOGF_INFO("Current read mode: %s (%dx%d)\n", readModeInfo[currentQHYReadMode].label,
+            LOGF_INFO("Current read mode: %s (%dx%d)", readModeInfo[currentQHYReadMode].label,
                       readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
         }
 
@@ -1192,9 +1192,6 @@ bool QHYCCD::Disconnect()
 bool QHYCCD::setupParams()
 {
 
-
-    LOG_DEBUG("setup params\n");
-
     //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
     uint32_t nbuf, bpp;
     double chipw, chiph, pixelw, pixelh;
@@ -1314,18 +1311,17 @@ bool QHYCCD::StartExposure(float duration)
         //ret = InitQHYCCD(m_CameraHandle);
         //if(ret != QHYCCD_SUCCESS)
         //{
-        //    LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+        //    LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d", ret);
         //    return false;
         //}
 
         currentQHYStreamMode = 0;
         SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
 
-
         ret = InitQHYCCD(m_CameraHandle);
         if(ret != QHYCCD_SUCCESS)
         {
-            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d", ret);
             return false;
         }
 
@@ -2403,7 +2399,7 @@ bool QHYCCD::StartStreaming()
         //if(ret != QHYCCD_SUCCESS)
         //{
         //    currentQHYStreamMode = 0;
-        //    LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+        //    LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d", ret);
         //    return false;
         //}
 
@@ -2415,7 +2411,7 @@ bool QHYCCD::StartStreaming()
         if(ret != QHYCCD_SUCCESS)
         {
             currentQHYStreamMode = 0;
-            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d\n", ret);
+            LOGF_INFO("Init QHYCCD for streaming mode failed, code:%d", ret);
             return false;
         }
     }
@@ -2478,9 +2474,10 @@ bool QHYCCD::StartStreaming()
         Streamer->setPixelFormat(qhyFormat, PrimaryCCD.getBPP());
     }
 
-    //LOG_INFO("start live mode\n"); //DEBUG
+    //LOG_INFO("start live mode"); //DEBUG
 
-    LOGF_INFO("Starting video streaming with exposure %.f seconds (%.f FPS)", m_ExposureRequest, Streamer->getTargetFPS());
+    LOGF_INFO("Starting video streaming with exposure %.f seconds (%.f FPS), w=%d h=%d", m_ExposureRequest,
+              Streamer->getTargetFPS(), subW, subH);
     BeginQHYCCDLive(m_CameraHandle);
     pthread_mutex_lock(&condMutex);
     m_ThreadRequest = StateStream;
@@ -2501,21 +2498,13 @@ bool QHYCCD::StopStreaming()
     }
     pthread_mutex_unlock(&condMutex);
     StopQHYCCDLive(m_CameraHandle);
-    
-    //LOG_INFO("stopped live mode\n"); //DEBUG
+
+    //LOG_INFO("stopped live mode"); //DEBUG
 
     //if (HasUSBSpeed)
     //    SetQHYCCDParam(m_CameraHandle, CONTROL_SPEED, SpeedN[0].value);
     //if (HasUSBTraffic)
     //    SetQHYCCDParam(m_CameraHandle, CONTROL_USBTRAFFIC, USBTrafficN[0].value);
-
-    currentQHYStreamMode = 0;
-    SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
-    
-    // FIX: Helps for cleaner teardown and prevents camera from staling
-    InitQHYCCD(m_CameraHandle);
-    
-    //LOG_INFO("Stopped streaming\n");  //DEBUG
 
     currentQHYStreamMode = 0;
     SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
@@ -2614,7 +2603,7 @@ void QHYCCD::streamVideo()
 
             //DEBUG
             //if(!frames)
-            //    LOG_INFO("Receiving frames ...");
+            //    LOGF_DEBUG("Receiving frames ...");
             //if(!(++frames % 30))
             //    LOGF_DEBUG("Frames received: %d (%.1f fps)", frames, 1.0 * frames / (time(NULL) - t_start));
         }

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -851,38 +851,7 @@ bool QHYCCD::Connect()
         {
             HasReadMode = true;
             //NEW CODE - format modifier %zu --> %u
-            LOGF_INFO("Number of read modes: %u", numReadModes);
-        }
-
-        readModeInfo = new QHYReadModeInfo[numReadModes];
-
-        for (uint32_t rm = 0; rm < numReadModes; rm++)
-        {
-            readModeInfo[rm].id = rm;
-            ret = GetQHYCCDReadModeName(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].label[0]);
-            if (ret == QHYCCD_SUCCESS) {
-                LOGF_INFO("Mode %d: %s\n", readModeInfo[rm].id, readModeInfo[rm].label);
-            } else {
-                LOGF_INFO("Failed to obtain read mode name for modeNumber: %d\n", readModeInfo[rm].id);
-                strcpy(readModeInfo[rm].label, "UNKNOWN");
-            }
-            ret = GetQHYCCDReadModeResolution(m_CameraHandle, readModeInfo[rm].id, &readModeInfo[rm].subW,
-                &readModeInfo[rm].subH);
-            if (ret == QHYCCD_SUCCESS) {
-                LOGF_INFO("Sensor resolution for mode %s: %dx%d px\n", readModeInfo[rm].label,
-                    readModeInfo[rm].subW, readModeInfo[rm].subH);
-            } else {
-                LOGF_WARN("Failed to read mode resolution name for modeNumber: %d\n", readModeInfo[rm].id);
-                readModeInfo[rm].subW = readModeInfo[rm].subH = 0;
-            }
-        }
-
-        //Correctly initialize current read mode
-        ret = GetQHYCCDReadMode(m_CameraHandle, &currentQHYReadMode);
-        if (ret == QHYCCD_SUCCESS && numReadModes > 1)
-        {
-            LOGF_INFO("Current read mode: %s (%dx%d)\n", readModeInfo[currentQHYReadMode].label,
-                readModeInfo[currentQHYReadMode].subW, readModeInfo[currentQHYReadMode].subH);
+            LOGF_INFO("Number of read modes: %u", readModes);
         }
 
         ////////////////////////////////////////////////////////////////////
@@ -1186,10 +1155,7 @@ bool QHYCCD::Disconnect()
 bool QHYCCD::setupParams()
 {
 
-
-    LOG_DEBUG("setup params\n");
-
-   //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
+    //NEW CODE - Add support for overscan/calibration area, use sensorROI & effectiveROI as containers for frame width/offest
     uint32_t nbuf, bpp;
     double chipw, chiph, pixelw, pixelh;
 
@@ -1879,9 +1845,8 @@ bool QHYCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 SetCCDParams(effectiveROI.subW, effectiveROI.subH, PrimaryCCD.getBPP(), PrimaryCCD.getPixelSizeX(),
                              PrimaryCCD.getPixelSizeX());
 
-                // Image Settings
-                // The true frame origin is at (effectiveROI.subX ,effectiveROI.subY).
-                // This vector that needs to be used for offset-correction when taking exposures or streaming while ignoring overscan areas.
+                //Image Settings
+                //The true frame origin is at (effectiveROI.subX ,effectiveROI.subY), need to correct for this offset when taking exposure or streaming.
                 UpdateCCDFrame(0, 0, effectiveROI.subW, effectiveROI.subH);
 
             }
@@ -2060,15 +2025,60 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
         else if (!strcmp(name, ReadModeNP.name))
         {
             //NEW CODE - Fix read mode handling
+            uint32_t currentReadMode;
 
             IUUpdateNumber(&ReadModeNP, values, names, n);
-            uint32_t newReadMode = static_cast<uint32_t>(ReadModeN[0].value);
+            uint32_t newReadMode = ReadModeN[0].value;
+
+            //Check if camera already is in the requested read mode
+            int rc = GetQHYCCDReadMode(m_CameraHandle, &currentReadMode);
+            if (rc == QHYCCD_SUCCESS)
+            {
+                if (newReadMode == currentReadMode)
+                {
+
+                    LOGF_INFO("Camera is already in read mode: %u", currentReadMode);
+                    return true;
+                }
+            }
 
             // Set readout mode
-            if (newReadMode != currentQHYReadMode)
+            rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
+            if (rc == QHYCCD_SUCCESS)
             {
-                int rc = SetQHYCCDReadMode(m_CameraHandle, newReadMode); // [NEW CODE] declaration int rc removed
-                if (rc == QHYCCD_SUCCESS)
+
+                currentReadMode = newReadMode;
+
+                char currentReadModeName[255] = {0};
+                strcpy(currentReadModeName, "");
+                int retVal = GetQHYCCDReadModeName(m_CameraHandle, currentReadMode, currentReadModeName);
+                if (retVal == QHYCCD_SUCCESS)
+                {
+                    LOGF_INFO("Read mode is now updated to: %s", currentReadModeName);
+                }
+                else
+                {
+                    LOGF_INFO("Read mode is now updated to: %u", currentReadMode);
+                }
+
+                //Reinitialize camera to get new chip characteristics
+                rc = InitQHYCCD(m_CameraHandle);
+                if (rc != QHYCCD_SUCCESS)
+                {
+                    LOGF_ERROR("Init Camera failed (%d)", rc);
+                    return false;
+                }
+
+
+                //NEW CODE - Fix read mode handling, move to setupParams()
+#if 0
+                uint32_t nbuf, imagew, imageh, bpp;
+                if (isSimulation())
+                {
+                    pixelh = pixelw = 5.4;
+                    bpp             = 8;
+                }
+                else
                 {
 
                     //Reinitialize camera to get new chip characteristics
@@ -2099,6 +2109,22 @@ bool QHYCCD::ISNewNumber(const char *dev, const char *name, double values[], cha
                     ReadModeN[0].value = newReadMode;
                     LOGF_ERROR("Failed to update read mode: %d", rc);
                 }
+#endif
+
+                //reinitialized the camera paramters...
+                QHYCCD::setupParams();
+
+                ReadModeNP.s = IPS_OK;
+                saveConfig(true, ReadModeNP.name);
+
+            }
+            else
+            {
+                ReadModeNP.s = IPS_ALERT;
+                //TODO - currentReadMode?
+                //ReadModeN[0].value = currentReadMode;
+                ReadModeN[0].value = newReadMode;
+                LOGF_ERROR("Failed to update read mode: %d", rc);
             }
 
             IDSetNumber(&ReadModeNP, nullptr);

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -1308,7 +1308,7 @@ bool QHYCCD::StartExposure(float duration)
     // Set streaming mode and re-initialize camera
     if (currentQHYStreamMode == 1 && !isSimulation())
     {
-        
+
         /* NR - Closing the camera will reset the connection in ECOS, I recommend to omit here. */
         //CloseQHYCCD(m_CameraHandle);
         //ret = InitQHYCCD(m_CameraHandle);
@@ -1321,7 +1321,7 @@ bool QHYCCD::StartExposure(float duration)
         currentQHYStreamMode = 0;
         SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
 
-        
+
         ret = InitQHYCCD(m_CameraHandle);
         if(ret != QHYCCD_SUCCESS)
         {
@@ -1330,7 +1330,7 @@ bool QHYCCD::StartExposure(float duration)
         }
 
         // Try to set 16bit mode if supported back.
-        SetQHYCCDBitsMode(m_CameraHandle,PrimaryCCD.getBPP());
+        SetQHYCCDBitsMode(m_CameraHandle, PrimaryCCD.getBPP());
     }
 
     m_ImageFrameType = PrimaryCCD.getFrameType();
@@ -2479,7 +2479,7 @@ bool QHYCCD::StartStreaming()
     }
 
     //LOG_INFO("start live mode\n"); //DEBUG
-    
+
     LOGF_INFO("Starting video streaming with exposure %.f seconds (%.f FPS)", m_ExposureRequest, Streamer->getTargetFPS());
     BeginQHYCCDLive(m_CameraHandle);
     pthread_mutex_lock(&condMutex);
@@ -2501,15 +2501,15 @@ bool QHYCCD::StopStreaming()
     }
     pthread_mutex_unlock(&condMutex);
     StopQHYCCDLive(m_CameraHandle);
-    
+
     currentQHYStreamMode = 0;
     SetQHYCCDStreamMode(m_CameraHandle, currentQHYStreamMode);
-    
+
     // FIX: Helps for cleaner teardown and prevents camera from staling
     InitQHYCCD(m_CameraHandle);
-    
+
     // Try to set 16bit mode if supported back. Use PrimaryCCD.getBPP as this is what we use to allocate the image buffer.
-    // Instead of doing this here, set the new bitmode when we go into exposure mode out of streaming mode. 
+    // Instead of doing this here, set the new bitmode when we go into exposure mode out of streaming mode.
     //SetQHYCCDBitsMode(m_CameraHandle, PrimaryCCD.getBPP());
     return true;
 }
@@ -2597,7 +2597,7 @@ void QHYCCD::streamVideo()
             if (HasGPS && GPSControlS[INDI_ENABLED].s == ISS_ON)
                 decodeGPSHeader();
 
-            //DEBUG 
+            //DEBUG
             //if(!frames)
             //    LOG_INFO("Receiving frames ...");
             //if(!(++frames % 30))

--- a/indi-qhy/qhy_ccd.h
+++ b/indi-qhy/qhy_ccd.h
@@ -124,7 +124,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
 
 
         // Overscan area Switch
-        //NEW CODE - Add support for overscan/calibration area 
+        //NEW CODE - Add support for overscan/calibration area
         ISwitchVectorProperty OverscanAreaSP;
         ISwitch OverscanAreaS[2];
         enum
@@ -298,6 +298,14 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
             uint32_t subH = 0;
         } effectiveROI, sensorROI;  //NEW CODE - Add support for overscan/calibration area, obsolete overscanROI
 
+        typedef struct
+        {
+            char label[128] = {0};
+            uint32_t id = 0;
+            uint32_t subW = 0;
+            uint32_t subH = 0;
+        } QHYReadModeInfo; // N.R. - Add support for read mode selection
+
         typedef enum GPSState
         {
             GPS_ON,
@@ -415,7 +423,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
         bool HasReadMode { false };
         bool HasGPS { false };
         bool HasAmpGlow { false };
-        //NEW CODE - Add support for overscan/calibration area 
+        //NEW CODE - Add support for overscan/calibration area
         bool HasOverscanArea { false };
         bool IgnoreOverscanArea { true };
 
@@ -446,6 +454,15 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
         double m_LastGainRequest = 1e6;
         // Filter Wheel Timeout
         uint16_t m_FilterCheckCounter = 0;
+        // Camera's current stream operating mode (0: exposure mode, 1: stream mode)
+        uint8_t currentQHYStreamMode = 0;
+        // Number of read modes which the camera supports
+        uint32_t numReadModes = 0;
+        // currently set read mode
+        uint32_t currentQHYReadMode;
+        // dynamic array to hold read mode information
+        QHYReadModeInfo *readModeInfo = nullptr;
+
 
         /////////////////////////////////////////////////////////////////////////////
         /// Threading

--- a/indi-qhy/qhy_ccd_test.cpp
+++ b/indi-qhy/qhy_ccd_test.cpp
@@ -26,7 +26,7 @@
 
 #define VERSION 1.00
 
-int main(int , char **)
+int main(int, char **)
 {
 
     int USB_TRAFFIC = 10;
@@ -35,50 +35,56 @@ int main(int , char **)
     int EXPOSURE_TIME = 1;
     int camBinX = 1;
     int camBinY = 1;
-    
+
     double chipWidthMM;
     double chipHeightMM;
     double pixelWidthUM;
     double pixelHeightUM;
-    
+
     unsigned int roiStartX;
     unsigned int roiStartY;
     unsigned int roiSizeX;
     unsigned int roiSizeY;
-    
+
     unsigned int overscanStartX;
     unsigned int overscanStartY;
     unsigned int overscanSizeX;
     unsigned int overscanSizeY;
-    
+
     unsigned int effectiveStartX;
     unsigned int effectiveStartY;
     unsigned int effectiveSizeX;
     unsigned int effectiveSizeY;
-    
+
     unsigned int maxImageSizeX;
     unsigned int maxImageSizeY;
     unsigned int bpp;
     unsigned int channels;
-    
+
     unsigned char *pImgData = 0;
 
     printf("QHY Test CCD using SingleFrameMode, Version: %.2f\n", VERSION);
-     
+
     // init SDK
     int retVal = InitQHYCCDResource();
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("SDK resources initialized.\n");
-    } else {
+    }
+    else
+    {
         printf("Cannot initialize SDK resources, error: %d\n", retVal);
         return 1;
     }
 
     // scan cameras
     int camCount = ScanQHYCCD();
-    if (camCount > 0) {
+    if (camCount > 0)
+    {
         printf("Number of QHYCCD cameras found: %d \n", camCount);
-    } else {
+    }
+    else
+    {
         printf("No QHYCCD camera found, please check USB or power.\n");
         return 1;
     }
@@ -87,22 +93,28 @@ int main(int , char **)
     bool camFound = false;
     char camId[32];
 
-    for (int i = 0; i < camCount; i++) {
+    for (int i = 0; i < camCount; i++)
+    {
         retVal = GetQHYCCDId(i, camId);
-        if (QHYCCD_SUCCESS == retVal) {
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("Application connected to the following camera from the list: Index: %d,  cameraID = %s\n", (i + 1), camId);
             camFound = true;
             break;
         }
     }
 
-    if (!camFound) {
+    if (!camFound)
+    {
         printf("The detected camera is not QHYCCD or other error.\n");
         // release sdk resources
         retVal = ReleaseQHYCCDResource();
-        if (QHYCCD_SUCCESS == retVal) {
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("SDK resources released.\n");
-        } else {
+        }
+        else
+        {
             printf("Cannot release SDK resources, error %d.\n", retVal);
         }
         return 1;
@@ -110,9 +122,12 @@ int main(int , char **)
 
     // open camera
     qhyccd_handle *pCamHandle = OpenQHYCCD(camId);
-    if (pCamHandle != nullptr) {
+    if (pCamHandle != nullptr)
+    {
         printf("Open QHYCCD success.\n");
-    } else {
+    }
+    else
+    {
         printf("Open QHYCCD failure.\n");
         return 1;
     }
@@ -120,82 +135,105 @@ int main(int , char **)
     // set single frame mode
     int mode = 0;
     retVal = SetQHYCCDStreamMode(pCamHandle, mode);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("SetQHYCCDStreamMode set to: %d, success.\n", mode);
-    } else {
+    }
+    else
+    {
         printf("SetQHYCCDStreamMode: %d failure, error: %d\n", mode, retVal);
         return 1;
     }
 
     // initialize camera
     retVal = InitQHYCCD(pCamHandle);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("InitQHYCCD success.\n");
-    } else {
+    }
+    else
+    {
         printf("InitQHYCCD faililure, error: %d\n", retVal);
         return 1;
     }
 
     // get overscan area
     retVal = GetQHYCCDOverScanArea(pCamHandle, &overscanStartX, &overscanStartY, &overscanSizeX, &overscanSizeY);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("GetQHYCCDOverScanArea:\n");
         printf("Overscan Area startX x startY : %d x %d\n", overscanStartX, overscanStartY);
         printf("Overscan Area sizeX  x sizeY  : %d x %d\n", overscanSizeX, overscanSizeY);
-    } else {
+    }
+    else
+    {
         printf("GetQHYCCDOverScanArea failure, error: %d\n", retVal);
         return 1;
     }
 
     // get effective area
     retVal = GetQHYCCDOverScanArea(pCamHandle, &effectiveStartX, &effectiveStartY, &effectiveSizeX, &effectiveSizeY);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("GetQHYCCDEffectiveArea:\n");
         printf("Effective Area startX x startY: %d x %d\n", effectiveStartX, effectiveStartY);
         printf("Effective Area sizeX  x sizeY : %d x %d\n", effectiveSizeX, effectiveSizeY);
-    } else {
+    }
+    else
+    {
         printf("GetQHYCCDOverScanArea failure, error: %d\n", retVal);
         return 1;
     }
 
     // get chip info
-    retVal = GetQHYCCDChipInfo(pCamHandle, &chipWidthMM, &chipHeightMM, &maxImageSizeX, &maxImageSizeY, &pixelWidthUM, &pixelHeightUM, &bpp);
-    if (QHYCCD_SUCCESS == retVal) {
+    retVal = GetQHYCCDChipInfo(pCamHandle, &chipWidthMM, &chipHeightMM, &maxImageSizeX, &maxImageSizeY, &pixelWidthUM,
+                               &pixelHeightUM, &bpp);
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("GetQHYCCDChipInfo:\n");
         printf("Effective Area startX x startY: %d x %d\n", effectiveStartX, effectiveStartY);
         printf("Chip  size width x height     : %.3f x %.3f [mm]\n", chipWidthMM, chipHeightMM);
         printf("Pixel size width x height     : %.3f x %.3f [um]\n", pixelWidthUM, pixelHeightUM);
         printf("Image size width x height     : %d x %d\n", maxImageSizeX, maxImageSizeY);
-    } else {
+    }
+    else
+    {
         printf("GetQHYCCDChipInfo failure, error: %d\n", retVal);
         return 1;
     }
-    
+
     // set ROI
     roiStartX = 0;
     roiStartY = 0;
     roiSizeX = maxImageSizeX;
     roiSizeY = maxImageSizeY;
-            
+
     // check color camera
     retVal = IsQHYCCDControlAvailable(pCamHandle, CAM_COLOR);
-    if (retVal == BAYER_GB || retVal == BAYER_GR || retVal == BAYER_BG || retVal == BAYER_RG) {
+    if (retVal == BAYER_GB || retVal == BAYER_GR || retVal == BAYER_BG || retVal == BAYER_RG)
+    {
         printf("This is a color camera.\n");
         SetQHYCCDDebayerOnOff(pCamHandle, true);
         SetQHYCCDParam(pCamHandle, CONTROL_WBR, 20);
         SetQHYCCDParam(pCamHandle, CONTROL_WBG, 20);
         SetQHYCCDParam(pCamHandle, CONTROL_WBB, 20);
-    } else {
+    }
+    else
+    {
         printf("This is a mono camera.\n");
     }
 
     // check traffic
     retVal = IsQHYCCDControlAvailable(pCamHandle, CONTROL_USBTRAFFIC);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         retVal = SetQHYCCDParam(pCamHandle, CONTROL_USBTRAFFIC, USB_TRAFFIC);
-        if (QHYCCD_SUCCESS == retVal) {
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("SetQHYCCDParam CONTROL_USBTRAFFIC set to: %d, success.\n", USB_TRAFFIC);
-        } else {
+        }
+        else
+        {
             printf("SetQHYCCDParam CONTROL_USBTRAFFIC failure, error: %d\n", retVal);
             getchar();
             return 1;
@@ -204,11 +242,15 @@ int main(int , char **)
 
     // check gain
     retVal = IsQHYCCDControlAvailable(pCamHandle, CONTROL_GAIN);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         retVal = SetQHYCCDParam(pCamHandle, CONTROL_GAIN, CHIP_GAIN);
-        if (retVal == QHYCCD_SUCCESS) {
+        if (retVal == QHYCCD_SUCCESS)
+        {
             printf("SetQHYCCDParam CONTROL_GAIN set to: %d, success\n", CHIP_GAIN);
-        } else {
+        }
+        else
+        {
             printf("SetQHYCCDParam CONTROL_GAIN failure, error: %d\n", retVal);
             getchar();
             return 1;
@@ -217,62 +259,74 @@ int main(int , char **)
 
     // check offset
     retVal = IsQHYCCDControlAvailable(pCamHandle, CONTROL_OFFSET);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         retVal = SetQHYCCDParam(pCamHandle, CONTROL_OFFSET, CHIP_OFFSET);
-        if (QHYCCD_SUCCESS == retVal) {
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("SetQHYCCDParam CONTROL_GAIN set to: %d, success.\n", CHIP_OFFSET);
-        } else {
+        }
+        else
+        {
             printf("SetQHYCCDParam CONTROL_GAIN failed.\n");
             getchar();
             return 1;
         }
     }
-    
+
     // check read mode in QHY42
     uint32_t currentReadMode = 0;
-    char *modeName=(char *)malloc((200)*sizeof(char));;
+    char *modeName = (char *)malloc((200) * sizeof(char));;
     retVal = GetQHYCCDReadMode(pCamHandle, &currentReadMode);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("Default read mode: %d \n", currentReadMode);
-        retVal = GetQHYCCDReadModeName(pCamHandle , currentReadMode, modeName);
-        if (QHYCCD_SUCCESS == retVal) {
+        retVal = GetQHYCCDReadModeName(pCamHandle, currentReadMode, modeName);
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("Default read mode name %s \n", modeName);
-        } else {
+        }
+        else
+        {
             printf("Error reading mode name \n");
             getchar();
             return 1;
         }
-        
+
         // Set read modes and read resolution for each one
         uint32_t readModes = 0;
         uint32_t imageRMw, imageRMh;
-        uint32_t i=0;
+        uint32_t i = 0;
         retVal = GetQHYCCDNumberOfReadModes(pCamHandle, &readModes);
-        for(i=0;i<readModes;i++)
+        for(i = 0; i < readModes; i++)
         {
             // Set read mode and get resolution
-            retVal = SetQHYCCDReadMode(pCamHandle,i);
-            if (QHYCCD_SUCCESS == retVal) {
+            retVal = SetQHYCCDReadMode(pCamHandle, i);
+            if (QHYCCD_SUCCESS == retVal)
+            {
                 // Get resolution
-                retVal = GetQHYCCDReadModeName(pCamHandle , i, modeName);
-                    if (QHYCCD_SUCCESS == retVal) {
-                        printf("Read mode name %s \n", modeName);
-                    } else {
-                        printf("Error reading mode name \n");
-                        getchar();
-                        return 1;
-                    }
-                    retVal = GetQHYCCDReadModeResolution(pCamHandle, i, &imageRMw, &imageRMh);
+                retVal = GetQHYCCDReadModeName(pCamHandle, i, modeName);
+                if (QHYCCD_SUCCESS == retVal)
+                {
+                    printf("Read mode name %s \n", modeName);
+                }
+                else
+                {
+                    printf("Error reading mode name \n");
+                    getchar();
+                    return 1;
+                }
+                retVal = GetQHYCCDReadModeResolution(pCamHandle, i, &imageRMw, &imageRMh);
                 printf("GetQHYCCDChipInfo in this ReadMode: imageW: %d imageH: %d \n", imageRMw, imageRMh);
             }
         }
-        
+
     }
-    
+
 
     // set exposure time
     retVal = SetQHYCCDParam(pCamHandle, CONTROL_EXPOSURE, EXPOSURE_TIME);
-        printf("SetQHYCCDParam CONTROL_EXPOSURE set to: %d, success.\n", EXPOSURE_TIME);
+    printf("SetQHYCCDParam CONTROL_EXPOSURE set to: %d, success.\n", EXPOSURE_TIME);
     if (QHYCCD_SUCCESS == retVal)
     {
     }
@@ -285,30 +339,40 @@ int main(int , char **)
 
     // set image resolution
     retVal = SetQHYCCDResolution(pCamHandle, roiStartX, roiStartY, roiSizeX, roiSizeY);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("SetQHYCCDResolution roiStartX x roiStartY: %d x %d\n", roiStartX, roiStartY);
         printf("SetQHYCCDResolution roiSizeX  x roiSizeY : %d x %d\n", roiSizeX, roiSizeY);
-    } else {
+    }
+    else
+    {
         printf("SetQHYCCDResolution failure, error: %d\n", retVal);
         return 1;
     }
 
     // set binning mode
     retVal = SetQHYCCDBinMode(pCamHandle, camBinX, camBinY);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("SetQHYCCDBinMode set to: binX: %d, binY: %d, success.\n", camBinX, camBinY);
-    } else {
+    }
+    else
+    {
         printf("SetQHYCCDBinMode failure, error: %d\n", retVal);
         return 1;
     }
 
     // set bit resolution
     retVal = IsQHYCCDControlAvailable(pCamHandle, CONTROL_TRANSFERBIT);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         retVal = SetQHYCCDBitsMode(pCamHandle, 16);
-        if (QHYCCD_SUCCESS == retVal) {
+        if (QHYCCD_SUCCESS == retVal)
+        {
             printf("SetQHYCCDParam CONTROL_GAIN set to: %d, success.\n", CONTROL_TRANSFERBIT);
-        } else {
+        }
+        else
+        {
             printf("SetQHYCCDParam CONTROL_GAIN failure, error: %d\n", retVal);
             getchar();
             return 1;
@@ -326,7 +390,9 @@ int main(int , char **)
         {
             sleep(1);
         }
-    } else {
+    }
+    else
+    {
         printf("ExpQHYCCDSingleFrame failure, error: %d\n", retVal);
         return 1;
     }
@@ -334,47 +400,62 @@ int main(int , char **)
     // get requested memory lenght
     uint32_t length = GetQHYCCDMemLength(pCamHandle);
 
-    if (length > 0) {
+    if (length > 0)
+    {
         pImgData = new unsigned char[length];
         memset(pImgData, 0, length);
         printf("Allocated memory for frame: %d [uchar].\n", length);
-    } else {
+    }
+    else
+    {
         printf("Cannot allocate memory for frame.\n");
         return 1;
     }
 
     // get single frame
     retVal = GetQHYCCDSingleFrame(pCamHandle, &roiSizeX, &roiSizeY, &bpp, &channels, pImgData);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("GetQHYCCDSingleFrame: %d x %d, bpp: %d, channels: %d, success.\n", roiSizeX, roiSizeY, bpp, channels);
         //process image here
-    } else {
+    }
+    else
+    {
         printf("GetQHYCCDSingleFrame failure, error: %d\n", retVal);
     }
 
     delete [] pImgData;
-    
+
     retVal = CancelQHYCCDExposingAndReadout(pCamHandle);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("CancelQHYCCDExposingAndReadout success.\n");
-    } else {
+    }
+    else
+    {
         printf("CancelQHYCCDExposingAndReadout failure, error: %d\n", retVal);
         return 1;
     }
 
     // close camera handle
     retVal = CloseQHYCCD(pCamHandle);
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("Close QHYCCD success.\n");
-    } else {
+    }
+    else
+    {
         printf("Close QHYCCD failure, error: %d\n", retVal);
     }
 
     // release sdk resources
     retVal = ReleaseQHYCCDResource();
-    if (QHYCCD_SUCCESS == retVal) {
+    if (QHYCCD_SUCCESS == retVal)
+    {
         printf("SDK resources released.\n");
-    } else {
+    }
+    else
+    {
         printf("Cannot release SDK resources, error %d.\n", retVal);
         return 1;
     }

--- a/indi-qhy/qhy_fw.cpp
+++ b/indi-qhy/qhy_fw.cpp
@@ -1,18 +1,18 @@
 /*
  QHY FW loader
- 
+
  Copyright (C) 2015 Peter Polakovic (peter.polakovic@cloudmakers.eu)
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
@@ -38,47 +38,48 @@ static struct uninitialized_cameras
     const char *loader;
     const char *firmware;
 } uninitialized_cameras[] = { { 0x1618, 0xb618, nullptr, "IMG0H.HEX" },
-                              { 0x1618, 0x0412, nullptr, "QHY2.HEX" },
-                              { 0x1618, 0x2850, nullptr, "QHY2P.HEX" },
-                              { 0x1618, 0xb285, nullptr, "QHY2S.HEX" },
-                              { 0x1618, 0x0901, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x1618, 0x1002, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x0547, 0x1002, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x296a, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x04b4, 0x8613, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x0818, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x081a, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x296e, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x296c, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x16c0, 0x2986, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x1781, 0x0c7c, "QHY5LOADER.HEX", "QHY5.HEX" },
-                              { 0x1618, 0x0920, nullptr, "QHY5II.HEX" },
-                              { 0x1618, 0x0921, nullptr, "QHY5II.HEX" },
-                              { 0x1618, 0x0259, nullptr, "QHY6.HEX" },
-                              { 0x1618, 0x4022, nullptr, "QHY7.HEX" },
-                              { 0x1618, 0x6000, nullptr, "QHY8.HEX" },
-                              { 0x1618, 0x6002, nullptr, "QHY8PRO.HEX" },
-                              { 0x1618, 0x6004, nullptr, "QHY8L.HEX" },
-                              { 0x1618, 0x6006, nullptr, "QHY8M.HEX" },
-                              { 0x1618, 0x8300, nullptr, "QHY9S.HEX" },
-                              { 0x1618, 0x1000, nullptr, "QHY10.HEX" },
-                              { 0x1618, 0x1110, nullptr, "QHY11.HEX" },
-                              { 0x1618, 0x1200, nullptr, "QHY12.HEX" },
-                              { 0x1618, 0x1500, nullptr, "QHY15.HEX" },
-                              { 0x1618, 0x1600, nullptr, "QHY16.HEX" },
-                              { 0x1618, 0x8050, nullptr, "QHY20.HEX" },
-                              { 0x1618, 0x6740, nullptr, "QHY21.HEX" },
-                              { 0x1618, 0x6940, nullptr, "QHY22.HEX" },
-                              { 0x1618, 0x8140, nullptr, "QHY23.HEX" },
-                              { 0x1618, 0x1650, nullptr, "QHY27.HEX" },
-                              { 0x1618, 0x1670, nullptr, "QHY28.HEX" },
-                              { 0x1618, 0x2950, nullptr, "QHY29.HEX" },
-                              { 0x1618, 0x8310, nullptr, "IC8300.HEX" },
-                              { 0x1618, 0x1620, nullptr, "IC16200A.HEX" },
-                              { 0x1618, 0x1630, nullptr, "IC16803.HEX" },
-                              { 0x1618, 0x8320, nullptr, "IC90A.HEX" },
-                              { 0x1618, 0x0930, nullptr, "miniCam5.HEX" },
-                              { 0, 0, nullptr, nullptr } };
+    { 0x1618, 0x0412, nullptr, "QHY2.HEX" },
+    { 0x1618, 0x2850, nullptr, "QHY2P.HEX" },
+    { 0x1618, 0xb285, nullptr, "QHY2S.HEX" },
+    { 0x1618, 0x0901, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x1618, 0x1002, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x0547, 0x1002, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x296a, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x04b4, 0x8613, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x0818, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x081a, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x296e, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x296c, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x16c0, 0x2986, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x1781, 0x0c7c, "QHY5LOADER.HEX", "QHY5.HEX" },
+    { 0x1618, 0x0920, nullptr, "QHY5II.HEX" },
+    { 0x1618, 0x0921, nullptr, "QHY5II.HEX" },
+    { 0x1618, 0x0259, nullptr, "QHY6.HEX" },
+    { 0x1618, 0x4022, nullptr, "QHY7.HEX" },
+    { 0x1618, 0x6000, nullptr, "QHY8.HEX" },
+    { 0x1618, 0x6002, nullptr, "QHY8PRO.HEX" },
+    { 0x1618, 0x6004, nullptr, "QHY8L.HEX" },
+    { 0x1618, 0x6006, nullptr, "QHY8M.HEX" },
+    { 0x1618, 0x8300, nullptr, "QHY9S.HEX" },
+    { 0x1618, 0x1000, nullptr, "QHY10.HEX" },
+    { 0x1618, 0x1110, nullptr, "QHY11.HEX" },
+    { 0x1618, 0x1200, nullptr, "QHY12.HEX" },
+    { 0x1618, 0x1500, nullptr, "QHY15.HEX" },
+    { 0x1618, 0x1600, nullptr, "QHY16.HEX" },
+    { 0x1618, 0x8050, nullptr, "QHY20.HEX" },
+    { 0x1618, 0x6740, nullptr, "QHY21.HEX" },
+    { 0x1618, 0x6940, nullptr, "QHY22.HEX" },
+    { 0x1618, 0x8140, nullptr, "QHY23.HEX" },
+    { 0x1618, 0x1650, nullptr, "QHY27.HEX" },
+    { 0x1618, 0x1670, nullptr, "QHY28.HEX" },
+    { 0x1618, 0x2950, nullptr, "QHY29.HEX" },
+    { 0x1618, 0x8310, nullptr, "IC8300.HEX" },
+    { 0x1618, 0x1620, nullptr, "IC16200A.HEX" },
+    { 0x1618, 0x1630, nullptr, "IC16803.HEX" },
+    { 0x1618, 0x8320, nullptr, "IC90A.HEX" },
+    { 0x1618, 0x0930, nullptr, "miniCam5.HEX" },
+    { 0, 0, nullptr, nullptr }
+};
 
 static int poke(libusb_device_handle *handle, unsigned short addr, unsigned char *data, unsigned length)
 {
@@ -87,7 +88,7 @@ static int poke(libusb_device_handle *handle, unsigned short addr, unsigned char
     while ((rc = libusb_control_transfer(handle,
                                          LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
                                          0xA0, addr, 0, data, length, 3000)) < 0 &&
-           retry < 5)
+            retry < 5)
     {
         if (errno != ETIMEDOUT)
             break;
@@ -267,8 +268,8 @@ void UploadFW()
         for (int j = 0; uninitialized_cameras[j].vid; j++)
         {
             if (!libusb_get_device_descriptor(device, &descriptor) &&
-                descriptor.idVendor == uninitialized_cameras[j].vid &&
-                descriptor.idProduct == uninitialized_cameras[j].pid)
+                    descriptor.idVendor == uninitialized_cameras[j].vid &&
+                    descriptor.idProduct == uninitialized_cameras[j].pid)
             {
                 initialize(device, j);
             }

--- a/indi-qhy/qhy_fw.h
+++ b/indi-qhy/qhy_fw.h
@@ -1,18 +1,18 @@
 /*
  QHY FW loader
- 
+
  Copyright (C) 2015 Peter Polakovic (peter.polakovic@cloudmakers.eu)
- 
+
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation; either
  version 2.1 of the License, or (at your option) any later version.
- 
+
  This library is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.
- 
+
  You should have received a copy of the GNU Lesser General Public
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

--- a/indi-qhy/qhy_video_test.cpp
+++ b/indi-qhy/qhy_video_test.cpp
@@ -174,18 +174,6 @@ int main(int, char **)
         return 1;
     }
 
-    // initialize camera
-    rc = InitQHYCCD(pCamHandle);
-    if (QHYCCD_SUCCESS == rc)
-    {
-        fprintf(stderr, "InitQHYCCD success.\n");
-    }
-    else
-    {
-        fprintf(stderr, "InitQHYCCD faililure, error: %d\n", rc);
-        return 1;
-    }
-
     // get overscan area
     rc = GetQHYCCDOverScanArea(pCamHandle, &overscanStartX, &overscanStartY, &overscanSizeX, &overscanSizeY);
     if (QHYCCD_SUCCESS == rc)
@@ -274,6 +262,15 @@ int main(int, char **)
     if (rc != QHYCCD_SUCCESS)
     {
         fprintf(stderr, "SetQHYCCDStreamMode failed: %d", rc);
+    }
+
+    // initialize camera after setting stream mode
+    rc = InitQHYCCD(pCamHandle);
+    if (QHYCCD_SUCCESS == rc) {
+        printf("InitQHYCCD success.\n");
+    } else {
+        printf("InitQHYCCD faililure, error: %d\n", rc);
+        return 1;
     }
 
     // check traffic

--- a/indi-qhy/qhy_video_test.cpp
+++ b/indi-qhy/qhy_video_test.cpp
@@ -203,7 +203,8 @@ int main(int, char **)
     }
 
     // get chip info
-    rc = GetQHYCCDChipInfo(pCamHandle, &chipWidthMM, &chipHeightMM, &maxImageSizeX, &maxImageSizeY, &pixelWidthUM, &pixelHeightUM, &bpp);
+    rc = GetQHYCCDChipInfo(pCamHandle, &chipWidthMM, &chipHeightMM, &maxImageSizeX, &maxImageSizeY, &pixelWidthUM,
+                           &pixelHeightUM, &bpp);
     if (QHYCCD_SUCCESS == rc)
     {
         fprintf(stderr, "GetQHYCCDChipInfo:\n");
@@ -266,9 +267,12 @@ int main(int, char **)
 
     // initialize camera after setting stream mode
     rc = InitQHYCCD(pCamHandle);
-    if (QHYCCD_SUCCESS == rc) {
+    if (QHYCCD_SUCCESS == rc)
+    {
         printf("InitQHYCCD success.\n");
-    } else {
+    }
+    else
+    {
         printf("InitQHYCCD faililure, error: %d\n", rc);
         return 1;
     }


### PR DESCRIPTION
This PR includes enhancements for QHYCCD read mode ans streaming mode support.

qyh_ccd.cpp
* Query the camera for available read modes only once during initial QHYCCD::connect() and maintain read mode information in new struct QHYReadModeInfo.
* Maintain the current read mode state in memory and call InitQHYCCD() only after the requested read mode changes from the currently set read mode. Before the camera was re-initialized also after the user set re-applied the read mode setting the camera currently is in.
*  Maintain the current streaming mode state in memory and Call InitQHYCCD() whenever camera goes into a new streaming mode change.
* Style fixes as per INDI AStyle configuration

qhy_ccd.h
* Add new variables to support the internal tracking of read mode and streaming mode states
* Add new struct and variable to hold read mode information for the various read modes of the camera
* Style fixes as per INDI AStyle configuration

qhy_ccd_test.cpp
* Add code to print out read mode information for all of the camera's supported read modes

Remaining files
* Style fixes as per INDI AStyle configuration


The change was tested with
* QHY5III-290M
* QHY290M-Pro
