### PR TITLE
Apply 8-bit video hack also for older ASI 130MM (USB 2.0)

### DIFF
--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -286,9 +286,10 @@ void ASICCD::workerExposure(const std::atomic_bool &isAboutToQuit, float duratio
         // Wait 100ms before trying again
         usleep(100 * 1000);
 
-        // JM 2020-02-17 Special hack for older ASI120 cameras that fail on 16bit
-        // images.
-        if (getImageType() == ASI_IMG_RAW16 && strstr(getDeviceName(), "ASI120"))
+        // JM 2020-02-17 Special hack for older ASI120 and ASI130 cameras (USB 2.0)
+        // that fail on 16bit images.
+        if (getImageType() == ASI_IMG_RAW16 &&
+            (strstr(getDeviceName(), "ASI120") || (strstr(getDeviceName(), "ASI130"))))
         {
             LOG_INFO("Switching to 8-bit video.");
             setVideoFormat(ASI_IMG_RAW8);


### PR DESCRIPTION
ZWO ASI cameras 120MM (USB 2.0) sometimes/frequently fails taking
exposures when set in 16-Bit mode. To overcome this problem
a 'hack' is proposed to switch to 8-Bit mode. The
ZWO ASI cameras 130MM suffers by the same problem, thus apply
the 'hack' also to this camera.