### PR TITLE
Fix getTrackingAdjustment sscanf format to return decimal value

### DIFF
--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -2044,7 +2044,7 @@ bool LX200StarGo::getTrackingAdjustment(double *valueRA)
     if (!sendQuery(":X42#", response))
         return false;
 
-    if (sscanf(response, "or%04i#", &raValue) < 1)
+    if (sscanf(response, "or%04d#", &raValue) < 1)
     {
         LOG_ERROR("Unable to parse response");
         return false;


### PR DESCRIPTION
getTrackingAdjustment currently treats values from the device as octal but they should be decimal.
Change sscanf format from i to d to return a decimal value