### PR TITLE
indi_playerone: Fix wrong pixel value except for RAW8

### DIFF
--- a/debian/indi-playerone/changelog
+++ b/debian/indi-playerone/changelog
@@ -1,3 +1,9 @@
+indi-playerone (0.3) bionic; urgency=medium
+
+  * Fix wrong pixel value except for RAW8
+
+ -- Hiroshi SAITO <hiro3110g@gmail.com>  Tue, 19 Oct 2021 12:00:00 +0900
+
 indi-playerone (0.2) bionic; urgency=low
 
   * Initial Release.

--- a/indi-playerone/CMakeLists.txt
+++ b/indi-playerone/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(PLAYERONE_VERSION_MAJOR 0)
-set(PLAYERONE_VERSION_MINOR 2)
+set(PLAYERONE_VERSION_MINOR 3)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_playerone.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_playerone.xml)

--- a/indi-playerone/ChangeLog
+++ b/indi-playerone/ChangeLog
@@ -1,3 +1,7 @@
+v0.3
+* BugFix: worng pixel value except for RAW8
+  BugFix: order of image format and buffer size in playerone_camera_test.cpp
+
 v0.2
 * BugFix: pulse guide implementation and user interface in "Controls" tab
   BugFix: temperature digit in playerone_camera_test.cpp

--- a/indi-playerone/README.md
+++ b/indi-playerone/README.md
@@ -44,7 +44,7 @@ The PlayerOne Cameras are very USB bandwidth hungry when running at high
 FPS. If you see "broken frames" with more that one of them running,
 keep in mind this important aspect.
 
-ASICameras continuously generate frames and they are buffered in the
+PlayerOne Cameras continuously generate frames and they are buffered in the
 driver. To avoid having frames with old parameters when these are
 changed, a flushing mechanism is employed. It looks OK, but if you
 find any problem with parameters changes not being immediately applied

--- a/indi-playerone/playerone_camera_test.cpp
+++ b/indi-playerone/playerone_camera_test.cpp
@@ -29,7 +29,7 @@
 int  main()
 {
     int width, height;
-    const char *formats[] = {"RAW 8-bit", "RGB 24-bit", "RAW 16-bit", "Luma 8-bit" };
+    const char *formats[] = {"RAW 8-bit", "RAW 16-bit", "RGB 24-bit", "Luma 8-bit" };
     int CamNum = 0;
 
     int numDevices = POAGetCameraCount();
@@ -129,7 +129,10 @@ int  main()
     POAGetImageBin(CamNum, &bin);
     POAGetImageFormat(CamNum, (POAImgFormat*)&imageFormat);
 
-    long imgSize = width * height * (1 + (imageFormat == POA_RAW16));
+    long imgSize = width * height;
+    if (imageFormat == POA_RAW16) imgSize *= 2;
+    else if (imageFormat == POA_RGB24) imgSize *= 3;
+
     unsigned char* imgBuf = new unsigned char[imgSize];
 
     POAConfigValue confVal;

--- a/indi-playerone/playerone_ccd.cpp
+++ b/indi-playerone/playerone_ccd.cpp
@@ -1212,6 +1212,13 @@ bool POACCD::UpdateCCDFrame(int x, int y, int w, int h)
         return false;
     }
 
+    ret = POASetImageFormat(mCameraInfo.cameraID, getImageType());
+    if (ret != POA_OK)
+    {
+        LOGF_ERROR("Failed to set ROI image format (%s).", Helpers::toString(ret));
+        return false;
+    }
+    
     ret = POASetImageStartPos(mCameraInfo.cameraID, subX, subY);
     if (ret != POA_OK)
     {


### PR DESCRIPTION
I have fixed wrong pixel value except for RAW8 in indi_playerone camera driver.
I confirmed that the FITS file can also be generated correctly for RAW8/RAW16/RGB24/MONO8.
In addition, I also corrected playerone_camera_test.cpp.
Version is increased to v0.3 now.
Could you please check it?