### PR TITLE
Add missing include

### DIFF
--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -26,6 +26,7 @@
 
 #include <libnova/julian_day.h>
 #include <algorithm>
+#include <map>
 #include <math.h>
 
 #define TEMP_THRESHOLD       0.05   /* Differential temperature threshold (C)*/


### PR DESCRIPTION
Hi!

The `#include <map>` was removed from streammanager.h in PR https://github.com/indilib/indi/pull/1383.
This causes a compilation error of qhy_ccd.cpp.
I have added a header file to a source file that uses std::map.