### PR TITLE
Fix for "Can not change rate while motor is running (direction differs)" error when guiding

### DIFF
--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -1010,6 +1010,7 @@ void Skywatcher::SetRARate(double rate)
         newstatus.speedmode = HIGHSPEED;
     else
         newstatus.speedmode = LOWSPEED;
+    ReadMotorStatus(Axis1);
     if (RARunning)
     {
         if (newstatus.speedmode != RAStatus.speedmode)
@@ -1053,6 +1054,7 @@ void Skywatcher::SetDERate(double rate)
         newstatus.speedmode = HIGHSPEED;
     else
         newstatus.speedmode = LOWSPEED;
+    ReadMotorStatus(Axis2);
     if (DERunning)
     {
         if (newstatus.speedmode != DEStatus.speedmode)


### PR DESCRIPTION
Resolves #358 

(I've made this PR using my @beaglebot github account, rather than the @bengal123 account I used in the issue earlier)

A number of EQMOD users reported that the PHD2 star cross test was failing, and the PHD Guiding Assistant would incorrectly report large DE backlash values (mine was 22000ms). The following message was present in the EQMOD log when these errors occured:
```
 "[WARNING] Warning: Invalid parameter -> Can not change rate while motor is running (direction differs). "
```

The error was triggered when a guide north command was quickly followed by a guide south command (within 1 second). This is unlikely to happen in a normal guiding situation, but does happen during the cross test and backlash estimation.

There's a test harness which duplicates the bug [here](https://gist.github.com/bengal123/4bbe4dcb0f5bd6ba474f7a4590f72655).

The cause of the error appears to be that the motor status is not updated after the call to StopMotor() between the two guiding commands, so DERunning still indicates the mount is still running in the second call to SetDERate().

NOTE: I've confirmed that this fix corrects the error in the test harness, however I haven't had a chance to do a star cross test yet, so can't be 100% sure the underlying issue is fixed. Feel free to hold off on merging this until then.