### PR TITLE
DRAFT: Celestron aux refactor

### DIFF
--- a/indi-celestronaux/CMakeLists.txt
+++ b/indi-celestronaux/CMakeLists.txt
@@ -12,8 +12,8 @@ find_package(Nova REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
-set(CAUX_VERSION_MAJOR 0)
-set(CAUX_VERSION_MINOR 10)
+set(CAUX_VERSION_MAJOR 1)
+set(CAUX_VERSION_MINOR 0)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_celestronaux.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_celestronaux.xml )

--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -413,25 +413,27 @@ unsigned char AUXCommand::checksum(AUXBuffer buf)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
-/// One definition rule (ODR) constants
-/// AUX commands use 24bit integer as a representation of angle in units of
-/// fractional revolutions. Thus 2^24 steps makes full revolution.
-/// Return encoder position in steps.
+/// Return 8, 16, or 24bit value as dictacted by the data response size.
 /////////////////////////////////////////////////////////////////////////////////////
-uint32_t AUXCommand::getData(uint8_t bytes)
+uint32_t AUXCommand::getData()
 {
-    if (m_Data.size() == 3)
+    uint32_t value = 0;
+    switch (m_Data.size())
     {
-        int32_t a = static_cast<int8_t>(m_Data[0]);
-        a <<= 16;
-        a |= static_cast<uint32_t>(m_Data[1]) << 8;
-        a |= static_cast<uint32_t>(m_Data[2]);
-        return a;
+        case 3:
+            value = (m_Data[0] << 16) | (m_Data[1] << 8) | m_Data[2];
+            break;
+
+        case 2:
+            value = (m_Data[0] << 8) | m_Data[1];
+            break;
+
+        case 1:
+            value = m_Data[0];
+            break;
     }
-    else
-    {
-        return 0;
-    }
+
+    return value;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -42,7 +42,9 @@ char AUXCommand::DEVICE_NAME[64] = {0};
 /////// Utility functions
 //////////////////////////////////////////////////
 
-
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void logBytes(unsigned char *buf, int n, const char *deviceName, uint32_t debugLevel)
 {
     char hex_buffer[BUFFER_SIZE] = {0};
@@ -55,98 +57,83 @@ void logBytes(unsigned char *buf, int n, const char *deviceName, uint32_t debugL
     DEBUGFDEVICE(deviceName, debugLevel, "[%s]", hex_buffer);
 }
 
-//void AUXCommand::logResponse(AUXBuffer buf)
-//{
-//    char hex_buffer[BUFFER_SIZE] = {0};
-//    for (size_t i = 0; i < buf.size(); i++)
-//        sprintf(hex_buffer + 3 * i, "%02X ", buf[i]);
-
-//    if (buf.size() > 0)
-//        hex_buffer[3 * buf.size() - 1] = '\0';
-
-//    DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "MSG: %s", hex_buffer);
-//}
-
-//void AUXCommand::logCommand()
-//{
-//    char hex_buffer[BUFFER_SIZE] = {0};
-//    for (size_t i = 0; i < data.size(); i++)
-//        sprintf(hex_buffer + 3 * i, "%02X ", data[i]);
-
-//    if (data.size() > 0)
-//        hex_buffer[3 * data.size() - 1] = '\0';
-
-//    DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "<%02x> %02x -> %02x: %s", cmd, src, dst, hex_buffer);
-//}
-
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::logResponse()
 {
     char hex_buffer[BUFFER_SIZE] = {0}, part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
-    for (size_t i = 0; i < data.size(); i++)
-        sprintf(hex_buffer + 3 * i, "%02X ", data[i]);
+    for (size_t i = 0; i < m_Data.size(); i++)
+        sprintf(hex_buffer + 3 * i, "%02X ", m_Data[i]);
 
-    if (data.size() > 0)
-        hex_buffer[3 * data.size() - 1] = '\0';
+    if (m_Data.size() > 0)
+        hex_buffer[3 * m_Data.size() - 1] = '\0';
 
-    const char * c = cmd_name(cmd);
-    const char * s = node_name(src);
-    const char * d = node_name(dst);
+    const char * c = commandName(m_Command);
+    const char * s = moduleName(m_Source);
+    const char * d = moduleName(m_Destination);
 
     if (c != nullptr)
         snprintf(part1, BUFFER_SIZE, "<%12s>", c);
     else
-        snprintf(part1, BUFFER_SIZE, "<%02x>", cmd);
+        snprintf(part1, BUFFER_SIZE, "<%02x>", m_Command);
 
     if (s != nullptr)
         snprintf(part2, BUFFER_SIZE, "%5s ->", s);
     else
-        snprintf(part2, BUFFER_SIZE, "%02x ->", src);
+        snprintf(part2, BUFFER_SIZE, "%02x ->", m_Source);
 
     if (s != nullptr)
         snprintf(part3, BUFFER_SIZE, "%5s", d);
     else
-        snprintf(part3, BUFFER_SIZE, "%02x", dst);
+        snprintf(part3, BUFFER_SIZE, "%02x", m_Destination);
 
-    if (data.size() > 0)
+    if (m_Data.size() > 0)
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "RES %s%s%s [%s]", part1, part2, part3, hex_buffer);
     else
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "RES %s%s%s", part1, part2, part3);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::logCommand()
 {
     char hex_buffer[BUFFER_SIZE] = {0}, part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
-    for (size_t i = 0; i < data.size(); i++)
-        sprintf(hex_buffer + 3 * i, "%02X ", data[i]);
+    for (size_t i = 0; i < m_Data.size(); i++)
+        sprintf(hex_buffer + 3 * i, "%02X ", m_Data[i]);
 
-    if (data.size() > 0)
-        hex_buffer[3 * data.size() - 1] = '\0';
+    if (m_Data.size() > 0)
+        hex_buffer[3 * m_Data.size() - 1] = '\0';
 
-    const char * c = cmd_name(cmd);
-    const char * s = node_name(src);
-    const char * d = node_name(dst);
+    const char * c = commandName(m_Command);
+    const char * s = moduleName(m_Source);
+    const char * d = moduleName(m_Destination);
 
     if (c != nullptr)
         snprintf(part1, BUFFER_SIZE, "<%12s>", c);
     else
-        snprintf(part1, BUFFER_SIZE, "<%02x>", cmd);
+        snprintf(part1, BUFFER_SIZE, "<%02x>", m_Command);
 
     if (s != nullptr)
         snprintf(part2, BUFFER_SIZE, "%5s ->", s);
     else
-        snprintf(part2, BUFFER_SIZE, "%02x ->", src);
+        snprintf(part2, BUFFER_SIZE, "%02x ->", m_Source);
 
     if (s != nullptr)
         snprintf(part3, BUFFER_SIZE, "%5s", d);
     else
-        snprintf(part3, BUFFER_SIZE, "%02x", dst);
+        snprintf(part3, BUFFER_SIZE, "%02x", m_Destination);
 
-    if (data.size() > 0)
+    if (m_Data.size() > 0)
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "CMD %s%s%s [%s]", part1, part2, part3, hex_buffer);
     else
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "CMD %s%s%s", part1, part2, part3);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::setDebugInfo(const char *deviceName, uint8_t debugLevel)
 {
     strncpy(DEVICE_NAME, deviceName, 64);
@@ -158,39 +145,51 @@ void AUXCommand::setDebugInfo(const char *deviceName, uint8_t debugLevel)
 
 AUXCommand::AUXCommand()
 {
-    data.reserve(MAX_CMD_LEN);
+    m_Data.reserve(MAX_CMD_LEN);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 AUXCommand::AUXCommand(const AUXBuffer &buf)
 {
-    data.reserve(MAX_CMD_LEN);
+    m_Data.reserve(MAX_CMD_LEN);
     parseBuf(buf);
 }
 
-AUXCommand::AUXCommand(AUXCommands c, AUXTargets s, AUXTargets d, const AUXBuffer &dat)
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+AUXCommand::AUXCommand(AUXCommands command, AUXTargets source, AUXTargets destination, const AUXBuffer &data)
 {
-    cmd = c;
-    src = s;
-    dst = d;
-    data.reserve(MAX_CMD_LEN);
-    data = dat;
-    len  = 3 + data.size();
+    m_Command = command;
+    m_Source = source;
+    m_Destination = destination;
+    m_Data.reserve(MAX_CMD_LEN);
+    m_Data = data;
+    len  = 3 + m_Data.size();
 }
 
-AUXCommand::AUXCommand(AUXCommands c, AUXTargets s, AUXTargets d)
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+AUXCommand::AUXCommand(AUXCommands command, AUXTargets source, AUXTargets destination)
 {
-    cmd = c;
-    src = s;
-    dst = d;
-    data.reserve(MAX_CMD_LEN);
-    len = 3 + data.size();
+    m_Command = command;
+    m_Source = source;
+    m_Destination = destination;
+    m_Data.reserve(MAX_CMD_LEN);
+    len = 3 + m_Data.size();
 }
 
-const char * AUXCommand::cmd_name(AUXCommands c)
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+const char * AUXCommand::commandName(AUXCommands command) const
 {
-    if (src == GPS || dst == GPS)
+    if (m_Source == GPS || m_Destination == GPS)
     {
-        switch (c)
+        switch (command)
         {
             case GPS_GET_LAT:
                 return "GPS_GET_LAT";
@@ -214,7 +213,7 @@ const char * AUXCommand::cmd_name(AUXCommands c)
     }
     else
     {
-        switch (c)
+        switch (command)
         {
             case MC_GET_POSITION:
                 return "MC_GET_POSITION";
@@ -256,10 +255,14 @@ const char * AUXCommand::cmd_name(AUXCommands c)
     }
 }
 
-int AUXCommand::response_data_size()
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+int AUXCommand::responseDataSize()
 {
-    if (src == GPS || dst == GPS)
-        switch (cmd)
+    if (m_Source == GPS || m_Destination == GPS)
+    {
+        switch (m_Command)
         {
             case GPS_GET_LAT:
             case GPS_GET_LONG:
@@ -275,8 +278,10 @@ int AUXCommand::response_data_size()
             default :
                 return -1;
         }
+    }
     else
-        switch (cmd)
+    {
+        switch (m_Command)
         {
             case MC_GET_POSITION:
             case MC_GET_CORDWRAP_POS:
@@ -303,10 +308,13 @@ int AUXCommand::response_data_size()
             default :
                 return -1;
         }
+    }
 }
 
-
-const char * AUXCommand::node_name(AUXTargets n)
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+const char * AUXCommand::moduleName(AUXTargets n)
 {
     switch (n)
     {
@@ -339,50 +347,60 @@ const char * AUXCommand::node_name(AUXTargets n)
     }
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::fillBuf(AUXBuffer &buf)
 {
     buf.resize(len + 3);
+
     buf[0] = 0x3b;
-    buf[1] = (unsigned char)len;
-    buf[2] = (unsigned char)src;
-    buf[3] = (unsigned char)dst;
-    buf[4] = (unsigned char)cmd;
-    for (unsigned int i = 0; i < data.size(); i++)
+    buf[1] = len;
+    buf[2] = m_Source;
+    buf[3] = m_Destination;
+    buf[4] = m_Command;
+    for (uint32_t i = 0; i < m_Data.size(); i++)
     {
-        buf[i + 5] = data[i];
+        buf[i + 5] = m_Data[i];
     }
     buf.back() = checksum(buf);
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::parseBuf(AUXBuffer buf)
 {
     len   = buf[1];
-    src   = (AUXTargets)buf[2];
-    dst   = (AUXTargets)buf[3];
-    cmd   = (AUXCommands)buf[4];
-    data  = AUXBuffer(buf.begin() + 5, buf.end() - 1);
+    m_Source   = (AUXTargets)buf[2];
+    m_Destination   = (AUXTargets)buf[3];
+    m_Command   = (AUXCommands)buf[4];
+    m_Data  = AUXBuffer(buf.begin() + 5, buf.end() - 1);
     valid = (checksum(buf) == buf.back());
     if (valid == false)
     {
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "Checksum error: %02x vs. %02x", checksum(buf), buf.back());
-        //logResponse(buf);
-        //logCommand();
     };
 }
 
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::parseBuf(AUXBuffer buf, bool do_checksum)
 {
     (void)do_checksum;
 
     len   = buf[1];
-    src   = (AUXTargets)buf[2];
-    dst   = (AUXTargets)buf[3];
-    cmd   = (AUXCommands)buf[4];
+    m_Source   = (AUXTargets)buf[2];
+    m_Destination   = (AUXTargets)buf[3];
+    m_Command   = (AUXCommands)buf[4];
     if (buf.size() > 5)
-        data  = AUXBuffer(buf.begin() + 5, buf.end());
+        m_Data  = AUXBuffer(buf.begin() + 5, buf.end());
 }
 
-
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 unsigned char AUXCommand::checksum(AUXBuffer buf)
 {
     int l  = buf[1];
@@ -391,27 +409,24 @@ unsigned char AUXCommand::checksum(AUXBuffer buf)
     {
         cs += buf[i];
     }
-    //fprintf(stderr,"CS: %x  %x  %x\n", cs, ~cs, ~cs+1);
     return (unsigned char)(((~cs) + 1) & 0xFF);
-    //return ((~sum([ord(c) for c in msg]) + 1) ) & 0xFF
 }
 
-// One definition rule (ODR) constants
-// AUX commands use 24bit integer as a representation of angle in units of
-// fractional revolutions. Thus 2^24 steps makes full revolution.
-const long STEPS_PER_REVOLUTION = 16777216;
-const double STEPS_PER_DEGREE   = STEPS_PER_REVOLUTION / 360.0;
-
-int32_t AUXCommand::getPosition()
+/////////////////////////////////////////////////////////////////////////////////////
+/// One definition rule (ODR) constants
+/// AUX commands use 24bit integer as a representation of angle in units of
+/// fractional revolutions. Thus 2^24 steps makes full revolution.
+/// Return encoder position in steps.
+/////////////////////////////////////////////////////////////////////////////////////
+uint32_t AUXCommand::getData(uint8_t bytes)
 {
-    if (data.size() == 3)
+    if (m_Data.size() == 3)
     {
-        int32_t a = static_cast<int8_t>(data[0]); 
+        int32_t a = static_cast<int8_t>(m_Data[0]);
         a <<= 16;
-        a |= static_cast<uint32_t>(data[1]) << 8; 
-        a |= static_cast<uint32_t>(data[2]);
-        //fprintf(stderr,"Angle: %d %08x = %d => %f\n", sizeof(a), a, a, a/pow(2,24));
-        return (int32_t)a % STEPS_PER_REVOLUTION;
+        a |= static_cast<uint32_t>(m_Data[1]) << 8;
+        a |= static_cast<uint32_t>(m_Data[2]);
+        return a;
     }
     else
     {
@@ -419,32 +434,30 @@ int32_t AUXCommand::getPosition()
     }
 }
 
-void AUXCommand::setPosition(double p)
+/////////////////////////////////////////////////////////////////////////////////////
+/// Set encoder position in steps.
+/////////////////////////////////////////////////////////////////////////////////////
+void AUXCommand::setData(uint32_t value, uint8_t bytes)
 {
-    setPosition(static_cast<int32_t>(p * STEPS_PER_DEGREE));
-}
-
-void AUXCommand::setPosition(int32_t p)
-{
-    //int a=(int)p; fprintf(stderr,"Angle: %08x = %d => %f\n", a, a, a/pow(2,24));
-    data.resize(3);
-    // Fold the value to 0-STEPS_PER_REVOLUTION range
-    if (p < 0)
+    m_Data.resize(bytes);
+    switch (bytes)
     {
-        p += STEPS_PER_REVOLUTION;
-    }
-    p = p % STEPS_PER_REVOLUTION;
-    for (int i = 2; i > -1; i--)
-    {
-        data[i] = static_cast<uint8_t>(p & 0xff);
-        p >>= 8;
-    }
-    len = 6;
-}
+        case 1:
+            len = 4;
+            m_Data[0] = static_cast<uint8_t>(value >> 0 & 0xff);
+            break;
+        case 2:
+            len = 5;
+            m_Data[1] = static_cast<uint8_t>(value >>  0 & 0xff);
+            m_Data[0] = static_cast<uint8_t>(value >>  8 & 0xff);
+            break;
 
-void AUXCommand::setRate(unsigned char r)
-{
-    data.resize(1);
-    len     = 4;
-    data[0] = r;
+        case 3:
+        default:
+            len = 6;
+            m_Data[2] = static_cast<uint8_t>(value >>  0 & 0xff);
+            m_Data[1] = static_cast<uint8_t>(value >>  8 & 0xff);
+            m_Data[0] = static_cast<uint8_t>(value >> 16 & 0xff);
+            break;
+    }
 }

--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -289,6 +289,8 @@ int AUXCommand::responseDataSize()
             case GET_VER:
                 return 4;
             case MC_SLEW_DONE:
+            case MC_SEEK_DONE:
+            case MC_LEVEL_DONE:
             case MC_POLL_CORDWRAP:
                 return 1;
             case MC_GOTO_FAST:

--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -97,6 +97,16 @@ class AUXCommand
         void parseBuf(AUXBuffer buf, bool do_checksum);
 
         ///////////////////////////////////////////////////////////////////////////////
+        /// Getters
+        ///////////////////////////////////////////////////////////////////////////////
+        const AUXTargets &source() const {return m_Source;}
+        const AUXTargets &destination() const {return m_Destination;}
+        const AUXBuffer &data() const {return m_Data;}
+        AUXCommands command() const {return m_Command;}
+        size_t dataSize() const {return m_Data.size();}
+        const char * commandName() const {return commandName(m_Command);}
+
+        ///////////////////////////////////////////////////////////////////////////////
         /// Set and Get data
         ///////////////////////////////////////////////////////////////////////////////
         /**
@@ -104,7 +114,7 @@ class AUXCommand
          * @param bytes How many bytes to interpret the data.
          * @return
          */
-        uint32_t getData(uint8_t bytes=3);
+        uint32_t getData();
         void setData(uint32_t value, uint8_t bytes=3);
 
         ///////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <stdint.h>
 
-typedef std::vector<unsigned char> AUXBuffer;
+typedef std::vector<uint8_t> AUXBuffer;
 
 enum AUXCommands
 {
@@ -86,8 +86,8 @@ class AUXCommand
     public:
         AUXCommand();
         AUXCommand(const AUXBuffer &buf);
-        AUXCommand(AUXCommands c, AUXTargets s, AUXTargets d, const AUXBuffer &dat);
-        AUXCommand(AUXCommands c, AUXTargets s, AUXTargets d);
+        AUXCommand(AUXCommands command, AUXTargets source, AUXTargets destination, const AUXBuffer &data);
+        AUXCommand(AUXCommands command, AUXTargets source, AUXTargets destination);
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Buffer Management
@@ -97,45 +97,41 @@ class AUXCommand
         void parseBuf(AUXBuffer buf, bool do_checksum);
 
         ///////////////////////////////////////////////////////////////////////////////
-        /// Position
+        /// Set and Get data
         ///////////////////////////////////////////////////////////////////////////////
-        int32_t getPosition();
-        void setPosition(int32_t p);
-        void setPosition(double p);
-
-        ///////////////////////////////////////////////////////////////////////////////
-        /// Rates
-        ///////////////////////////////////////////////////////////////////////////////
-        void setRate(unsigned char r);
+        /**
+         * @brief getData Parses data packet and convert it to a 32bit unsigned integer
+         * @param bytes How many bytes to interpret the data.
+         * @return
+         */
+        uint32_t getData(uint8_t bytes=3);
+        void setData(uint32_t value, uint8_t bytes=3);
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Check sum
         ///////////////////////////////////////////////////////////////////////////////
-        unsigned char checksum(AUXBuffer buf);
+        uint8_t checksum(AUXBuffer buf);
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Logging
         ///////////////////////////////////////////////////////////////////////////////
-        //void logCommand();
-        const char * cmd_name(AUXCommands c);
-        int response_data_size();
-        const char * node_name(AUXTargets n);
+        const char * commandName(AUXCommands command) const;
+        const char * moduleName(AUXTargets n);
+        int responseDataSize();
         void logResponse();
         void logCommand();
-        //void logResponse(AUXBuffer buf);
         static void setDebugInfo(const char *deviceName, uint8_t debugLevel);
-
-        // TODO these should be private
-        AUXCommands cmd;
-        AUXTargets src, dst;
-        AUXBuffer data;
 
         static uint8_t DEBUG_LEVEL;
         static char DEVICE_NAME[64];
 
     private:
-        int len {0};
+        uint8_t len {0};
         bool valid {false};
+
+        AUXCommands m_Command;
+        AUXTargets m_Source, m_Destination;
+        AUXBuffer m_Data;
 
 
 

--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -36,8 +36,10 @@ enum AUXCommands
     MC_SET_POS_GUIDERATE = 0x06,
     MC_SET_NEG_GUIDERATE = 0x07,
     MC_LEVEL_START       = 0x0b,
+    MC_LEVEL_DONE        = 0x12,
     MC_SLEW_DONE         = 0x13,
     MC_GOTO_SLOW         = 0x17,
+    MC_SEEK_DONE         = 0x18,
     MC_SEEK_INDEX        = 0x19,
     MC_MOVE_POS          = 0x24,
     MC_MOVE_NEG          = 0x25,
@@ -48,8 +50,8 @@ enum AUXCommands
     MC_SET_CORDWRAP_POS  = 0x3a,
     MC_POLL_CORDWRAP     = 0x3b,
     MC_GET_CORDWRAP_POS  = 0x3c,
-    MC_SET_AUTOGUIDE_RATE= 0x46,
-    MC_GET_AUTOGUIDE_RATE= 0x47,
+    MC_SET_AUTOGUIDE_RATE = 0x46,
+    MC_GET_AUTOGUIDE_RATE = 0x47,
     GET_VER              = 0xfe,
     GPS_GET_LAT          = 0x01,
     GPS_GET_LONG         = 0x02,
@@ -99,12 +101,30 @@ class AUXCommand
         ///////////////////////////////////////////////////////////////////////////////
         /// Getters
         ///////////////////////////////////////////////////////////////////////////////
-        const AUXTargets &source() const {return m_Source;}
-        const AUXTargets &destination() const {return m_Destination;}
-        const AUXBuffer &data() const {return m_Data;}
-        AUXCommands command() const {return m_Command;}
-        size_t dataSize() const {return m_Data.size();}
-        const char * commandName() const {return commandName(m_Command);}
+        const AUXTargets &source() const
+        {
+            return m_Source;
+        }
+        const AUXTargets &destination() const
+        {
+            return m_Destination;
+        }
+        const AUXBuffer &data() const
+        {
+            return m_Data;
+        }
+        AUXCommands command() const
+        {
+            return m_Command;
+        }
+        size_t dataSize() const
+        {
+            return m_Data.size();
+        }
+        const char * commandName() const
+        {
+            return commandName(m_Command);
+        }
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Set and Get data
@@ -115,7 +135,7 @@ class AUXCommand
          * @return
          */
         uint32_t getData();
-        void setData(uint32_t value, uint8_t bytes=3);
+        void setData(uint32_t value, uint8_t bytes = 3);
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Check sum

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -786,7 +786,7 @@ bool CelestronAUX::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
 /////////////////////////////////////////////////////////////////////////////////////
 IPState CelestronAUX::GuideNorth(uint32_t ms)
 {
-    LOGF_DEBUG("Guiding: N %d ms", ms);
+    // TODO FIXME  For Alt-Az setups, we must determine offset in steps
     int8_t rate = static_cast<int8_t>(GuideRateNP[AXIS_ALT].getValue() * 100);
     guidePulse(AXIS_DE, ms, rate);
     return IPS_BUSY;
@@ -794,7 +794,6 @@ IPState CelestronAUX::GuideNorth(uint32_t ms)
 
 IPState CelestronAUX::GuideSouth(uint32_t ms)
 {
-    LOGF_DEBUG("Guiding: S %d ms", ms);
     int8_t rate = static_cast<int8_t>(GuideRateNP[AXIS_ALT].getValue() * 100);
     guidePulse(AXIS_DE, ms, -rate);
     return IPS_BUSY;
@@ -802,7 +801,6 @@ IPState CelestronAUX::GuideSouth(uint32_t ms)
 
 IPState CelestronAUX::GuideEast(uint32_t ms)
 {
-    LOGF_DEBUG("Guiding: E %d ms", ms);
     int8_t rate = static_cast<int8_t>(GuideRateNP[AXIS_AZ].getValue() * 100);
     guidePulse(AXIS_RA, ms, -rate);
     return IPS_BUSY;
@@ -810,7 +808,6 @@ IPState CelestronAUX::GuideEast(uint32_t ms)
 
 IPState CelestronAUX::GuideWest(uint32_t ms)
 {
-    LOGF_DEBUG("Guiding: W %d ms", ms);
     int8_t rate = static_cast<int8_t>(GuideRateNP[AXIS_AZ].getValue() * 100);
     guidePulse(AXIS_RA, ms, rate);
     return IPS_BUSY;

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -105,6 +105,7 @@ bool CelestronAUX::Handshake()
             }
             else
             {
+                m_IsRTSCTS = detectRTSCTS();
                 serialConnection->setDefaultBaudRate(Connection::Serial::B_9600);
                 if (!tty_set_speed(B9600))
                 {

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -390,8 +390,8 @@ bool CelestronAUX::initProperties()
     Axis1PIDNP.fill(getDeviceName(), "AXIS1_PID", "Axis1 PID", MOUNTINFO_TAB, IP_RW, 60, IPS_IDLE);
 
     Axis2PIDNP[Propotional].fill("Propotional", "Propotional", "%.2f", 0, 500, 10, GAIN_STEPS);
-    Axis2PIDNP[Derivative].fill("Derivative", "Derivative", "%.2f", 0, 500, 10, 0);
-    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 500, 10, 0.25);
+    Axis2PIDNP[Derivative].fill("Derivative", "Derivative", "%.2f", 0, 100, 10, 0);
+    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 100, 10, 1);
     Axis2PIDNP.fill(getDeviceName(), "AXIS2_PID", "Axis2 PID", MOUNTINFO_TAB, IP_RW, 60, IPS_IDLE);
 
     // Firmware Info

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1774,11 +1774,12 @@ uint32_t CelestronAUX::RAToEncoders(double ra)
         m_TargetPierSide = PIER_EAST;
     else
         m_TargetPierSide = PIER_WEST;
-    // Flip in southerin hemisphere
-    if (!isNorthHemisphere())
+
+    // Flip for Northern hemisphere
+    if (isNorthHemisphere())
         ha *= -1;
 
-    // Range to 0 to 24 hours.
+    // Limit range to 0 to 24 hours.
     ha = range24(ha);
     return HoursToEncoders(ha);
 }

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1200,8 +1200,8 @@ bool CelestronAUX::ReadScopeStatus()
     {
         if (isSlewing() == false)
         {
-            SetTrackEnabled(false);
             SetParked(true);
+            SetTrackEnabled(false);
         }
     }
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1116,8 +1116,16 @@ bool CelestronAUX::ReadScopeStatus()
     {
         EncoderNP.setState(IPS_OK);
         EncoderNP.apply();
-        AngleNP[AXIS_AZ].setValue(m_MountCurrentAltAz.azimuth);
-        AngleNP[AXIS_ALT].setValue(m_MountCurrentAltAz.altitude);
+        if (MountTypeSP[ALTAZ].getState() == ISS_ON)
+        {
+            AngleNP[AXIS_AZ].setValue(m_MountCurrentAltAz.azimuth);
+            AngleNP[AXIS_ALT].setValue(m_MountCurrentAltAz.altitude);
+        }
+        else
+        {
+            AngleNP[AXIS_RA].setValue(range360(m_MountCurrentRADE.rightascension * 15));
+            AngleNP[AXIS_DE].setValue(rangeDec(m_MountCurrentRADE.declination));
+        }
         AngleNP.setState(IPS_OK);
         AngleNP.apply();
     }
@@ -1704,7 +1712,7 @@ uint32_t CelestronAUX::RAToEncoders(double ra)
 double CelestronAUX::DEToEncoders(double de)
 {
     if ((isNorthHemisphere() && getPierSide() == PIER_EAST) || (!isNorthHemisphere() && getPierSide() == PIER_WEST))
-        de = 180.0 - de;
+        de = rangeDec(180.0 - de);
     return DegreesToEncoders(de);
 }
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1121,10 +1121,23 @@ bool CelestronAUX::ReadScopeStatus()
     char RAStr[32] = {0}, DecStr[32] = {0};
     fs_sexa(RAStr, m_SkyCurrentRADE.rightascension, 2, 3600);
     fs_sexa(DecStr, m_SkyCurrentRADE.declination, 2, 3600);
-    DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "Mount -> Sky RA %s DE %s", RAStr, DecStr);
 
     INDI::IHorizontalCoordinates celestialAzAlt;
     INDI::EquatorialToHorizontal(&m_SkyCurrentRADE, &m_Location, ln_get_julian_from_sys(), &celestialAzAlt);
+
+    char AzStr[32] = {0}, AltStr[32] = {0}, HAStr[32] = {0};
+    fs_sexa(AzStr, celestialAzAlt.azimuth, 2, 3600);
+    fs_sexa(AltStr, celestialAzAlt.altitude, 2, 3600);
+    double HA = rangeHA(ln_get_julian_from_sys() - m_SkyCurrentRADE.rightascension);
+    fs_sexa(HAStr, HA, 2, 3600);
+    DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "Mount -> Sky RA: %s DE: %s AZ: %s AL: %s HA: %s Pier: %s",
+           RAStr,
+           DecStr,
+           AzStr,
+           AltStr,
+           HAStr,
+           MountTypeSP[ALTAZ].getState() == ISS_ON ? "NA" : getPierSideStr(currentPierSide));
+
     if (std::abs(celestialAzAlt.azimuth - HorizontalCoordsNP[AXIS_AZ].getValue()) > 0.1 ||
             std::abs(celestialAzAlt.altitude - HorizontalCoordsNP[AXIS_ALT].getValue()) > 0.1)
     {
@@ -1332,7 +1345,7 @@ bool CelestronAUX::Goto(double ra, double dec)
 
     fs_sexa(RAStr, MountRADE.rightascension, 2, 3600);
     fs_sexa(DecStr, MountRADE.declination, 2, 3600);
-    DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "Sky -> Mount RA (%ld) %s DE %s (%ld)", RAStr, axis1Steps, DecStr,
+    DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "Sky -> Mount RA %s (%ld) DE %s (%ld)", RAStr, axis1Steps, DecStr,
            axis2Steps);
 
     // Slew to physical steps.

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -282,16 +282,17 @@ bool CelestronAUX::initProperties()
     // Detect Equatorial Mounts
     if (strstr(getDeviceName(), "CGX") ||
             strstr(getDeviceName(), "CGEM") ||
-            strstr(getDeviceName(), "Advanced VX"))
+            strstr(getDeviceName(), "Advanced VX") ||
+            strstr(getDeviceName(), "Wedge"))
     {
         // Force equatorial for such mounts
         configMountType = EQUATORIAL;
-        SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
     }
-    else if (strstr(getDeviceName(), "Wedge"))
-    {
+
+    if (configMountType == EQUATORIAL)
         SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
-    }
+    else
+        SetApproximateMountAlignment(ZENITH);
 
     MountTypeSP[EQUATORIAL].fill("EQUATORIAL", "Equatorial", configMountType == EQUATORIAL ? ISS_ON : ISS_OFF);
     MountTypeSP[ALTAZ].fill("ALTAZ", "AltAz", configMountType == ALTAZ ? ISS_ON : ISS_OFF);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1141,15 +1141,18 @@ bool CelestronAUX::ReadScopeStatus()
             if (isTrackingRequested())
             {
                 // Goto has finished start tracking
-                TrackState = SCOPE_TRACKING;
                 ScopeStatus = TRACKING;
-
                 if (HorizontalCoordsNP.getState() == IPS_BUSY)
                 {
                     HorizontalCoordsNP.setState(IPS_OK);
                     HorizontalCoordsNP.apply();
                 }
+                TrackState = SCOPE_TRACKING;
                 resetTracking();
+
+                // For equatorial mounts, engage tracking.
+                if (MountTypeSP[EQUATORIAL].getState())
+                    SetTrackMode(IUFindOnSwitchIndex(&TrackModeSP));
                 LOG_INFO("Tracking started.");
             }
             else
@@ -1177,7 +1180,7 @@ bool CelestronAUX::ReadScopeStatus()
 /////////////////////////////////////////////////////////////////////////////////////
 bool CelestronAUX::Goto(double ra, double dec)
 {
-    char RAStr[32], DecStr[32];
+    char RAStr[32] = {0}, DecStr[32] = {0};
     fs_sexa(RAStr, ra, 2, 3600);
     fs_sexa(DecStr, dec, 2, 3600);
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1676,9 +1676,9 @@ double CelestronAUX::EncodersToHours(uint32_t steps)
     double value = steps * HOURS_PER_STEP;
     // North hemisphere
     if (isNorthHemisphere())
-        return range24(value + 6.0);
+        return range24(value);
     else
-        return range24( (24.0 - value) + 6.0);
+        return range24(24.0 - value);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -1686,11 +1686,7 @@ double CelestronAUX::EncodersToHours(uint32_t steps)
 /////////////////////////////////////////////////////////////////////////////////////
 uint32_t CelestronAUX::HoursToEncoders(double hour)
 {
-    double shifthour = range24(hour - 6);
-    if (isNorthHemisphere())
-        return round(((shifthour / 24.0) * STEPS_PER_REVOLUTION));
-    else
-        return round((((24.0 - shifthour) / 24.0) * STEPS_PER_REVOLUTION));
+    return DegreesToEncoders(hour * 15);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -1698,9 +1694,7 @@ uint32_t CelestronAUX::HoursToEncoders(double hour)
 /////////////////////////////////////////////////////////////////////////////////////
 uint32_t CelestronAUX::RAToEncoders(double ra)
 {
-    double ha = ra - get_local_sidereal_time(m_Location.longitude);
-    if (getPierSide() == PIER_EAST)
-        ha = ha + 12.0;
+    double ha = get_local_sidereal_time(m_Location.longitude) - ra;
     ha = range24(ha);
     return HoursToEncoders(ha);
 }

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -286,6 +286,7 @@ bool CelestronAUX::initProperties()
     {
         // Force equatorial for such mounts
         configMountType = EQUATORIAL;
+        SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
     }
     else if (strstr(getDeviceName(), "Wedge"))
     {
@@ -1219,7 +1220,7 @@ void CelestronAUX::EncodersToRADE(INDI::IEquatorialCoordinates &coords, Telescop
 {
     double HACurrent = EncodersToHours(EncoderNP[AXIS_RA].getValue());
     double RACurrent = HACurrent + get_local_sidereal_time(m_Location.longitude);
-    double DECurrent = EncodersToDegrees(EncoderNP[AXIS_DE].getValue());
+    double DECurrent = range360(EncodersToDegrees(EncoderNP[AXIS_DE].getValue()) + ((m_Location.latitude >= 0) ? 90 : -90));
     if (isNorthHemisphere())
     {
         if ((DECurrent > 90.0) && (DECurrent <= 270.0))

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -152,6 +152,8 @@ bool CelestronAUX::Handshake()
         // update cordwrap position at each init of the alignment subsystem
         if (isConnected())
             syncCoordWrapPosition();
+
+        LOG_WARN("This is an experimental driver. It was not tested in equatorial mode. Use it at your own risk.");
         return true;
     }
     else
@@ -2271,7 +2273,8 @@ bool CelestronAUX::processResponse(AUXCommand &m)
 {
     m.logResponse();
 
-    if ((m.destination() == GPS) && (m.source() != APP)) {
+    if ((m.destination() == GPS) && (m.source() != APP))
+    {
         // Avoid infinite loop by not responding to ourselves
         emulateGPS(m);
     }
@@ -2395,10 +2398,11 @@ bool CelestronAUX::processResponse(AUXCommand &m)
                 if (verBuf != nullptr)
                 {
                     size_t verBuflen = 4;
-                    if ( verBuflen != m.dataSize()) {
+                    if ( verBuflen != m.dataSize())
+                    {
                         LOGF_DEBUG("Data and buffer size mismatch for GET_VER: buf[%d] vs data[%d]", verBuflen, m.dataSize());
                     }
-                    for (int i = 0; i < (int)std::min(verBuflen,m.dataSize()); i++)
+                    for (int i = 0; i < (int)std::min(verBuflen, m.dataSize()); i++)
                         verBuf[i] = m.data()[i];
                 }
             }

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1040,8 +1040,10 @@ void CelestronAUX::resetTracking()
 
     m_Controllers[AXIS_AZ].reset(new PID(1, 100000, -100000, Axis1PIDNP[Propotional].getValue(),
                                          Axis1PIDNP[Derivative].getValue(), Axis1PIDNP[Integral].getValue()));
+    m_Controllers[AXIS_AZ]->setIntegratorLimits(-2000, 2000);
     m_Controllers[AXIS_ALT].reset(new PID(1, 100000, -100000, Axis2PIDNP[Propotional].getValue(),
                                           Axis2PIDNP[Derivative].getValue(), Axis2PIDNP[Integral].getValue()));
+    m_Controllers[AXIS_ALT]->setIntegratorLimits(-2000, 2000);
     m_TrackingElapsedTimer.restart();
     m_GuideOffset[AXIS_AZ] = m_GuideOffset[AXIS_ALT] = 0;
 }

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1247,7 +1247,6 @@ void CelestronAUX::EncodersToRADE(INDI::IEquatorialCoordinates &coords, Telescop
     else
         pierSide = PIER_WEST;
 
-    HACurrent = rangeHA(HACurrent);
     RACurrent = range24(RACurrent);
     DECurrent = rangeDec(DECurrent);
 
@@ -1694,7 +1693,16 @@ uint32_t CelestronAUX::HoursToEncoders(double hour)
 /////////////////////////////////////////////////////////////////////////////////////
 uint32_t CelestronAUX::RAToEncoders(double ra)
 {
-    double ha = get_local_sidereal_time(m_Location.longitude) - ra;
+    double ha = rangeHA(get_local_sidereal_time(m_Location.longitude) - ra);
+    if (ha < 0)
+        m_TargetPierSide = PIER_EAST;
+    else
+        m_TargetPierSide = PIER_WEST;
+    // Flip in southerin hemisphere
+    if (!isNorthHemisphere())
+        ha *= -1;
+
+    // Range to 0 to 24 hours.
     ha = range24(ha);
     return HoursToEncoders(ha);
 }
@@ -1705,7 +1713,7 @@ uint32_t CelestronAUX::RAToEncoders(double ra)
 double CelestronAUX::DEToEncoders(double de)
 {
     double degrees = 0;
-    if ((isNorthHemisphere() && getPierSide() == PIER_EAST) || (!isNorthHemisphere() && getPierSide() == PIER_WEST))
+    if ((isNorthHemisphere() && m_TargetPierSide == PIER_EAST) || (!isNorthHemisphere() && m_TargetPierSide == PIER_WEST))
         degrees = 270 + de;
     else
         degrees = 90 - de;

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -2010,8 +2010,7 @@ bool CelestronAUX::trackByRate(INDI_HO_AXIS axis, int32_t rate)
 /////////////////////////////////////////////////////////////////////////////////////
 bool CelestronAUX::trackByMode(INDI_HO_AXIS axis, uint8_t mode)
 {
-    // N.B. MC_SET_NEG_GUIDERATE should be used for NORTH hemisphere.
-    AUXCommand command(isNorthHemisphere() ? MC_SET_NEG_GUIDERATE : MC_SET_POS_GUIDERATE, APP, axis == AXIS_AZ ? AZM : ALT);
+    AUXCommand command(isNorthHemisphere() ? MC_SET_POS_GUIDERATE : MC_SET_NEG_GUIDERATE, APP, axis == AXIS_AZ ? AZM : ALT);
     switch (mode)
     {
         case TRACK_SOLAR:
@@ -2052,8 +2051,8 @@ bool CelestronAUX::SetTrackEnabled(bool enabled)
     else
     {
         TrackState = SCOPE_IDLE;
-        stopAxis(AXIS_AZ);
-        stopAxis(AXIS_ALT);
+        trackByRate(AXIS_AZ, 0);
+        trackByRate(AXIS_ALT, 0);
 
         if (HorizontalCoordsNP.getState() != IPS_IDLE)
         {

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1710,9 +1710,12 @@ uint32_t CelestronAUX::RAToEncoders(double ra)
 /////////////////////////////////////////////////////////////////////////////////////
 double CelestronAUX::DEToEncoders(double de)
 {
-    if (!isNorthHemisphere())
-        de = rangeDec(180.0 - de);
-    return DegreesToEncoders(de);
+    double degrees = 0;
+    if ((isNorthHemisphere() && getPierSide() == PIER_EAST) || (!isNorthHemisphere() && getPierSide() == PIER_WEST))
+        degrees = 270 + de;
+    else
+        degrees = 90 - de;
+    return DegreesToEncoders(degrees);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1678,9 +1678,9 @@ double CelestronAUX::EncodersToHours(uint32_t steps)
     double value = steps * HOURS_PER_STEP;
     // North hemisphere
     if (isNorthHemisphere())
-        return range24(24  - value);
-    else
         return range24(value);
+    else
+        return range24(24 - value);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1218,7 +1218,7 @@ void CelestronAUX::EncodersToAltAz(INDI::IHorizontalCoordinates &coords)
 void CelestronAUX::EncodersToRADE(INDI::IEquatorialCoordinates &coords, TelescopePierSide &pierSide)
 {
     double HACurrent = EncodersToHours(EncoderNP[AXIS_RA].getValue());
-    double RACurrent = HACurrent + ln_get_julian_from_sys();
+    double RACurrent = HACurrent + get_local_sidereal_time(m_Location.longitude);
     double DECurrent = EncodersToDegrees(EncoderNP[AXIS_DE].getValue());
     if (isNorthHemisphere())
     {
@@ -1689,7 +1689,7 @@ uint32_t CelestronAUX::HoursToEncoders(double hour)
 /////////////////////////////////////////////////////////////////////////////////////
 uint32_t CelestronAUX::RAToEncoders(double ra)
 {
-    double ha = ra - ln_get_julian_from_sys();
+    double ha = ra - get_local_sidereal_time(m_Location.longitude);
     if (getPierSide() == PIER_EAST)
         ha = ha + 12.0;
     ha = range24(ha);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -36,6 +36,8 @@
 #include "celestronaux.h"
 #include "config.h"
 
+#define DEBUG_PID
+
 using namespace INDI::AlignmentSubsystem;
 
 static std::unique_ptr<CelestronAUX> telescope_caux(new CelestronAUX());
@@ -380,8 +382,8 @@ bool CelestronAUX::initProperties()
     Axis1PIDNP.fill(getDeviceName(), "AXIS1_PID", "Axis1 PID", MOUNTINFO_TAB, IP_RW, 60, IPS_IDLE);
 
     Axis2PIDNP[Propotional].fill("Propotional", "Propotional", "%.2f", 0, 500, 10, GAIN_STEPS);
-    Axis2PIDNP[Derivative].fill("Derivative", "Derivative", "%.2f", 0, 500, 10, 5);
-    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 500, 10, 0.5);
+    Axis2PIDNP[Derivative].fill("Derivative", "Derivative", "%.2f", 0, 500, 10, 0);
+    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 500, 10, 0.25);
     Axis2PIDNP.fill(getDeviceName(), "AXIS2_PID", "Axis2 PID", MOUNTINFO_TAB, IP_RW, 60, IPS_IDLE);
 
     // Firmware Info
@@ -1581,8 +1583,20 @@ void CelestronAUX::TimerHit()
 
                 LOGF_DEBUG("Tracking AZ Now: %.f Target: %d Offset: %d Rate: %.2f", EncoderNP[AXIS_AZ].getValue(), targetSteps[AXIS_AZ],
                            offsetSteps[AXIS_AZ], trackRates[AXIS_AZ]);
+#ifdef DEBUG_PID
+                LOGF_DEBUG("Tracking AZ P: %f I: %f D: %f",
+                           m_Controllers[AXIS_AZ]->propotionalTerm(),
+                           m_Controllers[AXIS_AZ]->integralTerm(),
+                           m_Controllers[AXIS_AZ]->derivativeTerm());
+#endif
                 LOGF_DEBUG("Tracking AL Now: %.f Target: %d Offset: %d Rate: %.2f", EncoderNP[AXIS_ALT].getValue(), targetSteps[AXIS_ALT],
                            offsetSteps[AXIS_ALT], trackRates[AXIS_ALT]);
+#ifdef DEBUG_PID
+                LOGF_DEBUG("Tracking AL P: %f I: %f D: %f",
+                           m_Controllers[AXIS_ALT]->propotionalTerm(),
+                           m_Controllers[AXIS_ALT]->integralTerm(),
+                           m_Controllers[AXIS_ALT]->derivativeTerm());
+#endif
 
                 // Use PID to determine appropiate tracking rate
                 trackByRate(AXIS_AZ, trackRates[AXIS_AZ]);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1107,8 +1107,7 @@ bool CelestronAUX::ReadScopeStatus()
     {
         TelescopePierSide pierSide = currentPierSide;
         EncodersToRADE(m_MountCurrentRADE, pierSide);
-        if (pierSide != currentPierSide)
-            setPierSide(pierSide);
+        setPierSide(pierSide);
     }
 
     // Send to client if updated
@@ -1711,14 +1710,8 @@ uint32_t CelestronAUX::RAToEncoders(double ra)
 /////////////////////////////////////////////////////////////////////////////////////
 double CelestronAUX::DEToEncoders(double de)
 {
-    if ((isNorthHemisphere() && getPierSide() == PIER_EAST) || (!isNorthHemisphere() && getPierSide() == PIER_WEST))
-    {
-        de = 180.0 - de;
-        while (de > 90)
-            de -= 90;
-        while (de < -90)
-            de += 90;
-    }
+    if (!isNorthHemisphere())
+        de = rangeDec(180.0 - de);
     return DegreesToEncoders(de);
 }
 

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -26,9 +26,14 @@
 #include <indicom.h>
 #include <indiguiderinterface.h>
 #include <inditelescope.h>
+#include <indielapsedtimer.h>
 #include <connectionplugins/connectionserial.h>
 #include <connectionplugins/connectiontcp.h>
 #include <alignment/AlignmentSubsystemForDrivers.h>
+#include <indipropertyswitch.h>
+#include <indipropertynumber.h>
+#include <indipropertytext.h>
+#include <termios.h>
 
 #include "auxproto.h"
 
@@ -41,21 +46,59 @@ class CelestronAUX :
         CelestronAUX();
         ~CelestronAUX();
 
-        virtual void ISGetProperties(const char *dev) override;
         virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                                char *formats[], char *names[], int n) override;
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
         virtual bool ISSnoopDevice(XMLEle *root) override;
-        long requestedCordwrapPos;
-        double getNorthAz();
+
+        // Type defs
+        enum ScopeStatus_t
+        {
+            IDLE,
+            SLEWING_FAST,
+            APPROACH,
+            SLEWING_SLOW,
+            SLEWING_MANUAL,
+            TRACKING
+        };
+        ScopeStatus_t ScopeStatus;
+
+        enum AxisStatus
+        {
+            STOPPED,
+            SLEWING
+        };
+
+        enum AxisDirection
+        {
+            FORWARD,
+            REVERSE
+        };
+
+        // Previous motion direction
+        // TODO: Switch to AltAz from N-S/W-E
+        typedef enum
+        {
+            PREVIOUS_NS_MOTION_NORTH   = DIRECTION_NORTH,
+            PREVIOUS_NS_MOTION_SOUTH   = DIRECTION_SOUTH,
+            PREVIOUS_NS_MOTION_UNKNOWN = -1
+        } PreviousNSMotion_t;
+        typedef enum
+        {
+            PREVIOUS_WE_MOTION_WEST    = DIRECTION_WEST,
+            PREVIOUS_WE_MOTION_EAST    = DIRECTION_EAST,
+            PREVIOUS_WE_MOTION_UNKNOWN = -1
+        } PreviousWEMotion_t;
+
+        // Public to enable setting from ISSnoop
+        void syncCoordWrapPosition();
 
     protected:
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
         virtual bool saveConfigItems(FILE *fp) override;
-        //virtual bool Connect() override;
         virtual bool Handshake() override;
         virtual bool Disconnect() override;
 
@@ -84,120 +127,77 @@ class CelestronAUX :
 
         virtual bool ReadScopeStatus() override;
         virtual void TimerHit() override;
-
         virtual bool updateLocation(double latitude, double longitude, double elevation) override;
 
-        bool trackingRequested();
-
-        int32_t GetALT();
-        int32_t GetAZ();
-        bool slewing();
-        bool Slew(AUXTargets trg, int rate);
+        /////////////////////////////////////////////////////////////////////////////////////
+        /// Motion Control
+        /////////////////////////////////////////////////////////////////////////////////////
+        bool isSlewing();
+        bool Slew(AUXTargets target, int rate);
         bool SlewALT(int32_t rate);
         bool SlewAZ(int32_t rate);
         bool GoToFast(int32_t alt, int32_t az, bool track);
         bool GoToSlow(int32_t alt, int32_t az, bool track);
-        bool setCordwrap(bool enable);
-        bool getCordwrap();
-    public:
-        bool setCordwrapPos(int32_t pos);
-        long getCordwrapPos();
-        bool getCWBase();
-    private:
-        bool getVersion(AUXTargets trg);
-        void getVersions();
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        /// Tracking
+        /////////////////////////////////////////////////////////////////////////////////////
         bool Track(int32_t altRate, int32_t azRate);
         bool SetTrackEnabled(bool enabled) override;
+        bool trackingRequested();
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        /// Coord Wrap
+        /////////////////////////////////////////////////////////////////////////////////////
+        bool setCordWrapEnabled(bool enable);
+        bool getCordWrapEnabled();
+        bool setCordWrapPosition(int32_t pos);
+        uint32_t getCordWrapPosition();
+
+private:
+        /////////////////////////////////////////////////////////////////////////////////////
+        /// Misc
+        /////////////////////////////////////////////////////////////////////////////////////
+        double getNorthAz();
+        bool getVersion(AUXTargets target);
+        void getVersions();
+        void hex_dump(char *buf, AUXBuffer data, size_t size);
+        int32_t clampStepsPerRevolution(int32_t);
+
+        /////////////////////////////////////////////////////////////////////////////////////
+        /// Guiding
+        /////////////////////////////////////////////////////////////////////////////////////
         bool TimerTick(double dt);
         bool GuidePulse(INDI_EQ_AXIS axis, uint32_t ms, int8_t rate);
 
 
-    private:
-
-        // mount type
-        MountType_t requestedMountType;
-        MountType_t currentMountType;
-
-        bool pastAlignmentSubsystemStatus = true;
-        bool currentAlignmentSubsystemStatus;
-
-        enum ScopeStatus_t
-        {
-            IDLE,
-            SLEWING_FAST,
-            APPROACH,
-            SLEWING_SLOW,
-            SLEWING_MANUAL,
-            TRACKING
-        };
-        ScopeStatus_t ScopeStatus;
-
-        enum AxisStatus
-        {
-            STOPPED,
-            SLEWING
-        };
-
-        enum AxisDirection
-        {
-            FORWARD,
-            REVERSE
-        };
-
+    private:        
+        // Axis Information
         AxisStatus AxisStatusALT;
         AxisDirection AxisDirectionALT;
-
         AxisStatus AxisStatusAZ;
         AxisDirection AxisDirectionAZ;
 
-        double Approach; // approach distance
+        // Motion Control
 
-        // Previous motion direction
-        // TODO: Switch to AltAz from N-S/W-E
-        typedef enum
-        {
-            PREVIOUS_NS_MOTION_NORTH   = DIRECTION_NORTH,
-            PREVIOUS_NS_MOTION_SOUTH   = DIRECTION_SOUTH,
-            PREVIOUS_NS_MOTION_UNKNOWN = -1
-        } PreviousNSMotion_t;
-        typedef enum
-        {
-            PREVIOUS_WE_MOTION_WEST    = DIRECTION_WEST,
-            PREVIOUS_WE_MOTION_EAST    = DIRECTION_EAST,
-            PREVIOUS_WE_MOTION_UNKNOWN = -1
-        } PreviousWEMotion_t;
-
-        // GoTo
-        INDI::IEquatorialCoordinates GoToTarget;
-        int slewTicks, maxSlewTicks;
+        // approach distance
+        double Approach;
 
         // Tracking
-        INDI::IEquatorialCoordinates CurrentTrackingTarget;
-        INDI::IEquatorialCoordinates NewTrackingTarget;
+        INDI::IEquatorialCoordinates m_SkyTrackingTarget { 0, 0 };
+        INDI::IEquatorialCoordinates m_SkyCurrentRADE {0, 0};
+        INDI::IHorizontalCoordinates m_MountAltAz {0, 0};
+        long OldTrackingTarget[2] { 0, 0 };
+        INDI::ElapsedTimer m_TrackingElapsedTimer;
 
-        // Tracing in timer tick
-        int TraceThisTickCount;
-        bool TraceThisTick;
 
-        // connection
-        bool isRTSCTS;
-        bool isHC;
-
-        uint32_t DBG_CAUX {0};
-        uint32_t DBG_SERIAL {0};
-
-        int32_t range360int(int32_t);
-        void initScope(char const *ip, int port);
-        void initScope();
-        bool detectNetScope(bool set_ip);
-        bool detectNetScope();
         void closeConnection();
         void emulateGPS(AUXCommand &m);
         bool serialReadResponse(AUXCommand c);
         bool tcpReadResponse();
         bool readAUXResponse(AUXCommand c);
         bool processResponse(AUXCommand &cmd);
-        void querryStatus();
+        void queryStatus();
         int sendBuffer(int PortFD, AUXBuffer buf);
         bool sendAUXCommand(AUXCommand &c);
         void formatVersionString(char *s, int n, uint8_t *verBuf);
@@ -215,13 +215,10 @@ class CelestronAUX :
         // FIXME: Combined slew rate?
         int32_t slewRate {0};
 
-        bool m_Tracking {false};
         bool m_SlewingAlt {false}, m_SlewingAz {false};
-        bool gpsemu;
-        bool cw_base_sky = false ;
+        bool m_GPSEmulation {false};
 
-
-
+        // Firmware
         uint8_t m_MainBoardVersion[4] {0};
         uint8_t m_AltitudeVersion[4] {0};
         uint8_t m_AzimuthVersion[4] {0};
@@ -233,8 +230,15 @@ class CelestronAUX :
         // Coord Wrap
         bool m_CordWrapActive {false};
         int32_t m_CordWrapPosition {0};
+        uint32_t m_RequestedCordwrapPos;
 
-        // FP
+        // Debug
+        uint32_t DBG_CAUX {0};
+        uint32_t DBG_SERIAL {0};
+
+        ///////////////////////////////////////////////////////////////////////////////
+        /// Communication
+        ///////////////////////////////////////////////////////////////////////////////
         int modem_ctrl;
         void setRTS(bool rts);
         bool waitCTS(float timeout);
@@ -244,59 +248,58 @@ class CelestronAUX :
         int aux_tty_read(int PortFD, char *buf, int bufsiz, int timeout, int *n);
         int aux_tty_write (int PortFD, char *buf, int bufsiz, float timeout, int *n);
         bool tty_set_speed(int PortFD, speed_t speed);
-        void hex_dump(char *buf, AUXBuffer data, size_t size);
 
+        // connection
+        bool m_IsRTSCTS;
+        bool m_isHandController;
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Celestron AUX Properties
         ///////////////////////////////////////////////////////////////////////////////
 
         // Firmware
-        IText FirmwareT[10] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {7};
         enum {FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS};
-        // Networked Mount autodetect
-        ISwitch NetDetectS[1];
-        ISwitchVectorProperty NetDetectSP;
         // Mount type
-        ISwitch MountTypeS[2];
-        ISwitchVectorProperty MountTypeSP;
+        INDI::PropertySwitch MountTypeSP {2};
         enum
         {
             MOUNT_EQUATORIAL,
             MOUNT_ALTAZ
         };
-        // Mount Cordwrap
-        ISwitch CordWrapS[2];
-        ISwitchVectorProperty CordWrapSP;
+
+        // Mount Cord wrap Toogle
+        INDI::PropertySwitch CordWrapToggleSP {2};
         enum { CORDWRAP_OFF, CORDWRAP_ON };
-        ISwitch CWPosS[4];
-        ISwitchVectorProperty CWPosSP;
+
+        // Mount Coord wrap Position
+        INDI::PropertySwitch CordWrapPositionSP {4};
         enum { CORDWRAP_N, CORDWRAP_E, CORDWRAP_S, CORDWRAP_W };
+
         // Cordwrap base (0-encoder/True directions)
-        ISwitch CWBaseS[2];
-        ISwitchVectorProperty CWBaseSP;
-        enum {CW_BASE_ENC, CW_BASE_SKY}; // Use 0-encoders / Sky directions as base for parking and cordwrap
+        // Use 0-encoders / Sky directions as base for parking and cordwrap
+        INDI::PropertySwitch CordWrapBaseSP {2};
+        enum {CW_BASE_ENC, CW_BASE_SKY};
 
         // GPS emulator
-        ISwitch GPSEmuS[2];
-        ISwitchVectorProperty GPSEmuSP;
+        INDI::PropertySwitch GPSEmuSP {2};
         enum { GPSEMU_OFF, GPSEMU_ON };
-        // guide
-        INumber GuideRateN[2] {};
-        INumberVectorProperty GuideRateNP;
+
+        // Guide Rate
+        INDI::PropertyNumber GuideRateNP {2};
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Static Const Private Variables
         ///////////////////////////////////////////////////////////////////////////////
 
+    private:
+
         // One definition rule (ODR) constants
         // AUX commands use 24bit integer as a representation of angle in units of
         // fractional revolutions. Thus 2^24 steps makes full revolution.
         static constexpr int32_t STEPS_PER_REVOLUTION {16777216};
-    public:
         static constexpr double STEPS_PER_DEGREE {STEPS_PER_REVOLUTION / 360.0};
-    private:
+
         static constexpr double DEFAULT_SLEW_RATE {STEPS_PER_DEGREE * 2.0};
         static constexpr double MAX_ALT {90.0 * STEPS_PER_DEGREE};
         static constexpr double MIN_ALT {-90.0 * STEPS_PER_DEGREE};
@@ -308,10 +311,6 @@ class CelestronAUX :
         // to 61440/STEPS_PER_DEGREE = 1.318359375.
         static constexpr double TRACK_SCALE {61440 / STEPS_PER_DEGREE};
         static constexpr double SIDERAL_RATE {1.002737909350795};
-        static constexpr uint8_t MAX_SLEW_RATE {9};
-        static constexpr uint8_t FIND_SLEW_RATE {7};
-        static constexpr uint8_t CENTERING_SLEW_RATE {3};
-        static constexpr uint8_t GUIDE_SLEW_RATE {2};
         static constexpr uint32_t BUFFER_SIZE {10240};
         // seconds
         static constexpr uint8_t READ_TIMEOUT {1};
@@ -319,5 +318,8 @@ class CelestronAUX :
         static constexpr uint8_t CTS_TIMEOUT {100};
         // ms
         static constexpr uint8_t RTS_DELAY {50};
+        // Coord Wrap
+        static constexpr const char *CORDWRAP_TAB {"Coord Wrap"};
+        static constexpr const char *MOUNTINFO_TAB {"Mount info"};
 
 };

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -179,7 +179,7 @@ class CelestronAUX :
          * @return True if successful, false otherwise.
          */
         bool trackByMode(INDI_HO_AXIS axis, uint8_t mode);
-        bool trackingRequested();
+        bool isTrackingRequested();
 
         bool getStatus(INDI_HO_AXIS axis);
         bool getEncoder(INDI_HO_AXIS axis);
@@ -202,7 +202,7 @@ class CelestronAUX :
         void hex_dump(char *buf, AUXBuffer data, size_t size);
         double MicrostepsToDegrees(INDI_HO_AXIS axis, uint32_t steps);
         uint32_t DegreesToMicrosteps(INDI_HO_AXIS axis, double degrees);
-        bool getCurrentRADE(INDI::IHorizontalCoordinates altaz, INDI::IEquatorialCoordinates &rade);
+        bool getCurrentRADE(INDI::IHorizontalCoordinates mountAxisCoordinates, INDI::IEquatorialCoordinates &rade);
         int32_t clampStepsPerRevolution(int32_t);
 
         /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -318,6 +318,9 @@ class CelestronAUX :
         INDI::PropertySwitch GPSEmuSP {2};
         enum { GPSEMU_OFF, GPSEMU_ON };
 
+        // Horizontal Coords
+        INDI::PropertyNumber HorizontalCoordsNP {2};
+
         // Guide Rate
         INDI::PropertyNumber GuideRateNP {2};
 
@@ -330,6 +333,15 @@ class CelestronAUX :
         double m_TrackStartSteps[2] = {0,0};
 
         // PID controllers
+        INDI::PropertyNumber Axis1PIDNP {3};
+        INDI::PropertyNumber Axis2PIDNP {3};
+        enum
+        {
+            Propotional,
+            Derivative,
+            Integral
+        };
+
         std::unique_ptr<PID> m_Controllers[2];
 
         //INDI::PropertyNumber GainNP {2};
@@ -344,17 +356,13 @@ class CelestronAUX :
         // fractional revolutions. Thus 2^24 steps makes full revolution.
         static constexpr int32_t STEPS_PER_REVOLUTION {16777216};
         static constexpr double STEPS_PER_DEGREE {STEPS_PER_REVOLUTION / 360.0};
+        static constexpr double STEPS_PER_ARCSEC {STEPS_PER_DEGREE / 3600.0};
         static constexpr double DEGREES_PER_STEP {360.0 / STEPS_PER_REVOLUTION};
 
         // Measured rate that would result in 1 step/sec
         static constexpr uint32_t GAIN_STEPS {80};
 
-        static constexpr double DEFAULT_SLEW_RATE {STEPS_PER_DEGREE * 2.0};
-        static constexpr double MAX_ALT {90.0 * STEPS_PER_DEGREE};
-        static constexpr double MIN_ALT {-90.0 * STEPS_PER_DEGREE};
-
         // MC_SET_POS_GUIDERATE & MC_SET_NEG_GUIDERATE use 24bit number rate in
-        // units of 0.25 arc sec per sec. So 1 arcsec/s ==> rate = 4
         static constexpr uint8_t RATE_PER_ARCSEC {4};
 
         static constexpr uint32_t BUFFER_SIZE {10240};
@@ -364,7 +372,7 @@ class CelestronAUX :
         static constexpr uint8_t CTS_TIMEOUT {100};
         // Coord Wrap
         static constexpr const char *CORDWRAP_TAB {"Coord Wrap"};
-        static constexpr const char *MOUNTINFO_TAB {"Mount info"};
+        static constexpr const char *MOUNTINFO_TAB {"Mount Info"};
         // Track modes
         static constexpr uint16_t AUX_SIDEREAL {0xffff};
         static constexpr uint16_t AUX_SOLAR {0xfffe};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -157,8 +157,8 @@ class CelestronAUX :
         /////////////////////////////////////////////////////////////////////////////////////
         /// Tracking
         /////////////////////////////////////////////////////////////////////////////////////
-        //bool (INDI_HO_AXIS axis, double rate)
         bool SetTrackEnabled(bool enabled) override;
+        bool SetTrackMode(uint8_t mode) override;
         bool SetTrackRate(double raRate, double deRate) override;
         void resetTracking();
 
@@ -171,6 +171,14 @@ class CelestronAUX :
          * @return True if successful, false otherwise.
          */
         bool trackByRate(INDI_HO_AXIS axis, int32_t rate);
+
+        /**
+         * @brief trackByRate Track using specific mode (sidereal, solar, or lunar)
+         * @param axis AZ or ALT
+         * @param mode sidereal, solar, or lunar
+         * @return True if successful, false otherwise.
+         */
+        bool trackByMode(INDI_HO_AXIS axis, uint8_t mode);
         bool trackingRequested();
 
         bool getStatus(INDI_HO_AXIS axis);
@@ -184,7 +192,7 @@ class CelestronAUX :
         bool setCordWrapPosition(uint32_t steps);
         uint32_t getCordWrapPosition();
 
-private:
+    private:
         /////////////////////////////////////////////////////////////////////////////////////
         /// Misc
         /////////////////////////////////////////////////////////////////////////////////////
@@ -203,7 +211,7 @@ private:
         bool guidePulse(INDI_EQ_AXIS axis, uint32_t ms, int8_t rate);
 
 
-    private:        
+    private:
         // Axis Information
         AxisStatus m_AxisStatus[2] {STOPPED, STOPPED};
         AxisDirection m_AxisDirection[2] {FORWARD, FORWARD};
@@ -211,6 +219,7 @@ private:
         // Guiding offset in steps
         // For each pulse, we modify the offset so that we can add it to our current tracking traget
         int32_t m_GuideOffset[2] = {0, 0};
+        double m_TrackRates[2] = {TRACKRATE_SIDEREAL, 0};
 
         // approach distance
         double Approach;
@@ -218,7 +227,7 @@ private:
         // Tracking
         INDI::IEquatorialCoordinates m_SkyTrackingTarget { 0, 0 };
         INDI::IEquatorialCoordinates m_SkyCurrentRADE {0, 0};
-        INDI::IHorizontalCoordinates m_MountAltAz {0, 0};
+        INDI::IHorizontalCoordinates m_MountCoordinates {0, 0};
         INDI::ElapsedTimer m_TrackingElapsedTimer;
 
 
@@ -232,7 +241,7 @@ private:
         bool tcpReadResponse();
         bool readAUXResponse(AUXCommand c);
         bool processResponse(AUXCommand &cmd);
-        int sendBuffer(int PortFD, AUXBuffer buf);
+        int sendBuffer(AUXBuffer buf);
         void formatVersionString(char *s, int n, uint8_t *verBuf);
 
         // GPS Emulation
@@ -268,9 +277,9 @@ private:
         bool detectRTSCTS();
         bool detectHC(char *version, size_t size);
         int response_data_size;
-        int aux_tty_read(int PortFD, char *buf, int bufsiz, int timeout, int *n);
-        int aux_tty_write (int PortFD, char *buf, int bufsiz, float timeout, int *n);
-        bool tty_set_speed(int PortFD, speed_t speed);
+        int aux_tty_read(char *buf, int bufsiz, int timeout, int *n);
+        int aux_tty_write (char *buf, int bufsiz, float timeout, int *n);
+        bool tty_set_speed(speed_t speed);
 
         // connection
         bool m_IsRTSCTS;
@@ -342,10 +351,13 @@ private:
         static constexpr uint8_t READ_TIMEOUT {1};
         // ms
         static constexpr uint8_t CTS_TIMEOUT {100};
-        // ms
-        static constexpr uint8_t RTS_DELAY {50};
         // Coord Wrap
         static constexpr const char *CORDWRAP_TAB {"Coord Wrap"};
         static constexpr const char *MOUNTINFO_TAB {"Mount info"};
+        // Track modes
+        static constexpr uint16_t AUX_SIDEREAL {0xffff};
+        static constexpr uint16_t AUX_SOLAR {0xfffe};
+        static constexpr uint16_t AUX_LUNAR {0xfffd};
+
 
 };

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -285,8 +285,8 @@ class CelestronAUX :
         bool tty_set_speed(speed_t speed);
 
         // connection
-        bool m_IsRTSCTS;
-        bool m_isHandController;
+        bool m_IsRTSCTS {false};
+        bool m_isHandController {false};
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Celestron AUX Properties

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -223,6 +223,9 @@ class CelestronAUX :
         int32_t m_GuideOffset[2] = {0, 0};
         double m_TrackRates[2] = {TRACKRATE_SIDEREAL, 0};
 
+        // Home declination
+        double m_HomePole {90};
+
         // approach distance
         double Approach;
 

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -97,6 +97,7 @@ class CelestronAUX :
         void syncCoordWrapPosition();
 
     protected:
+        virtual void ISGetProperties(const char *dev) override;
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
         virtual bool saveConfigItems(FILE *fp) override;
@@ -344,6 +345,14 @@ class CelestronAUX :
 
         std::unique_ptr<PID> m_Controllers[2];
 
+        INDI::PropertySwitch PortTypeSP {2};
+        enum
+        {
+            PORT_AUX_PC,
+            PORT_HC_USB,
+        };
+
+        int m_ConfigPortType {PORT_AUX_PC};
         //INDI::PropertyNumber GainNP {2};
         ///////////////////////////////////////////////////////////////////////////////
         /// Static Const Private Variables

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -243,6 +243,7 @@ class CelestronAUX :
 
         // approach distance
         double Approach {1};
+        TelescopePierSide m_TargetPierSide {PIER_UNKNOWN};
 
         // Tracking targets
         INDI::IEquatorialCoordinates m_SkyTrackingTarget { 0, 0 };

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -199,7 +199,10 @@ class CelestronAUX :
         /// Misc
         /////////////////////////////////////////////////////////////////////////////////////
         double getNorthAz();
-        bool isNorthHemisphere() const {return m_Location.latitude >= 0;}
+        bool isNorthHemisphere() const
+        {
+            return m_Location.latitude >= 0;
+        }
         bool getVersion(AUXTargets target);
         void getVersions();
         void hex_dump(char *buf, AUXBuffer data, size_t size);
@@ -212,6 +215,8 @@ class CelestronAUX :
 
         uint32_t RAToEncoder(double ra);
         double DEToEncoder(double de);
+
+        void EncoderToRADE();
 
         bool getCurrentRADE(INDI::IHorizontalCoordinates mountAxisCoordinates, INDI::IEquatorialCoordinates &rade);
         int32_t clampStepsPerRevolution(int32_t);
@@ -343,7 +348,7 @@ class CelestronAUX :
         INDI::PropertyNumber AngleNP {2};
 
         int32_t m_LastTrackRate[2] = {0, 0};
-        double m_TrackStartSteps[2] = {0,0};
+        double m_TrackStartSteps[2] = {0, 0};
 
         // PID controllers
         INDI::PropertyNumber Axis1PIDNP {3};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -212,8 +212,9 @@ class CelestronAUX :
 
         double EncodersToHours(uint32_t steps);
         uint32_t HoursToEncoders(double hour);
-
         uint32_t RAToEncoders(double ra);
+
+        double EncodersToDE(uint32_t steps, TelescopePierSide pierSide);
         double DEToEncoders(double de);
 
         void EncodersToAltAz(INDI::IHorizontalCoordinates &coords);

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -207,20 +207,24 @@ class CelestronAUX :
         void getVersions();
         void hex_dump(char *buf, AUXBuffer data, size_t size);
 
-        double EncoderToDegrees(uint32_t steps);
-        uint32_t DegreesToEncoder(double degrees);
+        double EncodersToDegrees(uint32_t steps);
+        uint32_t DegreesToEncoders(double degrees);
 
-        double EncoderToHours(uint32_t steps);
-        uint32_t HoursToEncoder(double hour);
+        double EncodersToHours(uint32_t steps);
+        uint32_t HoursToEncoders(double hour);
 
-        uint32_t RAToEncoder(double ra);
-        double DEToEncoder(double de);
+        uint32_t RAToEncoders(double ra);
+        double DEToEncoders(double de);
 
-        void EncoderToRADE();
+        void EncodersToAltAz(INDI::IHorizontalCoordinates &coords);
+        void EncodersToRADE(INDI::IEquatorialCoordinates &coords, TelescopePierSide &pierSide);
 
-        bool getCurrentRADE(INDI::IHorizontalCoordinates mountAxisCoordinates, INDI::IEquatorialCoordinates &rade);
-        int32_t clampStepsPerRevolution(int32_t);
-
+        /**
+         * @brief mountToSkyCoords Convert mount coordinates to equatorial sky coordinates
+         * @return True if successful, false otherwise.
+         * @note This works for both Alt-Az and Equatorial Mounts.
+         */
+        bool mountToSkyCoords();
         /////////////////////////////////////////////////////////////////////////////////////
         /// Guiding
         /////////////////////////////////////////////////////////////////////////////////////
@@ -237,17 +241,20 @@ class CelestronAUX :
         int32_t m_GuideOffset[2] = {0, 0};
         double m_TrackRates[2] = {TRACKRATE_SIDEREAL, 0};
 
-        // Home declination
-        double m_HomePole {90};
-
         // approach distance
-        double Approach;
+        double Approach {1};
 
-        // Tracking
+        // Tracking targets
         INDI::IEquatorialCoordinates m_SkyTrackingTarget { 0, 0 };
         INDI::IEquatorialCoordinates m_SkyGOTOTarget { 0, 0 };
+
+        // Actual Sky Equatorial Coordinates
         INDI::IEquatorialCoordinates m_SkyCurrentRADE {0, 0};
-        INDI::IHorizontalCoordinates m_MountCoordinates {0, 0};
+
+        // Current Mount Alt/Az or RA/DE
+        INDI::IEquatorialCoordinates m_MountCurrentRADE {0, 0};
+        INDI::IHorizontalCoordinates m_MountCurrentAltAz {0, 0};
+
         INDI::ElapsedTimer m_TrackingElapsedTimer;
 
 

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -45,7 +45,7 @@ class CelestronAUX :
 {
     public:
         CelestronAUX();
-        ~CelestronAUX();
+        ~CelestronAUX() override;
 
         virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                                char *formats[], char *names[], int n) override;
@@ -155,6 +155,11 @@ class CelestronAUX :
          * @return True if successful, false otherwise.
          */
         bool slewByRate(INDI_HO_AXIS axis, int8_t rate);
+
+        // Go to index position or level
+        bool goHome(INDI_HO_AXIS axis);
+        bool isHomingDone(INDI_HO_AXIS axis);
+        bool m_HomingProgress[2] = {false, false};
 
         /////////////////////////////////////////////////////////////////////////////////////
         /// Tracking
@@ -379,6 +384,15 @@ class CelestronAUX :
         };
 
         int m_ConfigPortType {PORT_AUX_PC};
+
+        // Home/Level
+        INDI::PropertySwitch HomeSP {3};
+        enum
+        {
+            HOME_AXIS1,
+            HOME_AXIS2,
+            HOME_ALL
+        };
         //INDI::PropertyNumber GainNP {2};
         ///////////////////////////////////////////////////////////////////////////////
         /// Static Const Private Variables

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -199,11 +199,20 @@ class CelestronAUX :
         /// Misc
         /////////////////////////////////////////////////////////////////////////////////////
         double getNorthAz();
+        bool isNorthHemisphere() const {return m_Location.latitude >= 0;}
         bool getVersion(AUXTargets target);
         void getVersions();
         void hex_dump(char *buf, AUXBuffer data, size_t size);
-        double MicrostepsToDegrees(INDI_HO_AXIS axis, uint32_t steps);
-        uint32_t DegreesToMicrosteps(INDI_HO_AXIS axis, double degrees);
+
+        double EncoderToDegrees(uint32_t steps);
+        uint32_t DegreesToEncoder(double degrees);
+
+        double EncoderToHours(uint32_t steps);
+        uint32_t HoursToEncoder(double hour);
+
+        uint32_t RAToEncoder(double ra);
+        double DEToEncoder(double de);
+
         bool getCurrentRADE(INDI::IHorizontalCoordinates mountAxisCoordinates, INDI::IEquatorialCoordinates &rade);
         int32_t clampStepsPerRevolution(int32_t);
 
@@ -370,6 +379,9 @@ class CelestronAUX :
         static constexpr double STEPS_PER_DEGREE {STEPS_PER_REVOLUTION / 360.0};
         static constexpr double STEPS_PER_ARCSEC {STEPS_PER_DEGREE / 3600.0};
         static constexpr double DEGREES_PER_STEP {360.0 / STEPS_PER_REVOLUTION};
+
+        static constexpr double STEPS_PER_HOUR {STEPS_PER_REVOLUTION / 24.0};
+        static constexpr double HOURS_PER_STEP {24.0 / STEPS_PER_REVOLUTION};
 
         // Measured rate that would result in 1 step/sec
         static constexpr uint32_t GAIN_STEPS {80};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -363,6 +363,8 @@ class CelestronAUX :
 
         int32_t m_LastTrackRate[2] = {0, 0};
         double m_TrackStartSteps[2] = {0, 0};
+        double m_LastOffset[2] = {0, 0};
+        uint8_t m_OffsetSwitchSettle[2] = {0, 0};
 
         // PID controllers
         INDI::PropertyNumber Axis1PIDNP {3};

--- a/indi-celestronaux/indi_celestronaux.xml.cmake
+++ b/indi-celestronaux/indi_celestronaux.xml.cmake
@@ -9,7 +9,23 @@
       <driver name="Celestron AUX">indi_celestron_aux</driver>
       <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
    </device>
-   <device label="Nexstar Evolution" manufacturer="Celestron">
+   <device label="Evolution WiFi" manufacturer="Celestron">
+      <driver name="Celestron AUX">indi_celestron_aux</driver>
+      <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
+   </device>
+   <device label="Evolution WiFi Wedge" manufacturer="Celestron">
+      <driver name="Celestron AUX">indi_celestron_aux</driver>
+      <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
+   </device>
+   <device label="CGEM II WiFi" manufacturer="Celestron">
+      <driver name="Celestron AUX">indi_celestron_aux</driver>
+      <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
+   </device>
+   <device label="CGX WiFi" manufacturer="Celestron">
+      <driver name="Celestron AUX">indi_celestron_aux</driver>
+      <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
+   </device>
+   <device label="Advanced VX WiFi" manufacturer="Celestron">
       <driver name="Celestron AUX">indi_celestron_aux</driver>
       <version>@CAUX_VERSION_MAJOR@.@CAUX_VERSION_MINOR@</version>
    </device>

--- a/indi-celestronaux/simulator/nse_telescope.py
+++ b/indi-celestronaux/simulator/nse_telescope.py
@@ -192,6 +192,7 @@ class NexStarScope:
     
     __mcfw_ver=(7,11,5100//256,5100%256)
     __hcfw_ver=(5,28,5300//256,5300%256)
+    __mbfw_ver=(1,0,0,1)
     
     trg=('MB', 'HC', 'UKN1', 'HC+', 'AZM', 'ALT', 'APP', 
             'GPS', 'WiFi', 'BAT', 'CHG', 'LIGHT')
@@ -228,7 +229,7 @@ class NexStarScope:
         self._other_handlers = {
             0x10: NexStarScope.cmd_0x10,
             0x18: NexStarScope.cmd_0x18,
-            0xfe: NexStarScope.send_ack,
+            0xfe: NexStarScope.fw_version,
         }
         self._mc_handlers = {
           0x01 : NexStarScope.get_position,
@@ -517,6 +518,8 @@ class NexStarScope:
             trg = '???'
         if trg in ('ALT','AZM'):
             return bytes(NexStarScope.__mcfw_ver)
+        elif trg in ('MB', ):
+            return bytes(NexStarScope.__mbfw_ver)
         elif trg in ('HC', 'HC+'):
             return bytes(NexStarScope.__hcfw_ver)
         else :


### PR DESCRIPTION
This is a large refactor for the INDI Celestron AUX driver:

+ Add Track modes.
+ Add Track rates.
+ Fix parking/unparking.
+ Add PID control loop.
+ Support for both Alt-Az and Equatorial mounts (EQ mounts not well tested).
+ Migrate to new INDI styled properties.
+ Add new mount types in XML for selection.
+ Add raw mount information and angle transformations.
+ Improve documentation.

I just had one chance to test it tonight before the clouds rolled in. Tracking is OK. 30 seconds exposures are OK, sometimes star trails. The PID algorithm could be improved.