### PR TITLE
Removed the 'Use PulseCmd'-switch

### DIFF
--- a/debian/indi-aok/changelog
+++ b/debian/indi-aok/changelog
@@ -1,3 +1,8 @@
+indi-aok (1.1) bionic; urgency=low
+  * removed obsolete "Use PulsCmd"-switch and corresponding programming code
+  
+-- T. Schriber <escribana@bluewin.ch> Tue, 11 May 2021 08:56:32 +0200 
+
 indi-aok (1.0) bionic; urgency=low
   * cleared up the handling of notification of mountlock & trackstate
   * added query of mount when connecting, so mountlock and trackstate is reflected correctly

--- a/indi-aok/CMakeLists.txt
+++ b/indi-aok/CMakeLists.txt
@@ -15,8 +15,8 @@ include_directories(${NOVA_INCLUDE_DIR})
 
 include(CMakeCommon)
 
-set(SKYWALKER_VERSION_MAJOR 0)
-set(SKYWALKER_VERSION_MINOR 9)
+set(SKYWALKER_VERSION_MAJOR 1)
+set(SKYWALKER_VERSION_MINOR 1)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/indi-aok/ChangeLog
+++ b/indi-aok/ChangeLog
@@ -1,3 +1,7 @@
+Version 1.1 - 2021-05-10
+	- removed obsolete "Use PulsCmd"-switch (it makes no sense *not* to use
+	  the built-in pulse commands of the TCS)
+
 Version 1.0 - 2020-03-06
 	+ cleared up the handling of notification of mountlock & trackstate
 	+ added query of mount when connecting, so mountlock and trackstate

--- a/indi-aok/lx200aok.cpp
+++ b/indi-aok/lx200aok.cpp
@@ -343,6 +343,8 @@ bool LX200Skywalker::updateProperties()
         defineProperty(&MountStateSP);
         defineProperty(&SystemSlewSpeedNP);
         defineProperty(&FirmwareVersionTP);
+        // Switch is obsolete: NOT using pulse commands makes no sense with TC
+        deleteProperty(UsePulseCmdSP.name);
     }
     else
     {
@@ -487,7 +489,7 @@ void LX200Skywalker::getBasicData()
             LOG_INFO("Parkdata load failed");
     }
 
-    //ToDo: collect other fixed data here like Manufacturer, version etc...
+    /* NOT using pulse commands makes no sense with skywalker controller
     if (genericCapability & LX200_HAS_PULSE_GUIDING)
     {
         UsePulseCmdS[0].s = ISS_ON;
@@ -495,7 +497,7 @@ void LX200Skywalker::getBasicData()
         UsePulseCmdSP.s = IPS_OK;
         usePulseCommand = false; // ALWAYS set status! (cf. ISNewSwitch())
         IDSetSwitch(&UsePulseCmdSP, nullptr);
-    }
+    }*/
 
 }
 
@@ -1144,197 +1146,49 @@ bool LX200Skywalker::setSlewMode(int slewMode)
 
 IPState LX200Skywalker::GuideNorth(uint32_t ms)
 {
-    LOGF_DEBUG("%s %dms %d", __FUNCTION__, ms, usePulseCommand);
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    LOGF_DEBUG("%s %dms", __FUNCTION__, ms);
+    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
     {
         LOG_ERROR("Cannot guide while moving.");
         return IPS_ALERT;
     }
-
-    // If already moving (no pulse command), then stop movement
-    if (MovementNSSP.s == IPS_BUSY)
-    {
-        int dir = IUFindOnSwitchIndex(&MovementNSSP);
-
-        MoveNS(dir == 0 ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_STOP);
-    }
-
-    if (GuideNSTID)
-    {
-        IERmTimer(GuideNSTID);
-        GuideNSTID = 0;
-    }
-
-    if (usePulseCommand)
-    {
-        SendPulseCmd(LX200_NORTH, ms);
-    }
-    else
-    {
-        if (!setSlewMode(LX200_SLEW_GUIDE))
-        {
-            SlewRateSP.s = IPS_ALERT;
-            IDSetSwitch(&SlewRateSP, "Error setting slew mode.");
-            return IPS_ALERT;
-        }
-
-        MovementNSS[DIRECTION_NORTH].s = ISS_ON;
-        MoveNS(DIRECTION_NORTH, MOTION_START);
-    }
-
-    // Set slew to guiding
-    IUResetSwitch(&SlewRateSP);
-    SlewRateS[SLEW_GUIDE].s = ISS_ON;
-    IDSetSwitch(&SlewRateSP, nullptr);
-    guide_direction_ns = LX200_NORTH;
-    GuideNSTID      = IEAddTimer(ms, guideTimeoutHelperNS, this);
+    SendPulseCmd(LX200_NORTH, ms);
     return IPS_BUSY;
 }
 
 IPState LX200Skywalker::GuideSouth(uint32_t ms)
 {
-    LOGF_DEBUG("%s %dms %d", __FUNCTION__, ms, usePulseCommand);
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    LOGF_DEBUG("%s %dms", __FUNCTION__, ms);
+    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
     {
         LOG_ERROR("Cannot guide while moving.");
         return IPS_ALERT;
     }
-
-    // If already moving (no pulse command), then stop movement
-    if (MovementNSSP.s == IPS_BUSY)
-    {
-        int dir = IUFindOnSwitchIndex(&MovementNSSP);
-
-        MoveNS(dir == 0 ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_STOP);
-    }
-
-    if (GuideNSTID)
-    {
-        IERmTimer(GuideNSTID);
-        GuideNSTID = 0;
-    }
-
-    if (usePulseCommand)
-    {
-        SendPulseCmd(LX200_SOUTH, ms);
-    }
-    else
-    {
-        if (!setSlewMode(LX200_SLEW_GUIDE))
-        {
-            SlewRateSP.s = IPS_ALERT;
-            IDSetSwitch(&SlewRateSP, "Error setting slew mode.");
-            return IPS_ALERT;
-        }
-
-        MovementNSS[DIRECTION_SOUTH].s = ISS_ON;
-        MoveNS(DIRECTION_SOUTH, MOTION_START);
-    }
-
-    // Set slew to guiding
-    IUResetSwitch(&SlewRateSP);
-    SlewRateS[SLEW_GUIDE].s = ISS_ON;
-    IDSetSwitch(&SlewRateSP, nullptr);
-    guide_direction_ns = LX200_SOUTH;
-    GuideNSTID      = IEAddTimer(ms, guideTimeoutHelperNS, this);
+    SendPulseCmd(LX200_SOUTH, ms);
     return IPS_BUSY;
 }
 
 IPState LX200Skywalker::GuideEast(uint32_t ms)
 {
-    LOGF_DEBUG("%s %dms %d", __FUNCTION__, ms, usePulseCommand);
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    LOGF_DEBUG("%s %dms", __FUNCTION__, ms);
+    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
     {
         LOG_ERROR("Cannot guide while moving.");
         return IPS_ALERT;
     }
-
-    // If already moving (no pulse command), then stop movement
-    if (MovementWESP.s == IPS_BUSY)
-    {
-        int dir = IUFindOnSwitchIndex(&MovementWESP);
-
-        MoveWE(dir == 0 ? DIRECTION_WEST : DIRECTION_EAST, MOTION_STOP);
-    }
-
-    if (GuideWETID)
-    {
-        IERmTimer(GuideWETID);
-        GuideWETID = 0;
-    }
-
-    if (usePulseCommand)
-    {
-        SendPulseCmd(LX200_EAST, ms);
-    }
-    else
-    {
-        if (!setSlewMode(LX200_SLEW_GUIDE))
-        {
-            SlewRateSP.s = IPS_ALERT;
-            IDSetSwitch(&SlewRateSP, "Error setting slew mode.");
-            return IPS_ALERT;
-        }
-
-        MovementWES[DIRECTION_EAST].s = ISS_ON;
-        MoveWE(DIRECTION_EAST, MOTION_START);
-    }
-
-    // Set slew to guiding
-    IUResetSwitch(&SlewRateSP);
-    SlewRateS[SLEW_GUIDE].s = ISS_ON;
-    IDSetSwitch(&SlewRateSP, nullptr);
-    guide_direction_we = LX200_EAST;
-    GuideWETID      = IEAddTimer(ms, guideTimeoutHelperWE, this);
+    SendPulseCmd(LX200_EAST, ms);
     return IPS_BUSY;
 }
 
 IPState LX200Skywalker::GuideWest(uint32_t ms)
 {
-    LOGF_DEBUG("%s %dms %d", __FUNCTION__, ms, usePulseCommand);
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    LOGF_DEBUG("%s %dms", __FUNCTION__, ms);
+    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
     {
         LOG_ERROR("Cannot guide while moving.");
         return IPS_ALERT;
     }
-
-    // If already moving (no pulse command), then stop movement
-    if (MovementWESP.s == IPS_BUSY)
-    {
-        int dir = IUFindOnSwitchIndex(&MovementWESP);
-
-        MoveWE(dir == 0 ? DIRECTION_WEST : DIRECTION_EAST, MOTION_STOP);
-    }
-
-    if (GuideWETID)
-    {
-        IERmTimer(GuideWETID);
-        GuideWETID = 0;
-    }
-
-    if (usePulseCommand)
-    {
-        SendPulseCmd(LX200_WEST, ms);
-    }
-    else
-    {
-        if (!setSlewMode(LX200_SLEW_GUIDE))
-        {
-            SlewRateSP.s = IPS_ALERT;
-            IDSetSwitch(&SlewRateSP, "Error setting slew mode.");
-            return IPS_ALERT;
-        }
-
-        MovementWES[DIRECTION_WEST].s = ISS_ON;
-        MoveWE(DIRECTION_WEST, MOTION_START);
-    }
-
-    // Set slew to guiding
-    IUResetSwitch(&SlewRateSP);
-    SlewRateS[SLEW_GUIDE].s = ISS_ON;
-    IDSetSwitch(&SlewRateSP, nullptr);
-    guide_direction_we = LX200_WEST;
-    GuideWETID      = IEAddTimer(ms, guideTimeoutHelperWE, this);
+    SendPulseCmd(LX200_WEST, ms);
     return IPS_BUSY;
 }
 


### PR DESCRIPTION
The 'Use PulseCmd'-switch is removed as it makes definitively no sense **not** to use the built-in pulse commands of the skywalker controller (TCS).
Reason 1: The switch leads to confusion and off-setting can easily be overseen.
Reason 2: Switching 'Use PulseCmd" off, i.e. using the emulated pulse commands functions like in the lx200telescope driver, produces an extremely bad guiding due to timer lags.