### PR TITLE
Update qhy_ccd.cpp

### DIFF
--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -978,18 +978,26 @@ bool QHYCCD::Connect()
         //if(ret != QHYCCD_ERROR && ret != QHYCCD_ERROR_NOTSUPPORT)
         if (ret != QHYCCD_ERROR)
         {
-            if (ret == BAYER_GB)
+            if (ret == BAYER_GB){
                 IUSaveText(&BayerT[2], "GBRG");
-            else if (ret == BAYER_GR)
+                cap |= CCD_HAS_BAYER;
+            }
+            else if (ret == BAYER_GR){
                 IUSaveText(&BayerT[2], "GRBG");
-            else if (ret == BAYER_BG)
+                cap |= CCD_HAS_BAYER;
+            }
+            else if (ret == BAYER_BG){
                 IUSaveText(&BayerT[2], "BGGR");
-            else
+                cap |= CCD_HAS_BAYER;
+            }
+            else if (ret == BAYER_RG){
                 IUSaveText(&BayerT[2], "RGGB");
+                cap |= CCD_HAS_BAYER;
+            }
 
             LOGF_DEBUG("Color camera: %s", BayerT[2].text);
 
-            cap |= CCD_HAS_BAYER;
+            
         }
 
         ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Found the issue with my QHY 600m showing up with a BAYER pattern.

Looked at the original code and it seems it wasn't complete.

I edited the code and cleaned it up a bit.

I have tested with both my QHY600m and it now shows up as a mono camera, and I have tested with my QHY247c and it shows up as color with proper BAYER pattern now.

@knro please review when you can.
