### PR TITLE
Lxstargo

### DIFF
--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2015,8 +2015,7 @@ bool LX200StarGo::setTrackingAdjustment(double adjustRA)
     int parameter = static_cast<int>(adjustRA * 100);
     sprintf(cmd, ":X41%+04i#", parameter);
 
-//    if(!transmit(cmd))
-    char response[AVALON_RESPONSE_BUFFER_LENGTH];
+    char response[AVALON_RESPONSE_BUFFER_LENGTH] = {0};
     if(!sendQuery(cmd, response, 0))  // No response
     {
         LOGF_ERROR("Cannot adjust tracking by %d%%", adjustRA);

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2013,7 +2013,7 @@ bool LX200StarGo::setTrackingAdjustment(double adjustRA)
     }
 
     int parameter = static_cast<int>(adjustRA * 100);
-    sprintf(cmd, ":X41%+03i#", parameter);
+    sprintf(cmd, ":X41%+04i#", parameter);
 
 //    if(!transmit(cmd))
     char response[AVALON_RESPONSE_BUFFER_LENGTH];

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2015,7 +2015,9 @@ bool LX200StarGo::setTrackingAdjustment(double adjustRA)
     int parameter = static_cast<int>(adjustRA * 100);
     sprintf(cmd, ":X41%+03i#", parameter);
 
-    if(!transmit(cmd))
+//    if(!transmit(cmd))
+    char response[AVALON_RESPONSE_BUFFER_LENGTH];
+    if(!sendQuery(cmd, response, 0))  // No response
     {
         LOGF_ERROR("Cannot adjust tracking by %d%%", adjustRA);
         return false;

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -574,6 +574,17 @@ bool LX200StarGo::ReadScopeStatus()
         }
     }
 
+    double raCorrection;
+    if (getTrackingAdjustment(&raCorrection))
+    {
+        TrackingAdjustment[0].value = raCorrection;
+        TrackingAdjustmentNP.s      = IPS_OK;
+    }
+    else
+        TrackingAdjustmentNP.s = IPS_ALERT;
+
+    IDSetNumber(&TrackingAdjustmentNP, nullptr);
+
     double r, d;
     if(!getEqCoordinates(&r, &d))
     {


### PR DESCRIPTION
Fixes to RA Tracking Adjustment functionality.
Add get function to ReadScopeStatus() so that changes are shown/confirmed in the control panel
Use SendQuery() to send the command as standard instead of low level transmit()
Fix format of set command as zeroes were incorrectly formatted

Tested on M-Uno