### PR TITLE
fix toupcam OEM bus id

### DIFF
--- a/indi-toupbase/oem_cameras.cpp
+++ b/indi-toupbase/oem_cameras.cpp
@@ -1402,7 +1402,7 @@ int OEMCamEnum(XP(DeviceV2) *cam_infos, int cam_infos_count)
 
         cam_infos[cnt].model = &cam->toupcam->model;
         strcpy(cam_infos[cnt].displayname, cam->name);
-        sprintf(cam_infos[cnt].id, "tp-%d-%d-%d-%d", libusb_get_port_number(dev),
+        sprintf(cam_infos[cnt].id, "tp-%d-%d-%d-%d", libusb_get_bus_number(dev),
             libusb_get_device_address(dev), desc.idVendor, cam->toupcam->pid);
         cnt++;
     }


### PR DESCRIPTION
There was a bug in the original change that added the OEM camera support. Apparently I was getting lucky with the port that I was plugging my camera into.