### PR TITLE
Fixing Mac Installation problem for libfirmata

### DIFF
--- a/indi-duino/CMakeLists.txt
+++ b/indi-duino/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(indi_duino ${INDI_LIBRARIES} firmata)
 
 install(TARGETS indi_duino RUNTIME DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_duino.xml DESTINATION ${INDI_DATA_DIR})
+install(TARGETS firmata LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 ##################### weather radio #####################
 SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/gason/gason.cpp PROPERTIES COMPILE_FLAGS "-Wno-implicit-fallthrough")
 set(weatherradio_SRCS

--- a/indi-duino/CMakeLists.txt
+++ b/indi-duino/CMakeLists.txt
@@ -60,7 +60,9 @@ target_link_libraries(indi_duino ${INDI_LIBRARIES} firmata)
 
 install(TARGETS indi_duino RUNTIME DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_duino.xml DESTINATION ${INDI_DATA_DIR})
-install(TARGETS firmata LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if (APPLE)
+   install(TARGETS firmata LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif ()
 ##################### weather radio #####################
 SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/gason/gason.cpp PROPERTIES COMPILE_FLAGS "-Wno-implicit-fallthrough")
 set(weatherradio_SRCS


### PR DESCRIPTION
On Linux it appears libfirmata is a static library, but it is installing as a dynamic library on MacOS.  As such, we need to install the dynamic library, not leave it in the build folder.