### PR TITLE
Spec autosetup

### DIFF
--- a/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
+++ b/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 %define _lto_cflags %{nil}

--- a/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
+++ b/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 %define _lto_cflags %{nil}

--- a/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
+++ b/indi-aagcloudwatcher-ng/indi-aagcloudwatcher-ng.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 %define _lto_cflags %{nil}

--- a/indi-ahp-xc/indi-ahp-xc.spec
+++ b/indi-ahp-xc/indi-ahp-xc.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-ahp-xc/indi-ahp-xc.spec
+++ b/indi-ahp-xc/indi-ahp-xc.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-ahp-xc/indi-ahp-xc.spec
+++ b/indi-ahp-xc/indi-ahp-xc.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-aok/indi-aok.spec
+++ b/indi-aok/indi-aok.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-aok/indi-aok.spec
+++ b/indi-aok/indi-aok.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-aok/indi-aok.spec
+++ b/indi-aok/indi-aok.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-apogee/indi-apogee.spec
+++ b/indi-apogee/indi-apogee.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-apogee/indi-apogee.spec
+++ b/indi-apogee/indi-apogee.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-apogee/indi-apogee.spec
+++ b/indi-apogee/indi-apogee.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-armadillo-platypus/indi-armadillo-platypus.spec
+++ b/indi-armadillo-platypus/indi-armadillo-platypus.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-armadillo-platypus/indi-armadillo-platypus.spec
+++ b/indi-armadillo-platypus/indi-armadillo-platypus.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-armadillo-platypus/indi-armadillo-platypus.spec
+++ b/indi-armadillo-platypus/indi-armadillo-platypus.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-asi/indi-asi.spec
+++ b/indi-asi/indi-asi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-asi/indi-asi.spec
+++ b/indi-asi/indi-asi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-asi/indi-asi.spec
+++ b/indi-asi/indi-asi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astrolink4/indi-astrolink4.spec
+++ b/indi-astrolink4/indi-astrolink4.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astrolink4/indi-astrolink4.spec
+++ b/indi-astrolink4/indi-astrolink4.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astrolink4/indi-astrolink4.spec
+++ b/indi-astrolink4/indi-astrolink4.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astromechfoc/indi-astromechfoc.spec
+++ b/indi-astromechfoc/indi-astromechfoc.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astromechfoc/indi-astromechfoc.spec
+++ b/indi-astromechfoc/indi-astromechfoc.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-astromechfoc/indi-astromechfoc.spec
+++ b/indi-astromechfoc/indi-astromechfoc.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-atik/indi-atik.spec
+++ b/indi-atik/indi-atik.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-atik/indi-atik.spec
+++ b/indi-atik/indi-atik.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-atik/indi-atik.spec
+++ b/indi-atik/indi-atik.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-avalon/indi-avalon.spec
+++ b/indi-avalon/indi-avalon.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-avalon/indi-avalon.spec
+++ b/indi-avalon/indi-avalon.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-avalon/indi-avalon.spec
+++ b/indi-avalon/indi-avalon.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-beefocus/indi-beefocus.spec
+++ b/indi-beefocus/indi-beefocus.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-beefocus/indi-beefocus.spec
+++ b/indi-beefocus/indi-beefocus.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-beefocus/indi-beefocus.spec
+++ b/indi-beefocus/indi-beefocus.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-celestronaux/indi-celestronaux.spec
+++ b/indi-celestronaux/indi-celestronaux.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-celestronaux/indi-celestronaux.spec
+++ b/indi-celestronaux/indi-celestronaux.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-celestronaux/indi-celestronaux.spec
+++ b/indi-celestronaux/indi-celestronaux.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dreamfocuser/indi-dreamfocuser.spec
+++ b/indi-dreamfocuser/indi-dreamfocuser.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dreamfocuser/indi-dreamfocuser.spec
+++ b/indi-dreamfocuser/indi-dreamfocuser.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dreamfocuser/indi-dreamfocuser.spec
+++ b/indi-dreamfocuser/indi-dreamfocuser.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-duino/indi-duino.spec
+++ b/indi-duino/indi-duino.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-duino/indi-duino.spec
+++ b/indi-duino/indi-duino.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-duino/indi-duino.spec
+++ b/indi-duino/indi-duino.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-eqmod/indi-eqmod.spec
+++ b/indi-eqmod/indi-eqmod.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-eqmod/indi-eqmod.spec
+++ b/indi-eqmod/indi-eqmod.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-eqmod/indi-eqmod.spec
+++ b/indi-eqmod/indi-eqmod.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-ffmv/indi-ffmv.spec
+++ b/indi-ffmv/indi-ffmv.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-ffmv/indi-ffmv.spec
+++ b/indi-ffmv/indi-ffmv.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-ffmv/indi-ffmv.spec
+++ b/indi-ffmv/indi-ffmv.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gphoto/indi-gphoto.spec
+++ b/indi-gphoto/indi-gphoto.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gphoto/indi-gphoto.spec
+++ b/indi-gphoto/indi-gphoto.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gphoto/indi-gphoto.spec
+++ b/indi-gphoto/indi-gphoto.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsd/indi-gpsd.spec
+++ b/indi-gpsd/indi-gpsd.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsd/indi-gpsd.spec
+++ b/indi-gpsd/indi-gpsd.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsd/indi-gpsd.spec
+++ b/indi-gpsd/indi-gpsd.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsnmea/indi-gpsnmea.spec
+++ b/indi-gpsnmea/indi-gpsnmea.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsnmea/indi-gpsnmea.spec
+++ b/indi-gpsnmea/indi-gpsnmea.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-gpsnmea/indi-gpsnmea.spec
+++ b/indi-gpsnmea/indi-gpsnmea.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-inovaplx/indi-inovaplx.spec
+++ b/indi-inovaplx/indi-inovaplx.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-inovaplx/indi-inovaplx.spec
+++ b/indi-inovaplx/indi-inovaplx.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-inovaplx/indi-inovaplx.spec
+++ b/indi-inovaplx/indi-inovaplx.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-maxdomeii/indi-maxdomeii.spec
+++ b/indi-maxdomeii/indi-maxdomeii.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-maxdomeii/indi-maxdomeii.spec
+++ b/indi-maxdomeii/indi-maxdomeii.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-maxdomeii/indi-maxdomeii.spec
+++ b/indi-maxdomeii/indi-maxdomeii.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mgen/indi-mgen.spec
+++ b/indi-mgen/indi-mgen.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mgen/indi-mgen.spec
+++ b/indi-mgen/indi-mgen.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mgen/indi-mgen.spec
+++ b/indi-mgen/indi-mgen.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mi/indi-mi.spec
+++ b/indi-mi/indi-mi.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mi/indi-mi.spec
+++ b/indi-mi/indi-mi.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-mi/indi-mi.spec
+++ b/indi-mi/indi-mi.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nexdome/indi-nexdome.spec
+++ b/indi-nexdome/indi-nexdome.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nexdome/indi-nexdome.spec
+++ b/indi-nexdome/indi-nexdome.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nexdome/indi-nexdome.spec
+++ b/indi-nexdome/indi-nexdome.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nightscape/indi-nightscape.spec
+++ b/indi-nightscape/indi-nightscape.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nightscape/indi-nightscape.spec
+++ b/indi-nightscape/indi-nightscape.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-nightscape/indi-nightscape.spec
+++ b/indi-nightscape/indi-nightscape.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-pentax/indi-pentax.spec
+++ b/indi-pentax/indi-pentax.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-pentax/indi-pentax.spec
+++ b/indi-pentax/indi-pentax.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-pentax/indi-pentax.spec
+++ b/indi-pentax/indi-pentax.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-playerone/indi-playerone.spec
+++ b/indi-playerone/indi-playerone.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-playerone/indi-playerone.spec
+++ b/indi-playerone/indi-playerone.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-playerone/indi-playerone.spec
+++ b/indi-playerone/indi-playerone.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qhy/indi-qhy.spec
+++ b/indi-qhy/indi-qhy.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qhy/indi-qhy.spec
+++ b/indi-qhy/indi-qhy.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qhy/indi-qhy.spec
+++ b/indi-qhy/indi-qhy.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qsi/indi-qsi.spec
+++ b/indi-qsi/indi-qsi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qsi/indi-qsi.spec
+++ b/indi-qsi/indi-qsi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-qsi/indi-qsi.spec
+++ b/indi-qsi/indi-qsi.spec
@@ -53,7 +53,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-rtklib/indi-rtklib.spec
+++ b/indi-rtklib/indi-rtklib.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-rtklib/indi-rtklib.spec
+++ b/indi-rtklib/indi-rtklib.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-rtklib/indi-rtklib.spec
+++ b/indi-rtklib/indi-rtklib.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sbig/indi-sbig.spec
+++ b/indi-sbig/indi-sbig.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sbig/indi-sbig.spec
+++ b/indi-sbig/indi-sbig.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sbig/indi-sbig.spec
+++ b/indi-sbig/indi-sbig.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-shelyak/indi-shelyak.spec
+++ b/indi-shelyak/indi-shelyak.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-shelyak/indi-shelyak.spec
+++ b/indi-shelyak/indi-shelyak.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-shelyak/indi-shelyak.spec
+++ b/indi-shelyak/indi-shelyak.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-spectracyber/indi-spectracyber.spec
+++ b/indi-spectracyber/indi-spectracyber.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-spectracyber/indi-spectracyber.spec
+++ b/indi-spectracyber/indi-spectracyber.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-spectracyber/indi-spectracyber.spec
+++ b/indi-spectracyber/indi-spectracyber.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook-ten/indi-starbook-ten.spec
+++ b/indi-starbook-ten/indi-starbook-ten.spec
@@ -24,7 +24,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook-ten/indi-starbook-ten.spec
+++ b/indi-starbook-ten/indi-starbook-ten.spec
@@ -24,7 +24,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook-ten/indi-starbook-ten.spec
+++ b/indi-starbook-ten/indi-starbook-ten.spec
@@ -24,7 +24,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook/indi-starbook.spec
+++ b/indi-starbook/indi-starbook.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook/indi-starbook.spec
+++ b/indi-starbook/indi-starbook.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-starbook/indi-starbook.spec
+++ b/indi-starbook/indi-starbook.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sv305/indi-sv305.spec
+++ b/indi-sv305/indi-sv305.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sv305/indi-sv305.spec
+++ b/indi-sv305/indi-sv305.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sv305/indi-sv305.spec
+++ b/indi-sv305/indi-sv305.spec
@@ -55,7 +55,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sx/indi-sx.spec
+++ b/indi-sx/indi-sx.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sx/indi-sx.spec
+++ b/indi-sx/indi-sx.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-sx/indi-sx.spec
+++ b/indi-sx/indi-sx.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-toupbase/indi-toupbase.spec
+++ b/indi-toupbase/indi-toupbase.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-toupbase/indi-toupbase.spec
+++ b/indi-toupbase/indi-toupbase.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-toupbase/indi-toupbase.spec
+++ b/indi-toupbase/indi-toupbase.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-webcam/indi-webcam.spec
+++ b/indi-webcam/indi-webcam.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-webcam/indi-webcam.spec
+++ b/indi-webcam/indi-webcam.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/indi-webcam/indi-webcam.spec
+++ b/indi-webcam/indi-webcam.spec
@@ -51,7 +51,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libahp-xc/libahp_xc.spec
+++ b/libahp-xc/libahp_xc.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libahp-xc/libahp_xc.spec
+++ b/libahp-xc/libahp_xc.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libahp-xc/libahp_xc.spec
+++ b/libahp-xc/libahp_xc.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libaltaircam/libaltaircam.spec
+++ b/libaltaircam/libaltaircam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libaltaircam/libaltaircam.spec
+++ b/libaltaircam/libaltaircam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libaltaircam/libaltaircam.spec
+++ b/libaltaircam/libaltaircam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libasi/libasi.spec
+++ b/libasi/libasi.spec
@@ -66,7 +66,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libasi/libasi.spec
+++ b/libasi/libasi.spec
@@ -66,7 +66,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libasi/libasi.spec
+++ b/libasi/libasi.spec
@@ -66,7 +66,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libatik/libatik.spec
+++ b/libatik/libatik.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libatik/libatik.spec
+++ b/libatik/libatik.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libatik/libatik.spec
+++ b/libatik/libatik.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libfishcamp/libfishcamp.spec
+++ b/libfishcamp/libfishcamp.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libfishcamp/libfishcamp.spec
+++ b/libfishcamp/libfishcamp.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libfishcamp/libfishcamp.spec
+++ b/libfishcamp/libfishcamp.spec
@@ -54,7 +54,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libinovasdk/libinovasdk.spec
+++ b/libinovasdk/libinovasdk.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libinovasdk/libinovasdk.spec
+++ b/libinovasdk/libinovasdk.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libinovasdk/libinovasdk.spec
+++ b/libinovasdk/libinovasdk.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmallincam/libmallincam.spec
+++ b/libmallincam/libmallincam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmallincam/libmallincam.spec
+++ b/libmallincam/libmallincam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmallincam/libmallincam.spec
+++ b/libmallincam/libmallincam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmicam/libmicam.spec
+++ b/libmicam/libmicam.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmicam/libmicam.spec
+++ b/libmicam/libmicam.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libmicam/libmicam.spec
+++ b/libmicam/libmicam.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libnncam/libnncam.spec
+++ b/libnncam/libnncam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libnncam/libnncam.spec
+++ b/libnncam/libnncam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libnncam/libnncam.spec
+++ b/libnncam/libnncam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libpktriggercord/libpktriggercord.spec
+++ b/libpktriggercord/libpktriggercord.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libpktriggercord/libpktriggercord.spec
+++ b/libpktriggercord/libpktriggercord.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libpktriggercord/libpktriggercord.spec
+++ b/libpktriggercord/libpktriggercord.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libplayerone/libplayerone.spec
+++ b/libplayerone/libplayerone.spec
@@ -61,7 +61,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libplayerone/libplayerone.spec
+++ b/libplayerone/libplayerone.spec
@@ -61,7 +61,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libplayerone/libplayerone.spec
+++ b/libplayerone/libplayerone.spec
@@ -61,7 +61,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqhy/libqhy.spec
+++ b/libqhy/libqhy.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqsi/libqsi.spec
+++ b/libqsi/libqsi.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqsi/libqsi.spec
+++ b/libqsi/libqsi.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libqsi/libqsi.spec
+++ b/libqsi/libqsi.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libricohcamerasdk/libricohcamerasdk.spec
+++ b/libricohcamerasdk/libricohcamerasdk.spec
@@ -59,7 +59,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libricohcamerasdk/libricohcamerasdk.spec
+++ b/libricohcamerasdk/libricohcamerasdk.spec
@@ -59,7 +59,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libricohcamerasdk/libricohcamerasdk.spec
+++ b/libricohcamerasdk/libricohcamerasdk.spec
@@ -59,7 +59,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsbig/libsbig.spec
+++ b/libsbig/libsbig.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsbig/libsbig.spec
+++ b/libsbig/libsbig.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsbig/libsbig.spec
+++ b/libsbig/libsbig.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libstarshootg/libstarshootg.spec
+++ b/libstarshootg/libstarshootg.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libstarshootg/libstarshootg.spec
+++ b/libstarshootg/libstarshootg.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libstarshootg/libstarshootg.spec
+++ b/libstarshootg/libstarshootg.spec
@@ -56,7 +56,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsv305/libsv305.spec
+++ b/libsv305/libsv305.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsv305/libsv305.spec
+++ b/libsv305/libsv305.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libsv305/libsv305.spec
+++ b/libsv305/libsv305.spec
@@ -58,7 +58,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libtoupcam/libtoupcam.spec
+++ b/libtoupcam/libtoupcam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libtoupcam/libtoupcam.spec
+++ b/libtoupcam/libtoupcam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/libtoupcam/libtoupcam.spec
+++ b/libtoupcam/libtoupcam.spec
@@ -57,7 +57,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/obsolete/indi-nexstarevo/indi-nexstarevo.spec
+++ b/obsolete/indi-nexstarevo/indi-nexstarevo.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -p1 -n %{name}-master
+%autosetup -v -p1
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/obsolete/indi-nexstarevo/indi-nexstarevo.spec
+++ b/obsolete/indi-nexstarevo/indi-nexstarevo.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%autosetup -v -p1
+%autosetup -v -p1 -n indi-3rdparty-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will

--- a/obsolete/indi-nexstarevo/indi-nexstarevo.spec
+++ b/obsolete/indi-nexstarevo/indi-nexstarevo.spec
@@ -52,7 +52,7 @@ data acquisition, monitoring, and a lot more. This is a 3rd party driver.
 
 
 %prep -v
-%setup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-master
 
 %build
 # This package tries to mix and match PIE and PIC which is wrong and will


### PR DESCRIPTION
Change from the setup spec macro to the autosetup spec macro

Sample COPR build: https://copr.fedorainfracloud.org/coprs/xsnrg/indi-3rdparty-bleeding/build/3140620/