### PR TITLE
indi-asi-power Add DSLR control

### DIFF
--- a/debian/indi-asi-power/changelog
+++ b/debian/indi-asi-power/changelog
@@ -1,9 +1,14 @@
+indi-asi-power (0.91) buster; urgency=medium
+
+  * Add DSLR port control
+
+ -- Ken Self <ken.kgself@gmail.com>  Tue, 09 Mar 2021 12:20:00 +1100
+
 indi-asi-power (0.9) buster; urgency=medium
 
   * Initialize device type to None
   * Fix hardware revision and pigpio version reporting
   * make pigpiod a simple non-forking service
-
 
  -- Ken Self <ken.kgself@gmail.com>  Sat, 06 Mar 2021 17:50:00 +1100
 

--- a/indi-asi-power/CMakeLists.txt
+++ b/indi-asi-power/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set (VERSION_MAJOR 0)
-set (VERSION_MINOR 9)
+set (VERSION_MINOR 91)
 
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)

--- a/indi-asi-power/Changelog
+++ b/indi-asi-power/Changelog
@@ -1,3 +1,6 @@
+v0.91
+* Add DSLR port control
+
 v0.9
 * Initialize device type to None
 * Fix hardware revision and pigpio version reporting

--- a/indi-asi-power/asipower.cpp
+++ b/indi-asi-power/asipower.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <memory>
 #include <string.h>
+#include <math.h>
 #include <config.h>
 #include <pigpiod_if2.h>
 #include <asipower.h>
@@ -76,10 +77,20 @@ void ISSnoopDevice (XMLEle *root)
     ISInit();
     device->ISSnoopDevice(root);
 }
+
+static void DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
+{
+    device->DslrTimer(pi, user_gpio, level, tick);
+}
+
 IndiAsiPower::IndiAsiPower()
 {
     setVersion(VERSION_MAJOR,VERSION_MINOR);
     std::fill_n(m_type, n_dev_type, 0);
+    dslr_cb = 0;
+    dslr_end = dslr_last = 0;
+    dslr_isexp = false;
+    dslr_counter = 0;
 }
 IndiAsiPower::~IndiAsiPower()
 {
@@ -89,11 +100,14 @@ IndiAsiPower::~IndiAsiPower()
         deleteProperty(OnOffSP[i].name);
         deleteProperty(DutyCycleNP[i].name);
     }
+    deleteProperty(DslrSP.name);
+    deleteProperty(DslrExpNP.name);
+    callback_cancel(dslr_cb);
 }
 bool IndiAsiPower::Connect()
 {
     // Init GPIO
-    DEBUGF(INDI::Logger::DBG_SESSION, "pigpiod_if2 version %lu.", pigpiod_if_version());
+    DEBUGF(INDI::Logger::DBG_DEBUG, "pigpiod_if2 version %lu.", pigpiod_if_version());
     m_piId = pigpio_start(NULL,NULL);
 
     if (m_piId < 0)
@@ -102,17 +116,20 @@ bool IndiAsiPower::Connect()
         return false;
     }
     DEBUGF(INDI::Logger::DBG_SESSION, "pigpio version %lu.", get_pigpio_version(m_piId));
-    DEBUGF(INDI::Logger::DBG_SESSION, "Hardware revision %x.", get_hardware_revision(m_piId));
+    DEBUGF(INDI::Logger::DBG_DEBUG, "Hardware revision %x.", get_hardware_revision(m_piId));
     for(int i=0; i<n_gpio_pin; i++)
     {
         set_pull_up_down(m_piId, gpio_pin[i], PI_PUD_DOWN);
     }
+    dslr_cb = callback(m_piId, dslr_pin, EITHER_EDGE, ::DslrTimer);
+    DEBUGF(INDI::Logger::DBG_DEBUG, "Callback id %d pin %d", dslr_cb, dslr_pin);
     DEBUG(INDI::Logger::DBG_SESSION, "ASI Power connected successfully.");
     return true;
 }
 bool IndiAsiPower::Disconnect()
 {
     // Close GPIO
+    callback_cancel(dslr_cb);
     pigpio_stop(m_piId);
     DEBUG(INDI::Logger::DBG_SESSION, "ASI Power disconnected successfully.");
     return true;
@@ -144,10 +161,18 @@ bool IndiAsiPower::initProperties()
         IUFillSwitch(&OnOffS[i][0], (onoff + std::to_string(i) +"OFF").c_str(), "Off", ISS_ON);
         IUFillSwitch(&OnOffS[i][1], (onoff + std::to_string(i) +"ON").c_str(), "On", ISS_OFF);
         IUFillSwitchVector(&OnOffSP[i], OnOffS[i], 2, getDeviceName(), (onoff + std::to_string(i)).c_str(), "On/Off", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    
+
         IUFillNumber(&DutyCycleN[i][0], (dutyc + std::to_string(i)).c_str(), "Duty Cycle %", "%0.0f", 0, max_pwm_duty, 1, 0);
         IUFillNumberVector(&DutyCycleNP[i], DutyCycleN[i], 1, getDeviceName(), (dutyc + std::to_string(i)).c_str(), "Duty Cycle", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
     }
+    IUFillSwitch(&DslrS[0], "DSLR_START", "Start", ISS_OFF);
+    IUFillSwitch(&DslrS[1], "DSLR_STOP", "Stop", ISS_ON);
+    IUFillSwitchVector(&DslrSP, DslrS, 2, getDeviceName(), "DSLR_CTRL", "DSLR ", "DSLR", IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+
+    IUFillNumber(&DslrExpN[0], "DSLR_DUR", "Duration (s)", "%1.1f", 0, 3600, 1, 1);
+    IUFillNumber(&DslrExpN[1], "DSLR_COUNT", "Count", "%0.0f", 1, 500, 1, 1);
+    IUFillNumber(&DslrExpN[2], "DSLR_DELAY", "Delay (s)", "%1.1f", 0, 60, 1, 0);
+    IUFillNumberVector(&DslrExpNP, DslrExpN, 3, getDeviceName(), "DSLR_EXP", "Exposure", "DSLR", IP_RW, 0, IPS_IDLE);
     loadConfig();
 
     return true;
@@ -166,6 +191,8 @@ bool IndiAsiPower::updateProperties()
             defineProperty(&OnOffSP[i]);
             defineProperty(&DutyCycleNP[i]);
         }
+        defineProperty(&DslrSP);
+        defineProperty(&DslrExpNP);
     }
     else
     {
@@ -176,6 +203,8 @@ bool IndiAsiPower::updateProperties()
             deleteProperty(OnOffSP[i].name);
             deleteProperty(DutyCycleNP[i].name);
         }
+        deleteProperty(DslrSP.name);
+        deleteProperty(DslrExpNP.name);
     }
     return true;
 }
@@ -232,6 +261,36 @@ bool IndiAsiPower::ISNewNumber (const char *dev, const char *name, double values
                 }
                 return true;
             }
+        }
+        // handle Exposure settings: Duration, Count, Delay
+        if (!strcmp(name, DslrExpNP.name))
+        {
+            if( DslrS[0].s == ISS_ON )
+            {
+                DslrExpNP.s = IPS_ALERT;
+                IDSetNumber(&DslrExpNP, nullptr);
+                DEBUG(INDI::Logger::DBG_ERROR, "DSLR Cannot change settings during an exposure");
+                return false;
+            }
+            double intpart;
+            IUUpdateNumber(&DslrExpNP,values,names,n);
+            DslrExpNP.s = IPS_OK;
+            if(DslrExpN[0].value > 5 && modf(DslrExpN[0].value, &intpart) > 0)
+            {
+                DEBUGF(INDI::Logger::DBG_WARNING, "DSLR Duration %0.2f > 5.0 s rounded to nearest integer", DslrExpN[0].value);
+                DslrExpN[0].value = round(DslrExpN[0].value);
+            }
+            if(DslrExpN[1].value < 1)
+            {
+                DEBUGF(INDI::Logger::DBG_WARNING, "DSLR Count %0.0f is less than 1", DslrExpN[1].value);
+            }
+            if(DslrExpN[2].value > 5 && modf(DslrExpN[2].value, &intpart) > 0)
+            {
+                DEBUGF(INDI::Logger::DBG_WARNING, "DSLR Delay %0.2f > 5.0 rounded to nearest integer", DslrExpN[2].value);
+                DslrExpN[2].value = round(DslrExpN[2].value);
+            }
+            IDSetNumber(&DslrExpNP, nullptr);
+            DEBUGF(INDI::Logger::DBG_SESSION, "DSLR Duration %0.2f s Count %0.0f Delay %0.2f s", DslrExpN[0].value, DslrExpN[1].value, DslrExpN[2].value);
         }
     }
     return INDI::DefaultDevice::ISNewNumber(dev,name,values,names,n);
@@ -310,12 +369,12 @@ bool IndiAsiPower::ISNewSwitch (const char *dev, const char *name, ISState *stat
                 {
                     if(!dev_pwm[m_type[i]])
                     {
-                    DEBUGF(INDI::Logger::DBG_SESSION, "%s %s set to ON", DeviceSP[i].label, dev_type[m_type[i]].c_str() );
+                        DEBUGF(INDI::Logger::DBG_SESSION, "%s %s set to ON", DeviceSP[i].label, dev_type[m_type[i]].c_str() );
                         gpio_write(m_piId, gpio_pin[i], PI_HIGH);
                     }
                     else
                     {
-                    DEBUGF(INDI::Logger::DBG_SESSION, "%s %s PWM ON %0.0f\%", DeviceSP[i].label, dev_type[m_type[i]].c_str(), DutyCycleN[i][0].value);
+                        DEBUGF(INDI::Logger::DBG_SESSION, "%s %s PWM ON %0.0f\%", DeviceSP[i].label, dev_type[m_type[i]].c_str(), DutyCycleN[i][0].value);
                         set_PWM_dutycycle(m_piId, gpio_pin[i], DutyCycleN[i][0].value);
                     }
                     OnOffSP[i].s = IPS_OK;
@@ -323,6 +382,33 @@ bool IndiAsiPower::ISNewSwitch (const char *dev, const char *name, ISState *stat
                     return true;
                 }
             }
+        }
+        // Start and stop exposures
+        if (!strcmp(name, DslrSP.name))
+        {
+            IUUpdateSwitch(&DslrSP, states, names, n);
+            if( DslrS[0].s == ISS_ON )
+            {
+                DslrSP.s = IPS_OK;
+                IDSetSwitch(&DslrSP, nullptr);
+                DEBUGF(INDI::Logger::DBG_SESSION, "DSLR Start Exposure: Duration %0.2f s Count %0.0f Delay %0.2f s", DslrExpN[0].value, DslrExpN[1].value, DslrExpN[2].value);
+                DslrChange(true);
+                DslrExpNP.s = IPS_BUSY;
+                IDSetNumber(&DslrExpNP, nullptr);
+                return false;
+            }
+            if( DslrS[1].s == ISS_ON )
+            {
+                DslrSP.s = IPS_IDLE;
+                IDSetSwitch(&DslrSP, nullptr);
+                DslrChange(false, true);
+                DEBUG(INDI::Logger::DBG_SESSION, "DSLR Stop exposure");
+                DslrExpNP.s = IPS_IDLE;
+                IDSetNumber(&DslrExpNP, nullptr);
+                return false;
+            }
+            DslrSP.s = IPS_OK;
+            IDSetSwitch(&DslrSP, nullptr);
         }
     }
     return INDI::DefaultDevice::ISNewSwitch (dev, name, states, names, n);
@@ -347,5 +433,106 @@ bool IndiAsiPower::saveConfigItems(FILE *fp)
         IUSaveConfigSwitch(fp, &OnOffSP[i]);
         IUSaveConfigNumber(fp, &DutyCycleNP[i]);
     }
+    IUSaveConfigNumber(fp, &DslrExpNP);
     return true;
+}
+
+void IndiAsiPower::DslrChange(bool isInit, bool abort)
+{
+    gpio_write(m_piId, dslr_pin, PI_LOW);
+    set_watchdog(m_piId, dslr_pin, 0);
+    if (isInit)
+    {
+        dslr_counter = DslrExpN[1].value + 1;
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR SEQ INIT: Counter %d", dslr_counter);
+        dslr_isexp = true;
+    }
+    else
+    {
+        DEBUGF(INDI::Logger::DBG_SESSION, "DSLR END: %s timer: Counter %d", dslr_isexp ? "Expose":"Delay", dslr_counter);
+    }
+    if (dslr_isexp)
+    {
+        dslr_counter--;
+    }
+    if(abort)
+    {
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR SEQ ABORT: %s Counter %d", dslr_isexp ? "Expose":"Delay", dslr_counter);
+        dslr_counter = 0;
+    }
+    dslr_isexp =  ! dslr_isexp;
+
+    if (dslr_counter <= 0)
+    {
+        DEBUGF(INDI::Logger::DBG_SESSION, "DSLR SEQ END: %s Counter %d", dslr_isexp ? "Expose":"Delay", dslr_counter);
+        DslrS[0].s = ISS_OFF;
+        DslrS[1].s = ISS_ON;
+        DslrSP.s = IPS_IDLE;
+        IDSetSwitch(&DslrSP, nullptr);
+        DslrExpNP.s = IPS_IDLE;
+        IDSetNumber(&DslrExpNP, nullptr);
+        return;
+    }
+    uint32_t l_duration = (dslr_isexp ? DslrExpN[0].value : DslrExpN[2].value)*1000;
+
+    dslr_last = get_current_tick(m_piId);
+    dslr_end = static_cast<uint64_t>(dslr_last) + static_cast<uint64_t>(l_duration*1000);
+
+    if (l_duration > 0) // non-zero duration
+    {
+        if(l_duration > max_timer_ms) l_duration = max_timer_ms;
+        gpio_write(m_piId, dslr_pin, dslr_isexp ? PI_HIGH: PI_LOW);
+        set_watchdog(m_piId, dslr_pin, l_duration);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR START %s timer: Last tick %lu ms End tick %lu ms", dslr_isexp ? "Expose":"Delay", dslr_last/1000, dslr_end/1000);
+        DEBUGF(INDI::Logger::DBG_SESSION, "DSLR START %s timer: Duration %d ms", dslr_isexp ? "Expose":"Delay", l_duration);
+    }
+    else
+    {
+        if (dslr_isexp)
+        {
+            DEBUG(INDI::Logger::DBG_ERROR, "DSLR Zero length exposure requested");
+        }
+        else
+        {
+            DEBUGF(INDI::Logger::DBG_SESSION, "DSLR START %s timer: zero length duration %d ms", dslr_isexp ? "Expose":"Delay", l_duration);
+            DslrChange();  // Handle a zero length delay
+        }
+    }
+    return;
+}
+
+void IndiAsiPower::DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
+{
+    if(pi != m_piId || user_gpio != dslr_pin || level != PI_TIMEOUT)
+    {
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Other Callback received for Id %d GPIO %d level %d", pi, user_gpio, level);
+        return;
+    }
+    int32_t tick_ms = tick/1000;
+    int32_t last_ms = dslr_last/1000;
+    int64_t end_ms = dslr_end/1000;
+
+// If tick < dslr_last then the timer has wrapped around. So subtract max_tick from dslr_end.
+    if(tick < dslr_last)
+    {
+            dslr_end -= max_tick;
+            end_ms = dslr_end/1000;
+            DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Timer wrapped around. This tick %d ms Last tick %d ms => New End tick %d ms", tick_ms, last_ms, end_ms);
+    }
+
+    int32_t left_ms = end_ms - tick_ms;
+    if(left_ms <= 1) // Within 1ms
+    {
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Timer ended with overshoot %d ms", -left_ms);
+        DslrChange();  // Handle end of timer
+        return;
+    }
+    if(left_ms < max_timer_ms) // Reset to the time remaining
+    {
+        set_watchdog(m_piId, dslr_pin, left_ms);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Reset timer to %d ms", left_ms);
+    }
+
+    DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: This tick %d ms Last tick %d ms End tick %d ms Left %d ms", tick_ms, last_ms, end_ms, left_ms);
+    dslr_last = tick;
 }

--- a/indi-asi-power/asipower.h
+++ b/indi-asi-power/asipower.h
@@ -31,6 +31,10 @@
     static const int n_dev_type = 9;
     static const std::string dev_type[n_dev_type] = {"None","Camera","Focuser","Dew Heater","Flat Panel","Mount","Fan","Other on/off","Other variable"};
     static const bool dev_pwm[n_dev_type] = { false, false, false, true, true, false, true, false, true };
+    static const int dslr_pin = 21;
+    static const uint32_t max_tick = 4294967295;
+    static const int32_t max_timer_ms = 50000;
+    
     
 class IndiAsiPower : public INDI::DefaultDevice
 {
@@ -46,6 +50,8 @@ public:
     virtual bool ISNewText (const char *dev, const char *name, char *texts[], char *names[], int n);
     virtual bool ISNewBLOB (const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n);
     virtual bool ISSnoopDevice(XMLEle *root);
+    void DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick);
+
 protected:
     virtual bool saveConfigItems(FILE *fp);
 private:
@@ -61,6 +67,20 @@ private:
 
     int m_type[n_gpio_pin];
     int m_piId;
+
+// DSLR properties: DurationN, DelayN, CountN, StartS, AbortS
+    ISwitch DslrS[2];
+    ISwitchVectorProperty DslrSP;
+    INumber DslrExpN[3];
+    INumberVectorProperty DslrExpNP;
+    
+    int dslr_cb;
+    uint64_t dslr_end;
+    uint32_t dslr_last;
+    bool dslr_isexp;
+    int dslr_counter;
+    void DslrChange(bool isInit=false, bool abort=false);
+
 };
 
 #endif


### PR DESCRIPTION
Control the DSLR shutter port on GPIO 21. Allows setting exposure, count and delay. Accurate timing to within about 1ms or so.
Arbitrary limit on exposures to 3600s.