### PR TITLE
Fixed buffer overflow crashes after TCS firmware update

### DIFF
--- a/indi-aok/lx200aok.cpp
+++ b/indi-aok/lx200aok.cpp
@@ -1021,7 +1021,7 @@ bool LX200Skywalker::setSystemSlewSpeed (int xx)
  */
 bool LX200Skywalker::getFirmwareInfo(char* vstring)
 {
-    char lstat[20] = {0};
+    char lstat[40] = {0};
     if(!getJSONData_gp(1, lstat))
         return false;
     else


### PR DESCRIPTION
Ideally, adding a length parameter to getJSONData_gp() to reflect the actual size of the jstr parameter would make the code more robust. I may just do that later.