### PR TITLE
Handle non-systemd systems. Fixes #440

### DIFF
--- a/debian/libpigpiod/postinst
+++ b/debian/libpigpiod/postinst
@@ -1,6 +1,8 @@
 #!/bin/sh
 # postinst script for indi-asi-power
 
-sudo systemctl daemon-reload
-sudo systemctl enable pigpiod.service
-sudo systemctl start pigpiod.service
+if [ -x /run/systemd/system ]; then
+    sudo systemctl daemon-reload
+    sudo systemctl enable pigpiod.service
+    sudo systemctl start pigpiod.service
+fi


### PR DESCRIPTION
This resolves issue related to installing libpigpiod on systems that do not boot with systemd e.g. dockerized system
