### PR TITLE
udev_spec_fix: fix some udev spec file entries that were missed

### DIFF
--- a/indi-dsi/indi-dsi.spec
+++ b/indi-dsi/indi-dsi.spec
@@ -71,7 +71,7 @@ make DESTDIR=%{buildroot} install
 %files
 %{_bindir}/*
 %{_datadir}/indi
-/etc/udev/rules.d/99-meadedsi.rules
+/lib/udev/rules.d/99-meadedsi.rules
 /lib/firmware/meade-deepskyimager.hex
 
 

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -75,7 +75,7 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/*
 %{_includedir}/libapogee
 %{_sysconfdir}/Apogee
-%{_libdir}/udev/rules.d/99-apogee.rules
+/lib/udev/rules.d/99-apogee.rules
 
 
 %changelog

--- a/libapogee/libapogee.spec
+++ b/libapogee/libapogee.spec
@@ -75,7 +75,7 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/*
 %{_includedir}/libapogee
 %{_sysconfdir}/Apogee
-%{_sysconfdir}/udev/rules.d/99-apogee.rules
+%{_libdir}/udev/rules.d/99-apogee.rules
 
 
 %changelog


### PR DESCRIPTION
indi-dsi: https://copr.fedorainfracloud.org/coprs/xsnrg/indi-3rdparty-bleeding/build/3154582/
libapogee: https://copr.fedorainfracloud.org/coprs/xsnrg/indi-3rdparty-bleeding/build/3154802/