### PR TITLE
QHY174GPS - Strange correlation between SlaveGPS and the cooler 

### DIFF
--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -31,7 +31,7 @@
 #include <memory>
 #include <deque>
 
-#define UPDATE_THRESHOLD       0.2   /* Differential temperature threshold (C)*/
+#define UPDATE_THRESHOLD       0.05   /* Differential temperature threshold (C)*/
 
 //NB Disable for real driver
 //#define USE_SIMULATION
@@ -813,18 +813,18 @@ bool QHYCCD::Connect()
             cap |= CCD_HAS_SHUTTER;
         }
 
-        LOGF_INFO("Shutter Control: %s", (cap & CCD_HAS_SHUTTER) ? "True" : "False");
+        LOGF_DEBUG("Shutter Control: %s", (cap & CCD_HAS_SHUTTER) ? "True" : "False");
 
-        // ////////////////////////////////////////////////////////////////////
-        // /// Streaming Support
-        // ////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////
+        /// Streaming Support
+        ////////////////////////////////////////////////////////////////////
         ret = IsQHYCCDControlAvailable(m_CameraHandle, CAM_LIVEVIDEOMODE);
         if (ret == QHYCCD_SUCCESS)
         {
             cap |= CCD_HAS_STREAMING;
         }
 
-        LOGF_INFO("Has Streaming: %s", (cap & CCD_HAS_STREAMING) ? "True" : "False");
+        LOGF_DEBUG("Has Streaming: %s", (cap & CCD_HAS_STREAMING) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// AutoMode Cooler Support
@@ -835,7 +835,7 @@ bool QHYCCD::Connect()
             HasCoolerAutoMode = true;
             cap |= CCD_HAS_COOLER;
         }
-        LOGF_INFO("Automatic Cooler Control: %s", (cap & CCD_HAS_COOLER) ? "True" : "False");
+        LOGF_DEBUG("Automatic Cooler Control: %s", (cap & CCD_HAS_COOLER) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Manual PWM Support
@@ -845,7 +845,7 @@ bool QHYCCD::Connect()
         {
             HasCoolerManualMode = true;
         }
-        LOGF_INFO("Manual Cooler Control: %s", HasCoolerManualMode ? "True" : "False");
+        LOGF_DEBUG("Manual Cooler Control: %s", HasCoolerManualMode ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// ST4 Port Support
@@ -856,7 +856,7 @@ bool QHYCCD::Connect()
             cap |= CCD_HAS_ST4_PORT;
         }
 
-        LOGF_INFO("Guider Port Control: %s", (cap & CCD_HAS_ST4_PORT) ? "True" : "False");
+        LOGF_DEBUG("Guider Port Control: %s", (cap & CCD_HAS_ST4_PORT) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Camera Speed Support
@@ -874,7 +874,7 @@ bool QHYCCD::Connect()
                 SetQHYCCDParam(m_CameraHandle, CONTROL_SPEED, 1);
         }
 
-        LOGF_INFO("USB Speed Control: %s", HasUSBSpeed ? "True" : "False");
+        LOGF_DEBUG("USB Speed Control: %s", HasUSBSpeed ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Gain Support
@@ -1026,16 +1026,17 @@ bool QHYCCD::Connect()
 
         ////////////////////////////////////////////////////////////////////
         /// GPS Support
-        //////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////////////////////
         ret = IsQHYCCDControlAvailable(m_CameraHandle, CAM_GPS);
         // JM 2021.07.25: CAM_GPS is returned as true even when there is no GPS.
-        // This bug was reported to QHY and awaiting a fix. Currently limiting GSP to QHY174 only.
-        if ( ret == QHYCCD_SUCCESS && strstr(m_CamID, "174"))
+        // This bug was reported to QHY and awaiting a fix. Currently limiting 
+        // GSP to QHY174 only.
+        if (ret == QHYCCD_SUCCESS && strstr(m_CamID, "174"))
         {
             HasGPS = true;
         }
 
-        LOGF_WARN("GPS Support: %s", HasGPS ? "True" : "False");
+        LOGF_DEBUG("GPS Support: %s", HasGPS ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Humidity Support
@@ -2570,7 +2571,7 @@ void QHYCCD::streamVideo()
             if (HasGPS && GPSControlS[INDI_ENABLED].s == ISS_ON)
                 decodeGPSHeader();
 
-            
+            // DEBUG
             // if(!frames)
             //    LOGF_DEBUG("Receiving frames ...");
             // if(!(++frames % 30))

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -31,7 +31,7 @@
 #include <memory>
 #include <deque>
 
-#define UPDATE_THRESHOLD       0.05   /* Differential temperature threshold (C)*/
+#define UPDATE_THRESHOLD       0.2   /* Differential temperature threshold (C)*/
 
 //NB Disable for real driver
 //#define USE_SIMULATION
@@ -378,8 +378,8 @@ void QHYCCD::ISGetProperties(const char *dev)
 
         if (HasGPS)
         {
-            defineProperty(&GPSSlavingSP);
-            defineProperty(&GPSSlavingParamNP);
+            // defineProperty(&GPSSlavingSP);
+            // defineProperty(&GPSSlavingParamNP);
 
             defineProperty(&VCOXFreqNP);
             defineProperty(&GPSLEDCalibrationSP);
@@ -592,8 +592,8 @@ bool QHYCCD::updateProperties()
 
         if (HasGPS)
         {
-            defineProperty(&GPSSlavingSP);
-            defineProperty(&GPSSlavingParamNP);
+            // defineProperty(&GPSSlavingSP);
+            // defineProperty(&GPSSlavingParamNP);
             defineProperty(&VCOXFreqNP);
             defineProperty(&GPSLEDCalibrationSP);
             defineProperty(&GPSLEDStartPosNP);
@@ -668,8 +668,8 @@ bool QHYCCD::updateProperties()
 
         if (HasGPS)
         {
-            deleteProperty(GPSSlavingSP.name);
-            deleteProperty(GPSSlavingParamNP.name);
+            // deleteProperty(GPSSlavingSP.name);
+            // deleteProperty(GPSSlavingParamNP.name);
             deleteProperty(VCOXFreqNP.name);
             deleteProperty(GPSLEDCalibrationSP.name);
             deleteProperty(GPSLEDStartPosNP.name);
@@ -813,18 +813,18 @@ bool QHYCCD::Connect()
             cap |= CCD_HAS_SHUTTER;
         }
 
-        LOGF_DEBUG("Shutter Control: %s", (cap & CCD_HAS_SHUTTER) ? "True" : "False");
+        LOGF_INFO("Shutter Control: %s", (cap & CCD_HAS_SHUTTER) ? "True" : "False");
 
-        ////////////////////////////////////////////////////////////////////
-        /// Streaming Support
-        ////////////////////////////////////////////////////////////////////
+        // ////////////////////////////////////////////////////////////////////
+        // /// Streaming Support
+        // ////////////////////////////////////////////////////////////////////
         ret = IsQHYCCDControlAvailable(m_CameraHandle, CAM_LIVEVIDEOMODE);
         if (ret == QHYCCD_SUCCESS)
         {
             cap |= CCD_HAS_STREAMING;
         }
 
-        LOGF_DEBUG("Has Streaming: %s", (cap & CCD_HAS_STREAMING) ? "True" : "False");
+        LOGF_INFO("Has Streaming: %s", (cap & CCD_HAS_STREAMING) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// AutoMode Cooler Support
@@ -835,7 +835,7 @@ bool QHYCCD::Connect()
             HasCoolerAutoMode = true;
             cap |= CCD_HAS_COOLER;
         }
-        LOGF_DEBUG("Automatic Cooler Control: %s", (cap & CCD_HAS_COOLER) ? "True" : "False");
+        LOGF_INFO("Automatic Cooler Control: %s", (cap & CCD_HAS_COOLER) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Manual PWM Support
@@ -845,7 +845,7 @@ bool QHYCCD::Connect()
         {
             HasCoolerManualMode = true;
         }
-        LOGF_DEBUG("Manual Cooler Control: %s", HasCoolerManualMode ? "True" : "False");
+        LOGF_INFO("Manual Cooler Control: %s", HasCoolerManualMode ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// ST4 Port Support
@@ -856,7 +856,7 @@ bool QHYCCD::Connect()
             cap |= CCD_HAS_ST4_PORT;
         }
 
-        LOGF_DEBUG("Guider Port Control: %s", (cap & CCD_HAS_ST4_PORT) ? "True" : "False");
+        LOGF_INFO("Guider Port Control: %s", (cap & CCD_HAS_ST4_PORT) ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Camera Speed Support
@@ -874,7 +874,7 @@ bool QHYCCD::Connect()
                 SetQHYCCDParam(m_CameraHandle, CONTROL_SPEED, 1);
         }
 
-        LOGF_DEBUG("USB Speed Control: %s", HasUSBSpeed ? "True" : "False");
+        LOGF_INFO("USB Speed Control: %s", HasUSBSpeed ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Gain Support
@@ -1026,16 +1026,16 @@ bool QHYCCD::Connect()
 
         ////////////////////////////////////////////////////////////////////
         /// GPS Support
-        ////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////
         ret = IsQHYCCDControlAvailable(m_CameraHandle, CAM_GPS);
         // JM 2021.07.25: CAM_GPS is returned as true even when there is no GPS.
         // This bug was reported to QHY and awaiting a fix. Currently limiting GSP to QHY174 only.
-        if (ret == QHYCCD_SUCCESS && strstr(m_CamID, "174"))
+        if ( ret == QHYCCD_SUCCESS && strstr(m_CamID, "174"))
         {
             HasGPS = true;
         }
 
-        LOGF_DEBUG("GPS Support: %s", HasGPS ? "True" : "False");
+        LOGF_WARN("GPS Support: %s", HasGPS ? "True" : "False");
 
         ////////////////////////////////////////////////////////////////////
         /// Humidity Support
@@ -2570,10 +2570,10 @@ void QHYCCD::streamVideo()
             if (HasGPS && GPSControlS[INDI_ENABLED].s == ISS_ON)
                 decodeGPSHeader();
 
-            //DEBUG
-            //if(!frames)
+            
+            // if(!frames)
             //    LOGF_DEBUG("Receiving frames ...");
-            //if(!(++frames % 30))
+            // if(!(++frames % 30))
             //    LOGF_DEBUG("Frames received: %d (%.1f fps)", frames, 1.0 * frames / (time(NULL) - t_start));
         }
         pthread_mutex_lock(&condMutex);
@@ -2759,10 +2759,10 @@ void QHYCCD::addFITSKeywords(fitsfile *fptr, INDI::CCDChip *targetChip)
         // GPS Status
 
         // System Clock Offset
-        //fits_update_key_dbl(fptr, "GPS_DSYS", GPSHeader.now_us, 6, "System Clock - GPS Clock Offset (s)", &status);
+        fits_update_key_dbl(fptr, "GPS_DSYS", GPSHeader.now_us, 6, "System Clock - GPS Clock Offset (s)", &status);
 
         // Time Offset Stable for
-        //fits_update_key_lng(fptr, "GPS_DSTB", GPSHeader.max_clock, "Time Offset Stable for (s)", &status);
+        fits_update_key_lng(fptr, "GPS_DSTB", GPSHeader.max_clock, "Time Offset Stable for (s)", &status);
 
         // Longitude
         fits_update_key_dbl(fptr, "GPS_LONG", GPSHeader.longitude, 3, "GPS Longitude", &status);


### PR DESCRIPTION
Dear @knro and who it may concern in the QHY-driver devs operations,

I've decided to open this PR to focus your attention on a strange correlation that I experienced with my QHY174GPS and SDK version 21.10.12. After acquiring the QHY174.img firmware with `fxload`, the camera set the sensor temperature at 0 degC. The cooler stops working just after I connect the camera to Ekos. I opened the driver code and started to find the piece of code that crashed the cooling process. I have to notify you that if you comment the lines that get the GPS properties in slave mode, the cooling works fine, and everything generally works. 

I don't know the deep reasons for that behavior. Maybe it could be related to the QHY174.img firmware and its interactions with the driver calls. So I would like to prompt the QHY devs to the situation I pointed out. 

Since I can directly test the changes on my qhy174 GPS camera, I can work on the driver code, although the problem could be in the firmware.

Let me know your opinion. We could use this pull request to gather all the possible solutions. Now, I have just commented the lines for getting the GPS slave properties so far.

Stefano.