### PR TITLE
URGENT: Fix Alt < 0 wraparound in tracking (Dangerous!)

### DIFF
--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1409,11 +1409,11 @@ long CelestronAUX::GetALT()
     // return alt encoder adjusted to -90...90
     if (m_AltSteps > STEPS_PER_REVOLUTION / 2)
     {
-        return m_AltSteps - STEPS_PER_REVOLUTION;
+        return (long)m_AltSteps - STEPS_PER_REVOLUTION;
     }
     else
     {
-        return m_AltSteps;
+        return (long)m_AltSteps;
     }
 };
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1409,11 +1409,11 @@ long CelestronAUX::GetALT()
     // return alt encoder adjusted to -90...90
     if (m_AltSteps > STEPS_PER_REVOLUTION / 2)
     {
-        return (long)m_AltSteps - STEPS_PER_REVOLUTION;
+        return static_cast<int32_t>(m_AltSteps) - STEPS_PER_REVOLUTION;
     }
     else
     {
-        return (long)m_AltSteps;
+        return static_cast<int32_t>(m_AltSteps);
     }
 };
 


### PR DESCRIPTION
Wen the object goes to alt encoder < 0 the tracking wraps around in GetAlt function and results in fast swing in Alt to the other side of the sphere. 