### PR TITLE
Allows ASI EFW, which is an MDPD driver, to support aliasing in conjunction with a symbolic link

### DIFF
--- a/indi-asi/asi_wheel.cpp
+++ b/indi-asi/asi_wheel.cpp
@@ -30,6 +30,11 @@
  file called LICENSE.
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // for program_invocation_short_name used in Loader()
+#endif//_GNU_SOURCE
+
+
 #include "asi_wheel.h"
 
 #include "config.h"
@@ -38,6 +43,11 @@
 #include <unistd.h>
 #include <deque>
 #include <memory>
+
+#ifdef  _GNU_SOURCE
+#include <errno.h>
+#include <ctype.h>
+#endif//_GNU_SOURCE
 
 //#define SIMULATION
 
@@ -79,6 +89,24 @@ public:
                 continue;
             }
             std::string name = "ASI " + std::string(info.Name);
+#ifdef  _GNU_SOURCE
+	    {
+#define EFW_ASI_DFLT_DVR "indi_asi_wheel"
+
+		char *cptr;
+		if ((cptr = strstr(program_invocation_short_name, EFW_ASI_DFLT_DVR)) == program_invocation_short_name) { // i.e., startsWith
+		    cptr += strlen(EFW_ASI_DFLT_DVR);
+		    while (*cptr != '\0') {
+			if (isalnum(*cptr)) {
+			    name += (char)toupper(*cptr);
+			} else {
+			    name += " ";
+			}
+			cptr++;
+		    }
+		}
+	    }
+#endif//_GNU_SOURCE
             if (num_wheels > 1)
                 name += " " + std::to_string(i);
             wheels.push_back(std::unique_ptr<ASIWHEEL>(new ASIWHEEL(info, name.c_str())));


### PR DESCRIPTION
Since the ASI EFW driver is MDPD, it does not support aliasing in KStars "Tools->Devices->Custom Drivers...". Normally the ASI EFW label shows up as "ASI EFW" no matter what is placed into the alias field of a Custom Driver request. The changes here allow a work-around. If one creates a symbolic link to /usr/bin/indi_asi_wheel that adds to the name, for example /usr/bin/indi_asi_wheel_color, then any characters after the standard name (indi_asi_wheel) are appended to the standard label (ASI EFW) as follows: each alphanumeric is converted to upper-case and each non-alphanumeric is converted to space. Thus for the above, the label would become ASI EFW COLOR.

Note: MDPD behavior is unchanged, namely if two ASI filter wheels are attached at the same time, two instances will appear in the profiles with digits 0 or 1 (separated by a space) appended to the label. So, in this case, ASI EFW COLOR 0 and ASI EFW COLOR 1.

To access the driver with this label, one creates a Custom Driver entry as follows:

1. Since MDPD drivers do not appear in the Custom Drivers pull-down menu, one types it in to the "Driver" field and hits <RETURN> so that the remaining fields are updated. In this case the driver field entry would be ASI EFW.
2. The driver file name in the "Executable" field (in this case, indi_asi_wheel) should be extended to match the name of a symbolic link file the user has created in /usr/bin that links back to /usr/bin/indi_asi_wheel. For example, indi_asi_wheel_color.
3. Fill in the "Label" field with the value in "Name" (in this case, ASI EFW) and extend it with an upper-case version of the added portion of the file name with non-alphanumerics becoming spaces (in this case, " COLOR" so that the "Label" field ends up containing ASI EFW COLOR.
4. Hit "Add New".
5. Repeat as needed to add other variations (e.g., indi_asi_wheel_mono and ASI EFW MONO)
6. Quit and restart KStars so that the changes propagate.
7. Now when creating a new profile, Filter Wheel choices will include: ASI EFW, ASI EFW COLOR and ASI EFW MONO.

Thus profiles will not have filter name entries over-written each time one goes between filters being used with a monochrome camera and filters being used with a one-shot-color camera.

While not perfect and somewhat constrained, this workaround to the MDPD alias restriction without the need for a user to create custom code and executable.