### PR TITLE
Adopt ASI driver to simulator behavior and like QHY driver

### DIFF
--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -229,7 +229,11 @@ void ASIBase::workerExposure(const std::atomic_bool &isAboutToQuit, float durati
             timeLeft = std::round(timeLeft);
         }
 
-        PrimaryCCD.setExposureLeft(timeLeft);
+        if (timeLeft > 0)
+        {
+            PrimaryCCD.setExposureLeft(timeLeft);
+        }
+        
         usleep(delay * 1000 * 1000);
 
         ASI_ERROR_CODE ret = ASIGetExpStatus(mCameraInfo.CameraID, &status);
@@ -268,7 +272,7 @@ void ASIBase::workerExposure(const std::atomic_bool &isAboutToQuit, float durati
     // Reset exposure retry
     mExposureRetry = 0;
     PrimaryCCD.setExposureLeft(0.0);
-    if (PrimaryCCD.getExposureDuration() > 3)
+    if (PrimaryCCD.getExposureDuration() > VERBOSE_EXPOSURE)
         LOG_INFO("Exposure done, downloading image...");
 
     grabImage(duration);


### PR DESCRIPTION
Hi Jasem,

based on our discussion on INDI forum, I cleaned up the VERBOSE_EXPOSURE time as constant and adjusted the sending of CCD_EXPOSURE = 0 only if the exposure is finished. The solution is used in the QHY driver as well, which also only reports CCD_EXPOSURE back if timeLeft is bigger than 0.0049 s. Both driver set the CCD_EPOSURE value to 0 explicit anyway if exposure is finished.
I cannot build myself, so please review an accept if ok or comment if wrong.

Michel 