### PR TITLE
usbfs_memory_mb: revert to setting 256MB as system defaults are too small

### DIFF
--- a/libasi/99-asi.rules
+++ b/libasi/99-asi.rules
@@ -1,2 +1,3 @@
+ACTION=="add", ATTR{idVendor}=="03c3", RUN+="/bin/sh -c '/bin/echo 256 >/sys/module/usbcore/parameters/usbfs_memory_mb'"
 # All ASI Cameras and filter wheels
-SUBSYSTEMS=="usb", ATTR{idVendor}=="03c3", MODE="0666" 
+SUBSYSTEMS=="usb", ATTR{idVendor}=="03c3", MODE="0666"


### PR DESCRIPTION
@knro This is the fix/revert for the conversation around the ASI camera not able to capture in the forum.