### PR TITLE
Replace pigpio timer with INDI timer

### DIFF
--- a/debian/indi-asi-power/changelog
+++ b/debian/indi-asi-power/changelog
@@ -1,3 +1,9 @@
+indi-asi-power (0.95) buster; urgency=medium
+
+  * Replace pigpio timer with INDI timer
+
+ -- Ken Self <ken.kgself@gmail.com>  Mon, 3 May 2021 20:45:00 +1000
+
 indi-asi-power (0.94) buster; urgency=medium
 
   * Minor fix to return codes
@@ -35,7 +41,7 @@ indi-asi-power (0.9) buster; urgency=medium
 indi-asi-power (0.8) buster; urgency=medium
 
   * Label ports 1-4
- * Force type None to OFF
+  * Force type None to OFF
 
  -- Ken Self <ken.kgself@gmail.com>  Tue, 02 Mar 2021 13:50:00 +1100
 
@@ -65,7 +71,7 @@ indi-asi-power (0.5) buster; urgency=medium
 
 indi-asi-power (0.4) buster; urgency=medium
 
- * tested on ASIAir Pro
+  * tested on ASIAir Pro
 
  -- Ken Self <ken.kgself@gmail.com>  Mon, 15 Feb 2021 12:19:00 +1100
 
@@ -77,18 +83,18 @@ indi-asi-power (0.3) buster; urgency=medium
 
 indi-asi-power (0.2) buster; urgency=medium
 
- * Expand to 4 outputs
+  * Expand to 4 outputs
 
  -- Ken Self <ken.kgself@gmail.com>  Mon, 15 Feb 2021 09:37:00 +1100
 
 indi-asi-power (0.1) buster; urgency=medium
 
- * indi_asi_power - Moved under indi-3rdparty. Works with one port: GPIO 12
+  * indi_asi_power - Moved under indi-3rdparty. Works with one port: GPIO 12
 
  -- Ken Self <ken.kgself@gmail.com>  Sun, 14 Feb 2021 12:11:00 +1100
 
 indi-asi-power (0.0) buster; urgency=medium
 
- * all - Initial prototype of asi power driver
+  * all - Initial prototype of asi power driver
 
  -- Ken Self <ken.kgself@gmail.com>  Sun, 14 Feb 2021 11:40:00 +1100

--- a/debian/indi-rpi-gpio/changelog
+++ b/debian/indi-rpi-gpio/changelog
@@ -1,3 +1,9 @@
+indi-rpi-gpio (0.4) buster; urgency=medium
+
+  * Replace pigpio timer with INDI timer
+
+ -- Ken Self <ken.kgself@gmail.com>  Mon, 3 May 2021 20:45:00 +1000
+
 indi-rpi-gpio (0.3) buster; urgency=medium
 
   * Add Active Low option

--- a/debian/libpigpiod/changelog
+++ b/debian/libpigpiod/changelog
@@ -1,3 +1,9 @@
+libpigpiod (0.2) buster; urgency=medium
+
+  * Add -m option to service to reduce CPU load
+
+ -- Ken Self <ken.kgself@gmail.com>  Sun, 25 Apr 2021 15:10:00 +1000
+
 libpigpiod (0.1) buster; urgency=medium
 
   * Initial build of pigpiod services under INDI

--- a/indi-asi-power/CMakeLists.txt
+++ b/indi-asi-power/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set (VERSION_MAJOR 0)
-set (VERSION_MINOR 94)
+set (VERSION_MINOR 95)
 
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)

--- a/indi-asi-power/Changelog
+++ b/indi-asi-power/Changelog
@@ -1,3 +1,6 @@
+v0.95
+* Replace pigpio timer with INDI timer
+
 v0.94
 * Minor fix to return codes
 

--- a/indi-asi-power/README.md
+++ b/indi-asi-power/README.md
@@ -33,10 +33,10 @@ cd ~/Projects
 git clone https://github.com/indilib/indi-3rdparty.git
 cd indi-3rdparty
 ```
-Compile and install the driver and pigpiod
+Compile and install the driver
 ```
-cd ~/Projects/indi-3rd-party
-mkdir -p ~/projects/build/indi-asi-power
+mkdir -p ~/Projects/build/indi-asi-power
+cd ~/Projects/build/indi-asi-power
 cmake -DCMAKE_INSTALL_PREFIX=/usr ~/Projects/indi-3rdparty/indi-asi-power
 make
 sudo make install

--- a/indi-asi-power/asipower.cpp
+++ b/indi-asi-power/asipower.cpp
@@ -21,11 +21,13 @@
 #include <string.h>
 #include <math.h>
 #include <config.h>
+#include <chrono>
 #include <pigpiod_if2.h>
 #include <asipower.h>
 
 static class Loader
 {
+public:
     std::unique_ptr<IndiAsiPower> device;
 public:
     Loader()
@@ -34,19 +36,14 @@ public:
     }
 } loader;
 
-static void DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
-{
-    device->DslrTimer(pi, user_gpio, level, tick);
-}
-
 IndiAsiPower::IndiAsiPower()
 {
     setVersion(VERSION_MAJOR,VERSION_MINOR);
     std::fill_n(m_type, n_dev_type, 0);
-    dslr_cb = 0;
-    dslr_end = dslr_last = 0;
     dslr_isexp = false;
     dslr_counter = 0;
+    timer.callOnTimeout([this](){IndiTimerCallback();});
+    timer.setSingleShot(true);
 }
 IndiAsiPower::~IndiAsiPower()
 {
@@ -58,7 +55,6 @@ IndiAsiPower::~IndiAsiPower()
     }
     deleteProperty(DslrSP.name);
     deleteProperty(DslrExpNP.name);
-    callback_cancel(dslr_cb);
 }
 bool IndiAsiPower::Connect()
 {
@@ -77,15 +73,13 @@ bool IndiAsiPower::Connect()
     {
         set_pull_up_down(m_piId, gpio_pin[i], PI_PUD_DOWN);
     }
-    dslr_cb = callback(m_piId, dslr_pin, EITHER_EDGE, ::DslrTimer);
-    DEBUGF(INDI::Logger::DBG_DEBUG, "Callback id %d pin %d", dslr_cb, dslr_pin);
     DEBUG(INDI::Logger::DBG_SESSION, "ASI Power connected successfully.");
     return true;
 }
 bool IndiAsiPower::Disconnect()
 {
+    DslrChange(false,true);       // Abort exposures
     // Close GPIO
-    callback_cancel(dslr_cb);
     pigpio_stop(m_piId);
     DEBUG(INDI::Logger::DBG_SESSION, "ASI Power disconnected successfully.");
     return true;
@@ -402,7 +396,8 @@ bool IndiAsiPower::saveConfigItems(FILE *fp)
 void IndiAsiPower::DslrChange(bool isInit, bool abort)
 {
     gpio_write(m_piId, dslr_pin, PI_LOW);
-    set_watchdog(m_piId, dslr_pin, 0);
+    timer.stop();
+    auto now = std::chrono::system_clock::now();
     if (isInit)
     {
         dslr_counter = DslrExpN[1].value + 1;
@@ -411,7 +406,9 @@ void IndiAsiPower::DslrChange(bool isInit, bool abort)
     }
     else
     {
-        DEBUGF(INDI::Logger::DBG_SESSION, "DSLR END: %s timer: Counter %d", dslr_isexp ? "Expose":"Delay", dslr_counter);
+    // integral duration: requires duration_cast
+        auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - dslr_start);
+        DEBUGF(INDI::Logger::DBG_SESSION, "DSLR END: %s timer: Duration %d ms, Counter %d", dslr_isexp ? "Expose":"Delay", int_ms, dslr_counter);
     }
     if (dslr_isexp)
     {
@@ -437,15 +434,12 @@ void IndiAsiPower::DslrChange(bool isInit, bool abort)
     }
     uint32_t l_duration = (dslr_isexp ? DslrExpN[0].value : DslrExpN[2].value)*1000;
 
-    dslr_last = get_current_tick(m_piId);
-    dslr_end = static_cast<uint64_t>(dslr_last) + static_cast<uint64_t>(l_duration*1000);
-
     if (l_duration > 0) // non-zero duration
     {
         if(l_duration > max_timer_ms) l_duration = max_timer_ms;
         gpio_write(m_piId, dslr_pin, dslr_isexp ? PI_HIGH: PI_LOW);
-        set_watchdog(m_piId, dslr_pin, l_duration);
-        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR START %s timer: Last tick %lu ms End tick %lu ms", dslr_isexp ? "Expose":"Delay", dslr_last/1000, dslr_end/1000);
+        timer.start(l_duration);
+        dslr_start = std::chrono::system_clock::now();
         DEBUGF(INDI::Logger::DBG_SESSION, "DSLR START %s timer: Duration %d ms", dslr_isexp ? "Expose":"Delay", l_duration);
     }
     else
@@ -463,38 +457,9 @@ void IndiAsiPower::DslrChange(bool isInit, bool abort)
     return;
 }
 
-void IndiAsiPower::DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
+void IndiAsiPower::IndiTimerCallback()
 {
-    if(pi != m_piId || user_gpio != dslr_pin || level != PI_TIMEOUT)
-    {
-        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Other Callback received for Id %d GPIO %d level %d", pi, user_gpio, level);
-        return;
-    }
-    int32_t tick_ms = tick/1000;
-    int32_t last_ms = dslr_last/1000;
-    int64_t end_ms = dslr_end/1000;
-
-// If tick < dslr_last then the timer has wrapped around. So subtract max_tick from dslr_end.
-    if(tick < dslr_last)
-    {
-            dslr_end -= max_tick;
-            end_ms = dslr_end/1000;
-            DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Timer wrapped around. This tick %d ms Last tick %d ms => New End tick %d ms", tick_ms, last_ms, end_ms);
-    }
-
-    int32_t left_ms = end_ms - tick_ms;
-    if(left_ms <= 1) // Within 1ms
-    {
-        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Timer ended with overshoot %d ms", -left_ms);
-        DslrChange();  // Handle end of timer
-        return;
-    }
-    if(left_ms < max_timer_ms) // Reset to the time remaining
-    {
-        set_watchdog(m_piId, dslr_pin, left_ms);
-        DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: Reset timer to %d ms", left_ms);
-    }
-
-    DEBUGF(INDI::Logger::DBG_DEBUG, "DSLR callback: This tick %d ms Last tick %d ms End tick %d ms Left %d ms", tick_ms, last_ms, end_ms, left_ms);
-    dslr_last = tick;
+    DEBUG(INDI::Logger::DBG_DEBUG, "DSLR callback: Timer ended");
+    DslrChange();  // Handle end of timer
+    return;
 }

--- a/indi-asi-power/asipower.h
+++ b/indi-asi-power/asipower.h
@@ -22,6 +22,7 @@
 #include <string.h>
 #include <iostream>
 #include <stdio.h>
+#include <inditimer.h>
 
 #include <defaultdevice.h>
     static const int max_pwm_duty = 100;
@@ -50,7 +51,7 @@ public:
     virtual bool ISNewText (const char *dev, const char *name, char *texts[], char *names[], int n);
     virtual bool ISNewBLOB (const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n);
     virtual bool ISSnoopDevice(XMLEle *root);
-    void DslrTimer(int pi, unsigned user_gpio, unsigned level, uint32_t tick);
+    void IndiTimerCallback();
 
 protected:
     virtual bool saveConfigItems(FILE *fp);
@@ -74,12 +75,11 @@ private:
     INumber DslrExpN[3];
     INumberVectorProperty DslrExpNP;
     
-    int dslr_cb;
-    uint64_t dslr_end;
-    uint32_t dslr_last;
+    std::chrono::time_point<std::chrono::system_clock> dslr_start;
     bool dslr_isexp;
     int dslr_counter;
     void DslrChange(bool isInit=false, bool abort=false);
+    INDI::Timer timer;
 
 };
 

--- a/indi-rpi-gpio/CMakeLists.txt
+++ b/indi-rpi-gpio/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set (VERSION_MAJOR 0)
-set (VERSION_MINOR 3)
+set (VERSION_MINOR 4)
 
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)

--- a/indi-rpi-gpio/Changelog
+++ b/indi-rpi-gpio/Changelog
@@ -1,10 +1,13 @@
-v0.1
-* Initial version of Raspberry Pi GPIO driver
-
-v0.2
-* Split from pigpiod service/library
+v0.4
+* Replace pigpio timer with INDI timer
 
 v0.3
 * Add Active Low option
 * Fix disconnect stopping functionality
 * Move duty cycle to main tab as an operational control
+
+v0.2
+* Split from pigpiod service/library
+
+v0.1
+* Initial version of Raspberry Pi GPIO driver

--- a/indi-rpi-gpio/README.md
+++ b/indi-rpi-gpio/README.md
@@ -34,8 +34,8 @@ cd indi-3rdparty
 ```
 Compile and install the driver
 ```
-cd ~/Projects/indi-3rd-party
-mkdir -p ~/projects/build/indi-rpi-gpio
+mkdir -p ~/Projects/build/indi-rpi-gpio
+cd ~/Projects/build/indi-rpi-gpio
 cmake -DCMAKE_INSTALL_PREFIX=/usr ~/Projects/indi-3rdparty/indi-rpi-gpio
 make
 sudo make install

--- a/indi-rpi-gpio/rpigpio.cpp
+++ b/indi-rpi-gpio/rpigpio.cpp
@@ -24,25 +24,30 @@
 #include <pigpiod_if2.h>
 #include <rpigpio.h>
 
-// We declare an auto pointer to IndiRpiGpio
-static std::unique_ptr<IndiRpiGpio> device(new IndiRpiGpio());
-
-static void TimerCallback(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
+static class Loader
 {
-    device->TimerCallback(pi, user_gpio, level, tick);
-}
+public:
+    std::unique_ptr<IndiRpiGpio> device;
+public:
+    Loader()
+    {
+        device.reset(new IndiRpiGpio());
+    }
+} loader;
 
 IndiRpiGpio::IndiRpiGpio()
 {
     setVersion(VERSION_MAJOR,VERSION_MINOR);
     std::fill_n(m_gpio_pin, n_gpio_pin, -1);
     std::fill_n(m_type, n_dev_type, 0);
-    std::fill_n(timer_end, n_gpio_pin, 0);
-    std::fill_n(timer_last, n_gpio_pin, 0);
+    std::fill_n(timer_counter, n_gpio_pin, 0);
     std::fill_n(timer_isexp, n_gpio_pin, 0);
-    std::fill_n(timer_end, n_gpio_pin, 0);
-    std::fill_n(timer_cb, n_gpio_pin, -1);
 
+    for(int i=0; i<n_gpio_pin;i++)
+    {
+        timer[i].callOnTimeout([this,i](){TimerCallback(i);});
+        timer[i].setSingleShot(true);
+    }
 }
 
 IndiRpiGpio::~IndiRpiGpio()
@@ -56,14 +61,6 @@ IndiRpiGpio::~IndiRpiGpio()
         deleteProperty(ActiveSP[i].name);
         deleteProperty(DutyCycleNP[i].name);
         deleteProperty(TimerOnNP[i].name);
-    }
-    for(int i=0; i<n_gpio_pin;i++)
-    {
-        if(timer_cb[i] >= 0)
-        {
-            callback_cancel(timer_cb[i]);
-            timer_cb[i] = -1;
-        }
     }
     pigpio_stop(m_piId);
 }
@@ -160,7 +157,6 @@ int IndiRpiGpio::InitPiModel()
     return 0;
 }
 
-
 bool IndiRpiGpio::Connect()
 {
     if(m_piId < 0)
@@ -174,14 +170,10 @@ bool IndiRpiGpio::Connect()
 }
 bool IndiRpiGpio::Disconnect()
 {
-    // Close GPIO
+    // Close GPIO. Stop any timers
     for(int i=0; i<n_gpio_pin;i++)
     {
-        if(timer_cb[i] >= 0)
-        {
-            callback_cancel(timer_cb[i]);
-            timer_cb[i] = -1;
-        }
+        if(dev_timer[m_type[i]]) TimerChange(i, false, true);
     }
     DEBUG(INDI::Logger::DBG_SESSION, "RPi GPIO disconnected successfully.");
     return true;
@@ -464,12 +456,8 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                 // See if the GPIO has changed
                 if( m_gpio_pin[i] != l_gpio_pin)
                 {
-                    if(timer_cb[i] >= 0)    // Cancel the timer on the old pin
-                    {
-                        callback_cancel(timer_cb[i]);
-                        timer_cb[i] = -1;
-                        DEBUGF(INDI::Logger::DBG_SESSION, "%s type %s GPIO# %d timer cancelled", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
-                    }
+                    if(dev_timer[m_type[i]]) TimerChange(i, false, true);   // Stop any timer
+                    DEBUGF(INDI::Logger::DBG_SESSION, "%s type %s GPIO# %d timer cancelled", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
                     if(dev_pwm[m_type[i]])     // Cancel the PWM on the old pin (not really needed if switched off)
                     {
                     // If Active LOW then the duty cycle is the complement of the Active HIGH 
@@ -484,14 +472,6 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                     m_gpio_pin[i] = l_gpio_pin;
                     set_pull_up_down(m_piId, m_gpio_pin[i], PI_PUD_DOWN);  // Ensure Pull Up/Down set to Pull Down
                     gpio_write(m_piId, m_gpio_pin[i], (ActiveS[i][0].s == ISS_ON)? PI_LOW: PI_HIGH);  // Assume OFF
-                    if(dev_timer[m_type[i]])   // Create a timer on the new pin
-                    {
-                        if(m_gpio_pin[i] >= 0 && timer_cb[i] < 0)
-                        {
-                            timer_cb[i] = callback(m_piId, m_gpio_pin[i], EITHER_EDGE, ::TimerCallback);
-                            DEBUGF(INDI::Logger::DBG_SESSION, "%s type %s GPIO# %d timer callback set", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
-                        }
-                    }
                     if(dev_pwm[m_type[i]])    // Set up PWM on the new pin
                     {
                         set_PWM_frequency(m_piId, m_gpio_pin[i], pwm_freq);
@@ -529,8 +509,7 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                 {
                     if(dev_timer[m_type[i]] && !dev_timer[l_type])    // Cancel the timer
                     {
-                        callback_cancel(timer_cb[i]);
-                        timer_cb[i] = -1;
+                        TimerChange(i, false, true);                  // Stop any timer
                         DEBUGF(INDI::Logger::DBG_SESSION, "%s type %s GPIO# %d timer cancelled", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
                     }
                     if(dev_pwm[m_type[i]] && !dev_pwm[l_type])         // Cancel the PWM
@@ -540,13 +519,6 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                         DEBUGF(INDI::Logger::DBG_SESSION, "%s type %s GPIO# %d PWM disabled", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
                     }
                     m_type[i] = l_type;
-                    if(dev_timer[m_type[i]] && timer_cb[i] < 0)   // Create a timer for the new type
-                    {
-                        if(m_gpio_pin[i] >= 0)
-                        {
-                            timer_cb[i] = callback(m_piId, m_gpio_pin[i], EITHER_EDGE, ::TimerCallback);
-                        }
-                    }
                     if(dev_pwm[m_type[i]])    // Set up PWM on the new pin
                     {
                         set_PWM_frequency(m_piId, m_gpio_pin[i], pwm_freq);
@@ -597,7 +569,7 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                         }
                         else
                         {
-                            TimerChange(m_gpio_pin[i], false, true);
+                            TimerChange(i, false, true);        // Stop the timer
                             DEBUG(INDI::Logger::DBG_SESSION, "Timer Stop exposure");
                             TimerOnNP[i].s = IPS_IDLE;
                             IDSetNumber(&TimerOnNP[i], nullptr);
@@ -626,7 +598,7 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                         else
                         {
                             DEBUGF(INDI::Logger::DBG_SESSION, "%s %s GPIO# %d start timer: Duration %0.2f s Count %0.0f Delay %0.2f s", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i], TimerOnN[i][0].value, TimerOnN[i][1].value, TimerOnN[i][2].value);
-                            TimerChange(m_gpio_pin[i], true);
+                            TimerChange(i, true);
                             TimerOnNP[i].s = IPS_BUSY;
                             IDSetNumber(&TimerOnNP[i], nullptr);
                         }
@@ -653,20 +625,11 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                     DEBUGF(INDI::Logger::DBG_ERROR, "%s type %s GPIO# %d Parity cannot be changed while device is ON", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i] );
                     return false;
                 }
-//                // verify a valid device - not of type None
-//                if(m_type[i] == 0)
-//                {
-//                    ActiveSP[i].s = IPS_ALERT;
-//                    IDSetSwitch(&ActiveSP[i], NULL);
-//                    DEBUGF(INDI::Logger::DBG_ERROR, "%s type %s GPIO# %d cannot set active parity when not in use", DeviceSP[i].label, dev_type[m_type[i]].c_str(), m_gpio_pin[i]);
-//                    return false;
-//                }
                 IUUpdateSwitch(&ActiveSP[i], states, names, n);
                 
                 // Set Active High
                 if ( ActiveS[i][0].s == ISS_ON )
                 {
-//                    set_pull_up_down(m_piId, m_gpio_pin[i], PI_PUD_DOWN);
                     gpio_write(m_piId, m_gpio_pin[i], PI_LOW );    // Assumed in OFF state
                     ActiveSP[i].s = IPS_OK;
                     IDSetSwitch(&ActiveSP[i], NULL);
@@ -676,7 +639,6 @@ bool IndiRpiGpio::ISNewSwitch (const char *dev, const char *name, ISState *state
                 // Seet Active Low
                 if ( ActiveS[i][1].s == ISS_ON )
                 {
-//                    set_pull_up_down(m_piId, m_gpio_pin[i], PI_PUD_UP);
                     gpio_write(m_piId, m_gpio_pin[i], PI_HIGH );   // Assumed in OFF state
                     ActiveSP[i].s = IPS_OK;
                     IDSetSwitch(&ActiveSP[i], NULL);
@@ -711,24 +673,30 @@ bool IndiRpiGpio::saveConfigItems(FILE *fp)
     return true;
 }
 
-void IndiRpiGpio::TimerChange(unsigned user_gpio, bool isInit, bool abort)
+void IndiRpiGpio::TimerChange(int i, bool isInit, bool abort)
 {
-    int i = FindPinIndex(user_gpio);
+    unsigned user_gpio = m_gpio_pin[i];
     gpio_write(m_piId, user_gpio, (ActiveS[i][0].s == ISS_ON)? PI_LOW: PI_HIGH);
-    set_watchdog(m_piId, user_gpio, 0);
+    stopTimer(i);
+    auto now = std::chrono::system_clock::now();
+    
+    const int ip = i+1; // Port number
+    
     if(i < 0 || !dev_timer[m_type[i]])
     {
-        DEBUGF(INDI::Logger::DBG_ERROR, "TimerChange: Invalid GPIO or not timed %lu", user_gpio);
+        DEBUGF(INDI::Logger::DBG_ERROR, "TimerChange: Port %d Invalid GPIO or not timed %lu", ip, user_gpio);
     }
     if (isInit)
     {
         timer_counter[i] = TimerOnN[i][1].value + 1;
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer SEQ INIT: Counter %d", timer_counter[i]);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer SEQ INIT: Port %d Counter %d", ip, timer_counter[i]);
         timer_isexp[i] = true;
     }
     else
     {
-        DEBUGF(INDI::Logger::DBG_SESSION, "Timer END: %s timer: Counter %d", timer_isexp ? "Expose":"Delay", timer_counter[i]);
+    // integral duration: requires duration_cast
+        auto int_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - timer_start[i]);
+        DEBUGF(INDI::Logger::DBG_SESSION, "Timer END: Port %d %s timer: Duration %d ms, Counter %d", ip, timer_isexp ? "Expose":"Delay", int_ms, timer_counter[i]);
     }
     if (timer_isexp[i])
     {
@@ -736,14 +704,14 @@ void IndiRpiGpio::TimerChange(unsigned user_gpio, bool isInit, bool abort)
     }
     if(abort)
     {
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer SEQ ABORT: %s Counter %d", timer_isexp ? "Expose":"Delay", timer_counter[i]);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer SEQ ABORT: Port %d %s Counter %d", ip, timer_isexp ? "Expose":"Delay", timer_counter[i]);
         timer_counter[i] = 0;
     }
     timer_isexp[i] =  ! timer_isexp[i];
 
     if (timer_counter[i] <= 0)
     {
-        DEBUGF(INDI::Logger::DBG_SESSION, "Timer SEQ END: %s Counter %d", timer_isexp[i] ? "Expose":"Delay", timer_counter[i]);
+        DEBUGF(INDI::Logger::DBG_SESSION, "Timer SEQ END: Port %d %s Counter %d", ip, timer_isexp[i] ? "Expose":"Delay", timer_counter[i]);
         OnOffS[i][0].s = ISS_ON;
         OnOffS[i][1].s = ISS_OFF;
         OnOffSP[i].s = IPS_IDLE;
@@ -754,65 +722,38 @@ void IndiRpiGpio::TimerChange(unsigned user_gpio, bool isInit, bool abort)
     }
     uint32_t l_duration = (timer_isexp[i] ? TimerOnN[i][0].value : TimerOnN[i][2].value)*1000;
 
-    timer_last[i] = get_current_tick(m_piId);
-    timer_end[i] = static_cast<uint64_t>(timer_last[i]) + static_cast<uint64_t>(l_duration*1000);
-
     if (l_duration > 0) // non-zero duration
     {
         if(l_duration > max_timer_ms) l_duration = max_timer_ms;
         gpio_write(m_piId, user_gpio, timer_isexp[i] ? ((ActiveS[i][0].s == ISS_ON)? PI_HIGH: PI_LOW): ((ActiveS[i][0].s == ISS_ON)? PI_LOW: PI_HIGH));
-        set_watchdog(m_piId, user_gpio, l_duration);
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer START %s timer: Last tick %lu ms End tick %lu ms", timer_isexp[i] ? "Expose":"Delay", timer_last[i]/1000, timer_end[i]/1000);
-        DEBUGF(INDI::Logger::DBG_SESSION, "Timer START %s timer: Duration %d ms", timer_isexp[i] ? "Expose":"Delay", l_duration);
+        startTimer(i, l_duration);
+        timer_start[i] = std::chrono::system_clock::now();
+        DEBUGF(INDI::Logger::DBG_SESSION, "Timer START Port %d %s timer: Duration %d ms", ip, timer_isexp[i] ? "Expose":"Delay", l_duration);
     }
     else
     {
         if (timer_isexp[i])
         {
-            DEBUG(INDI::Logger::DBG_ERROR, "Timer Zero length exposure requested");
+            DEBUGF(INDI::Logger::DBG_ERROR, "Port %d Timer Zero length exposure requested", ip);
         }
         else
         {
-            DEBUGF(INDI::Logger::DBG_SESSION, "Timer START %s timer: zero length duration %d ms", timer_isexp[i] ? "Expose":"Delay", l_duration);
-            TimerChange(user_gpio);  // Handle a zero length delay
+            DEBUGF(INDI::Logger::DBG_SESSION, "Timer START Port %d %s timer: zero length duration %d ms", ip, timer_isexp[i] ? "Expose":"Delay", l_duration);
+            TimerChange(i);  // Handle a zero length delay
         }
     }
     return;
 }
 
-void IndiRpiGpio::TimerCallback(int pi, unsigned user_gpio, unsigned level, uint32_t tick)
+void IndiRpiGpio::TimerCallback(int i)
 {
-    int i = FindPinIndex(user_gpio);
-    if(pi != m_piId || i < 0 || level != PI_TIMEOUT)
+    if(i < 0 || i >= n_gpio_pin)
     {
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer callback: Other Callback received for Id %d GPIO %d level %d", pi, user_gpio, level);
+        DEBUGF(INDI::Logger::DBG_SESSION, "Timer callback: Invalid callback received for Id %d", i);
         return;
     }
-    int32_t tick_ms = tick/1000;
-    int32_t last_ms = timer_last[i]/1000;
-    int64_t end_ms = timer_end[i]/1000;
-
-// If tick < timer_last then the timer has wrapped around. So subtract max_tick from timer_end.
-    if(tick < timer_last[i])
-    {
-            timer_end[i] -= max_tick;
-            end_ms = timer_end[i]/1000;
-            DEBUGF(INDI::Logger::DBG_DEBUG, "Timer callback: Timer wrapped around. This tick %d ms Last tick %d ms => New End tick %d ms", tick_ms, last_ms, end_ms);
-    }
-
-    int32_t left_ms = end_ms - tick_ms;
-    if(left_ms <= 1) // Within 1ms
-    {
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer callback: Timer ended with overshoot %d ms", -left_ms);
-        TimerChange(user_gpio);  // Handle end of timer
-        return;
-    }
-    if(left_ms < max_timer_ms) // Reset to the time remaining
-    {
-        set_watchdog(m_piId, user_gpio, left_ms);
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Timer callback: Reset timer to %d ms", left_ms);
-    }
-
-    DEBUGF(INDI::Logger::DBG_DEBUG, "Timer callback: This tick %d ms Last tick %d ms End tick %d ms Left %d ms", tick_ms, last_ms, end_ms, left_ms);
-    timer_last[i] = tick;
+    // Timer ended
+    DEBUGF(INDI::Logger::DBG_SESSION, "Timer callback: Timer ended for id %d", i);
+    TimerChange(i);  // Handle end of timer
+    return;
 }

--- a/libpigpiod/CMakeLists.txt
+++ b/libpigpiod/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set (VERSION_MAJOR 0)
-set (VERSION_MINOR 1)
+set (VERSION_MINOR 2)
 
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)

--- a/libpigpiod/README.md
+++ b/libpigpiod/README.md
@@ -37,8 +37,8 @@ cd indi-3rdparty
 ```
 Compile and install the driver and pigpiod
 ```
-cd ~/Projects/indi-3rd-party
-mkdir -p ~/projects/build/libpigpiod
+mkdir -p ~/Projects/build/libpigpiod
+cd ~/Projects/build/libpigpiod
 cmake -DCMAKE_INSTALL_PREFIX=/usr ~/Projects/indi-3rdparty/libpigpiod
 make
 sudo make install

--- a/libpigpiod/pigpiod.service.in
+++ b/libpigpiod/pigpiod.service.in
@@ -3,7 +3,7 @@ Description=pigpiod daemon to control Raspberry Pi GPIO
 
 [Service]
 Type=simple
-ExecStart=@CMAKE_INSTALL_PREFIX@/bin/pigpiod -g
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/pigpiod -g -m
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add -m option when starting pigpiod to reduce idle CPU usage
Replace the pigpio timer in indi-asi-power and indi-rpi-gpio with the built in INDI timer as the pigpio timer does not work with the -m option.