### PR TITLE
indi-rpi-gpio v0.3 Add Active Low option

### DIFF
--- a/debian/indi-rpi-gpio/changelog
+++ b/debian/indi-rpi-gpio/changelog
@@ -1,3 +1,11 @@
+indi-rpi-gpio (0.3) buster; urgency=medium
+
+  * Add Active Low option
+  * Fix disconnect stopping functionality
+  * Move duty cycle to main tab as an operational control
+
+ -- Ken Self <ken.kgself@gmail.com>  Wed, 24 Mar 2021 11:00:00 +1100
+
 indi-rpi-gpio (0.2) buster; urgency=medium
 
   * Split from pigpiod service/library

--- a/indi-rpi-gpio/CMakeLists.txt
+++ b/indi-rpi-gpio/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set (VERSION_MAJOR 0)
-set (VERSION_MINOR 2)
+set (VERSION_MINOR 3)
 
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)

--- a/indi-rpi-gpio/Changelog
+++ b/indi-rpi-gpio/Changelog
@@ -1,2 +1,10 @@
 v0.1
 * Initial version of Raspberry Pi GPIO driver
+
+v0.2
+* Split from pigpiod service/library
+
+v0.3
+* Add Active Low option
+* Fix disconnect stopping functionality
+* Move duty cycle to main tab as an operational control

--- a/indi-rpi-gpio/README.md
+++ b/indi-rpi-gpio/README.md
@@ -6,6 +6,7 @@ Features:
   - Select device type to determine whether it is On/Off or PWM controlled
   - PWM control in increments of 1%
   - Support for a sequence of timed pulses any pin to control e.g. DSLR shutter and focus/half-shutter
+  - Support for Active Low operation
 
 # Source
 * https://github.com/indilib/indi-3rdparty.git

--- a/indi-rpi-gpio/rpigpio.h
+++ b/indi-rpi-gpio/rpigpio.h
@@ -81,6 +81,8 @@ private:
     ISwitchVectorProperty DeviceSP[n_gpio_pin];
     ISwitch OnOffS[n_gpio_pin][2];
     ISwitchVectorProperty OnOffSP[n_gpio_pin];
+    ISwitch ActiveS[n_gpio_pin][2];
+    ISwitchVectorProperty ActiveSP[n_gpio_pin];
     INumber DutyCycleN[n_gpio_pin][1];
     INumberVectorProperty DutyCycleNP[n_gpio_pin];
 


### PR DESCRIPTION
Allos GPIO to be specified as Active Low so switching on changes pin value to 0 rather than 1. 
Someties GPIO use active low e.g. when operating relays
Applies to on/off, PWM and timed pins