### PR TITLE
Updated indi-gige to compile with aravis 0.8

### DIFF
--- a/cmake_modules/FindARAVIS.cmake
+++ b/cmake_modules/FindARAVIS.cmake
@@ -19,15 +19,15 @@
 
 SET(ARV_FIND_REQUIRED ${Arv_FIND_REQUIRED})
 
-find_path(ARV_INCLUDE_DIR aravis-0.6/arv.h)
+find_path(ARV_INCLUDE_DIR aravis-0.8/arv.h)
 mark_as_advanced(ARV_INCLUDE_DIR)
 
-set(ARV_NAMES ${ARV_NAMES} aravis-0.6)
+set(ARV_NAMES ${ARV_NAMES} aravis-0.8)
 find_library(ARV_LIBRARY NAMES ${ARV_NAMES} )
 mark_as_advanced(ARV_LIBRARY)
 
 set(ARV_VERSION_MAJOR "0")
-set(ARV_VERSION_MINOR "6")
+set(ARV_VERSION_MINOR "8")
 set(ARV_VERSION_STRING "${ARV_VERSION_MAJOR}.${ARV_VERSION_MINOR}")
 
 # handle the QUIETLY and REQUIRED arguments and set ARV_FOUND to TRUE if
@@ -37,7 +37,7 @@ find_package_handle_standard_args(ARV DEFAULT_MSG ARV_LIBRARY ARV_INCLUDE_DIR)
 
 IF(ARV_FOUND)
     #SET(Arv_LIBRARIES ${ARV_LIBRARY})
-    SET(Arv_LIBRARIES "aravis-0.6")
-    SET(Arv_INCLUDE_DIRS "${ARV_INCLUDE_DIR}/aravis-0.6")
+    SET(Arv_LIBRARIES "aravis-0.8")
+    SET(Arv_INCLUDE_DIRS "${ARV_INCLUDE_DIR}/aravis-0.8")
     MESSAGE (STATUS "Found aravis: ${Arv_LIBRARIES} ${Arv_INCLUDE_DIRS}")
 ENDIF(ARV_FOUND)

--- a/indi-gige/src/ArvFactory.cpp
+++ b/indi-gige/src/ArvFactory.cpp
@@ -28,8 +28,9 @@
 
 arv::ArvCamera *ArvFactory::find_first_available(void)
 {
-    ::ArvCamera *camera    = arv_camera_new(nullptr);
-    const char *model_name = arv_camera_get_model_name(camera);
+    GError *error = NULL;
+    ::ArvCamera *camera    = arv_camera_new(nullptr, &error);
+    const char *model_name = arv_camera_get_model_name(camera, &error);
 
     if ((camera == nullptr) || (model_name == nullptr))
         return nullptr;

--- a/indi-gige/src/ArvGeneric.h
+++ b/indi-gige/src/ArvGeneric.h
@@ -19,11 +19,11 @@
 #ifndef CPP_ARV_GENERIC_H
 #define CPP_ARV_GENERIC_H
 
-extern "C" {
+//#extern "C" {
 #include <stddef.h>
 #include <stdio.h>
 #include <arv.h>
-}
+//}
 
 #include "ArvInterface.h"
 
@@ -71,9 +71,9 @@ class ArvGeneric : public arv::ArvCamera
     bool _configure(void);
     void _test_exposure_and_abort(void);
     template <typename T>
-    bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max), min_max_property<T> *prop);
+    bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop);
     template <typename T>
-    void _set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T), min_max_property<T> *prop, T const new_val);
+    void _set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**), min_max_property<T> *prop, T const new_val);
 
     const char *_str_val(const char *s);
     bool _get_initial_config();
@@ -85,6 +85,7 @@ class ArvGeneric : public arv::ArvCamera
     ::ArvDevice *dev;
     ::ArvStream *stream;
     ::ArvBuffer *buffer;
+    ::GError *error;
 
     /* streaming, capturing functions */
     ::ArvStream *_stream_create(void);


### PR DESCRIPTION
The current version of Aravis introduced an addition error parameter in its function calls. This parameter has been added and the CMake dependencies updated to aravis 0.8. See #464 