### PR TITLE
qhyccd-21: libqhy now builds libqhy version 21, not 20

### DIFF
--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -13,7 +13,7 @@ Source0: https://github.com/indilib/indi-3rdparty/archive/master.tar.gz
 %global debug_package %{nil}
 %define __find_requires %{nil}
 
-Provides: libqhyccd.so.20()(64bit)
+Provides: libqhyccd.so.21()(64bit)
 Provides: libqhyccd.so
 
 BuildRequires: cmake


### PR DESCRIPTION
I also wonder if we can just remove the version and say that the package provides libqhyccd.so by itself and let the version float. Either way, this request is more accurate and should fix packages for Fedora 33 and 34.