### PR TITLE
indi-qhy: add support for qhy humidity readout

### DIFF
--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -434,7 +434,7 @@ bool QHYCCD::updateProperties()
                 uint32_t ret = GetQHYCCDHumidity(m_CameraHandle, &humidity);
                 if (ret == QHYCCD_SUCCESS)
                 {
-                    HumidityN[0].step = humidity;
+                    HumidityN[0].value = humidity;
                 }
 
                 LOGF_INFO("Humidity Sensor: %s", ret == QHYCCD_SUCCESS ? "true" :

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -202,7 +202,7 @@ bool QHYCCD::initProperties()
     IUFillNumberVector(&USBBufferNP, USBBufferN, 1, getDeviceName(), "USB_BUFFER", "USB Buffer", MAIN_CONTROL_TAB,
                        IP_RW, 60, IPS_IDLE);
 
-    // USB Buffer
+    // Humidity
     IUFillNumber(&HumidityN[0], "HUMIDITY", "%", "%.2f", -100, 1000, 0.1, 0);
     IUFillNumberVector(&HumidityNP, HumidityN, 1, getDeviceName(), "CCD_HUMIDITY", "Humidity", MAIN_CONTROL_TAB,
                        IP_RO, 60, IPS_IDLE);
@@ -1028,7 +1028,7 @@ bool QHYCCD::Connect()
         LOGF_DEBUG("GPS Support: %s", HasGPS ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
-        /// GPS Support
+        /// Humidity Support
         ////////////////////////////////////////////////////////////////////
         double humidity = 0;
         ret = GetQHYCCDHumidity(m_CameraHandle, &humidity);

--- a/indi-qhy/qhy_ccd.h
+++ b/indi-qhy/qhy_ccd.h
@@ -163,6 +163,9 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
         INumber USBBufferN[1];
         INumberVectorProperty USBBufferNP;
 
+        // Humidity Readout
+        INumber HumidityN[1];
+        INumberVectorProperty HumidityNP;
         /////////////////////////////////////////////////////////////////////////////
         /// Properties: Utility Controls
         /////////////////////////////////////////////////////////////////////////////
@@ -422,6 +425,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
         bool HasCoolerManualMode { false };
         bool HasReadMode { false };
         bool HasGPS { false };
+        bool HasHumidity { false };
         bool HasAmpGlow { false };
         //NEW CODE - Add support for overscan/calibration area
         bool HasOverscanArea { false };


### PR DESCRIPTION
add support for reading humidity sensor, if supported.

tested with qhy268m:
rsarwar@astroberry : ~/workspace/indi-3rdparty-branch/indi-qhy/cbuild
$ indiserver ./indi_qhy_ccd 
2021-06-24T16:01:37: startup: indiserver ./indi_qhy_ccd 
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: -- InitQHYCCDResource param
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|InitQHYCCDResource()|START
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|InitQHYCCDResource|auto_detect_camera:false,call InitQHYCCDResourceInside
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|InitQHYCCDResourceInside|START
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|libusb_version 1.0.22.11312
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|libusb_init(libqhyccd_context) called...
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|InitQHYCCDResourceInside|numdev set to 0
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: QHYCCD|QHYCCD.CPP|InitQHYCCDResourceInside|END
2021-06-24T16:01:37: Driver ./indi_qhy_ccd: ************************** config file path  21.6.3.13 svn: 11038  ************************************

rsarwar@astroberry : ~/workspace/indi-3rdparty-branch/indi-qhy
$ indiserver --version
2021-06-24T16:17:34: startup: indiserver --version 
Usage: indiserver [options] driver [driver ...]
Purpose: server for local and remote INDI drivers
INDI Library: 1.9.0
Code v1.9.0. Protocol 1.7.

TODO: 
send out alerts based on humidity. But what is an acceptable range????
