### PR TITLE
Indi bresserexos2 v900 hotfix

### DIFF
--- a/indi-bresserexos2/BresserExosIIGoToDriver.cpp
+++ b/indi-bresserexos2/BresserExosIIGoToDriver.cpp
@@ -302,8 +302,6 @@ bool BresserExosIIDriver::SetTrackingEnabled(bool enabled)
 //update the time of the scope.
 bool BresserExosIIDriver::updateTime(ln_date *utc, double utc_offset)
 {
-    INDI::Telescope::updateTime(utc, utc_offset);
-    
     // Bresser takes local time and DST but ln_zonedate doesn't have DST
     struct ln_zonedate local_date;
     ln_date_to_zonedate(utc, &local_date, static_cast<int>(utc_offset * 3600));
@@ -337,7 +335,7 @@ bool BresserExosIIDriver::updateLocation(double latitude, double longitude, doub
     
     if(realLongitude>180)
     {
-        realLongitude = -(360-realLongitude);
+	realLongitude -= 360;
     }
 
     LOGF_INFO("Location updated: Longitude (%g) Latitude (%g)", realLongitude, latitude);

--- a/indi-bresserexos2/CMakeLists.txt
+++ b/indi-bresserexos2/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(indi-bresserexos2 VERSION 0.900)
+project(indi-bresserexos2 VERSION 0.901)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
@@ -15,13 +15,14 @@ include(CMakeCommon)
 
 find_package(Threads REQUIRED)
 find_package(INDI REQUIRED)
+find_package(Nova REQUIRED)
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR})
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories( ${INDI_INCLUDE_DIR})
 
 add_executable(indi_bresserexos2 BresserExosIIGoToDriver.cpp IndiSerialWrapper.cpp SerialCommand.cpp)
-target_link_libraries(indi_bresserexos2 ${INDI_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} Threads::Threads)
+target_link_libraries(indi_bresserexos2 ${INDI_LIBRARIES} ${NOVA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} Threads::Threads)
 target_include_directories(indi_bresserexos2 PUBLIC
 						  "${PROJECT_BINARY_DIR}"
 						  )

--- a/indi-bresserexos2/Documentation/FAQ.md
+++ b/indi-bresserexos2/Documentation/FAQ.md
@@ -10,10 +10,12 @@ You will only hit the vicinity of your target and have to adjust it using your h
 Furthermore, there seems to be a minor issue with the coordinates too. It shows completely different coordinates on the display, compared to those I sent to the mount.
 I tried it with the Ascom driver from Bresser, sending the same coordinates with my driver and the mount pointed to the same direction in both cases. I concluded this seems to be a deviance which may be caused by a bug in either the mount or any driver component. I'm still observing this problem, and fix it once a solution is found.
 
-## Software Autoguiding was removed, why?
+## Software Autoguiding was removed (and reintroduced), why?
 Yes it was experimental from the start, and I decided to remove it due to fact that its simply not possible with this mount, unless the handbox firmware gets a mayor overhaul.
 However you can still use the ST-4 cable and it should work as intended by Bresser, or whoever originally created this mount.
 Since I don't want to promise functionality that is not possible I removed Autoguiding from the driver. It may be reintroduces however if I'm in the mood.
+
+The is reintroduced with version 0.900 because of user requests. However, its still buggy, and requires a firmware patch for proper operation and is therefore not recommended. If you want reliable guiding use the ST-4 cable.
 
 ## The software direction keys do not work but the Handbox keys work, why?
 From my examinations I found these motion commands only to work when an object is tracked. The answer boils down to, the manufacturer intended it to work that way.

--- a/indi-bresserexos2/Documentation/Troubleshooting.md
+++ b/indi-bresserexos2/Documentation/Troubleshooting.md
@@ -92,3 +92,32 @@ Open your build directory in a terminal, similarly to the procedure in the debug
 Go to the [Driver installation](Installation.md) documentation to the stage where you perform the `cmake --build .` command and simply rerun the process from there.
 
 However there may cases where this does not work. So if you encounter linker or compiler error in the process, create a bug ticket, with keep the "useful debug information"-paradigm in mind.
+
+### Indi Webmanager Service does not display driver
+In order to avoid users the trouble of starting the whole application stack manually, the webmanager in astroberry is used to set up everything using a browser.
+
+However since the build system may change its default install prefixes (paths) via updates, its possible the `sudo cmake make install` command may place these files in a unexpected location. Thus the driver does not appear in the web manager list.
+
+In order to ensure operation place make sure the driver files are located at:
+
+- `indi_bresserexos2` needs to reside in `/usr/bin/`
+- `indi_bresserexos2.xml` needs to reside in `/usr/share/indi/`
+
+If you can not see the entries on your distribution, make sure your first remove to current installation to tidy up your system and avoid later issues with old driver files (see: [Driver removal](Installation.md#remove-the-driver) for the procedure)
+
+1. open your driver build directory in a terminal
+2. copy the driver files manually to the correct locations by using:
+
+- `sudo cp indi_bresserexos2 /usr/bin/` to copy the driver binary to its install directory
+- `sudo cp indi_bresserexos2.xml /usr/share/indi/` to copy the driver xml file to its install directory
+
+It is also posible the distribution you are using, expects the driver files in a completelly different spot, in that case ask your distribution maintainer information about where such files should be placed, or look for existing driver files in your filesystem (eg. shipped drivers) and place the Bresser driver files accordingly.
+
+This should solve this issue.
+
+### Difference in Coordinates between Astro Software and Handbox Display
+
+The coordinates in your astro software may differ from the coordinates displayed on handbox display. The reason is yet unknown, there was a bug with missing timezones. However after fixing this issue the difference only grew larger.
+General advice here: do not use the handbox to rely on coordinates. If you are synchronized with the sky, (eg. Polar Alignment, Star Alignment OK), your Astro software should be able to point to your targets no matter what the display says.
+
+If you see a known star in your scope you pointed to manually and confirmed its position, you should be fine pointing to any other object in the sky.

--- a/indi-bresserexos2/README.md
+++ b/indi-bresserexos2/README.md
@@ -40,8 +40,8 @@ The mount is quite autonomous, in terms motion controls, when initialized proper
 On the serial protocol side however, this device is quite primitive. 
 The data exchange is established using a 13 Byte message frame, with a 4 Byte preamble, leaving 1 byte for a command and 8 bytes for command parameter data.
 The protocol only accepts, a few commands for goto, sync, parking, motion stop and Location/Time/Date setting.
-The Device is not very talkative, it only sends responses to location command, and only reports back the its current pointing coordinates.
-This makes it difficult to assess the state of the mount.
+The Device is not very talkative, it only sends responses to location command, and only reports back the its current pointing coordinates, without the tracking status information.
+This makes it difficult to determine the state of the mount.
 Also this introduces some limitations which competative products may not have.
 
 The serial protocol was reverse engineered using serial port sniffing tools, developping this driver as a result. 
@@ -84,7 +84,7 @@ It is **important** that you put the scope in the Home position, Polar and Star 
 
 **Its vital in order to avoid damage to your Equipment. This Driver can not handle this for your!**
 
-**Also do not point your Telescope directly to the sun, using this driver. It only handles coordinates not objects, and will there for no prevent you from doing so!**
+**Also do not point your Telescope directly to the sun, without recommended protective equipment, using this driver. It only handles coordinates not objects, and will therefore no prevent you from looking directly in to the sun!**
 
 ---
 

--- a/indi-bresserexos2/SerialCommand.cpp
+++ b/indi-bresserexos2/SerialCommand.cpp
@@ -25,6 +25,10 @@
 
 using SerialDeviceControl::SerialCommand;
 
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+
 //TODO: change logging,
 #ifdef USE_CERR_LOGGING
 #include <iostream>
@@ -402,21 +406,28 @@ bool SerialCommand::GetSetDateTimeCommandMessage(
 
     buffer.push_back(SerialCommandID::SET_DATE_TIME_COMMAND_ID);
 
-    uint8_t hiYear = (uint8_t)(year / 100);
-    uint8_t loYear = (uint8_t)(year % 100);
-
     //when received the incomming byte is offset by -12 for some reason, so adjust for this. probably offset sign handling.
-    int8_t utc_shift = utc_offset + 12;
-
+   
+    
+    uint8_t local_hiYear = (uint8_t)(year / 100);
+    uint8_t local_loYear = (uint8_t)(year % 100);
+    uint8_t local_month = (uint8_t)month;
+    uint8_t local_day = (uint8_t)day;
+    
     //TODO: Be aware, the firmware only supports dates prior to 10000-01-01, please fix this at the appropriate time!
-    buffer.push_back(hiYear);
-    buffer.push_back(loYear);
-    buffer.push_back(month);
-    buffer.push_back(day);
+    buffer.push_back(local_hiYear);
+    buffer.push_back(local_loYear);
+    buffer.push_back(local_month);
+    buffer.push_back(local_day);
 
-    buffer.push_back(hour+utc_offset); //handbox uses local time as your clock shows, and calculates back to the UTC from that.
-    buffer.push_back(minute);
-    buffer.push_back(second);
+    uint8_t local_hour   = (uint8_t)hour;
+    uint8_t local_minute = (uint8_t)minute;
+    uint8_t local_second = (uint8_t)second;
+    uint8_t utc_shift    = (uint8_t)(utc_offset + 12);
+    
+    buffer.push_back(local_hour); //handbox uses local time as your clock shows, and calculates back to the UTC from that.
+    buffer.push_back(local_minute);
+    buffer.push_back(local_second);
     buffer.push_back(utc_shift); //TODO: offset range limiting...
 
     return true;

--- a/indi-bresserexos2/SerialCommand.cpp
+++ b/indi-bresserexos2/SerialCommand.cpp
@@ -34,22 +34,22 @@ using SerialDeviceControl::SerialCommand;
 #include <iostream>
 #endif
 
-#define ERROR_NULL_BUFFER ("error: buffer is null pointer.")
-#define ERROR_INVALID_RA_RANGE ("error: invalid range for right ascension.")
-#define ERROR_INVALID_DEC_RANGE ("error: invalid range for declination.")
-#define ERROR_INVALID_LAT_RANGE ("error: invalid range for latitude.")
-#define ERROR_INVALID_LON_RANGE ("error: invalid range for longitude.")
-#define ERROR_INVALID_YEAR_RANGE ("error: invalid range for year.")
-#define ERROR_INVALID_MONTH_RANGE ("error: invalid range for month.")
-#define ERROR_INVALID_DAY_RANGE ("error: invalid range for day.")
-#define ERROR_INVALID_HOUR_RANGE ("error: invalid range for hour.")
-#define ERROR_INVALID_MINUTE_RANGE ("error: invalid range for minute.")
-#define ERROR_INVALID_SECOND_RANGE ("error: invalid range for second.")
-#define ERROR_INVALID_RANGE_FEBURARY ("error: the february can only have 29 days at maximum!")
-#define ERROR_INVALID_RANGE_THIRTYONE ("error: the provided month can only have 31 days!")
-#define ERROR_INVALID_RANGE_THIRTY ("error: the provided month can only have 30 days!")
-#define ERROR_INVALID_RANGE_NO_LEAP_YEAR ("error: the provided date is invalid, februry can only have 29 days in leap years!")
-#define ERROR_INVALID_DIRECTION ("error: the direction provided is invalid!")
+#define ERROR_NULL_BUFFER ("buffer is null pointer.")
+#define ERROR_INVALID_RA_RANGE ("invalid range for right ascension.")
+#define ERROR_INVALID_DEC_RANGE ("invalid range for declination.")
+#define ERROR_INVALID_LAT_RANGE ("invalid range for latitude.")
+#define ERROR_INVALID_LON_RANGE ("invalid range for longitude.")
+#define ERROR_INVALID_YEAR_RANGE ("invalid range for year.")
+#define ERROR_INVALID_MONTH_RANGE ("invalid range for month.")
+#define ERROR_INVALID_DAY_RANGE ("invalid range for day.")
+#define ERROR_INVALID_HOUR_RANGE ("invalid range for hour.")
+#define ERROR_INVALID_MINUTE_RANGE ("invalid range for minute.")
+#define ERROR_INVALID_SECOND_RANGE ("invalid range for second.")
+#define ERROR_INVALID_RANGE_FEBURARY ("the february can only have 29 days at maximum!")
+#define ERROR_INVALID_RANGE_THIRTYONE ("the provided month can only have 31 days!")
+#define ERROR_INVALID_RANGE_THIRTY ("the provided month can only have 30 days!")
+#define ERROR_INVALID_RANGE_NO_LEAP_YEAR ("the provided date is invalid, februry can only have 29 days in leap years!")
+#define ERROR_INVALID_DIRECTION ("the direction provided is invalid!")
 
 
 uint8_t SerialCommand::MessageHeader[4] = {0x55, 0xaa, 0x01, 0x09};

--- a/indi-bresserexos2/SerialCommand.hpp
+++ b/indi-bresserexos2/SerialCommand.hpp
@@ -28,6 +28,8 @@
 #include <vector>
 #include <chrono>
 #include <cmath>
+#include <ctime>
+#include <libnova/julian_day.h>
 #include "config.h"
 
 #define MESSAGE_FRAME_SIZE (13)


### PR DESCRIPTION
Errors were made and fixed in time and location handling. 
This PR fixes: 
- 360° complement longitude handling for negative (westward) values.
- libnova now handles time and zone handling and should no longer provide wrong times to the handbox.
