### PR TITLE
celestronaux: add missing header file

### DIFF
--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <vector>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef std::vector<uint8_t> AUXBuffer;


### PR DESCRIPTION
When compiling `indi-celestronaux` version 1.8.4 I got the following error message:

```
In file included from /var/tmp/portage/sci-libs/indilib-driver-celestronaux-1.9.4/work/indi-3rdparty-1.9.4/indi-celestronaux/auxproto.cpp:24:
/var/tmp/portage/sci-libs/indilib-driver-celestronaux-1.9.4/work/indi-3rdparty-1.9.4/indi-celestronaux/auxproto.h:120:9: error: ‘size_t’ does not name a type
  120 |         size_t dataSize() const
      |         ^~~~~~
```

This patch adds the necessary header file, so the type `size_t` is known to the compiler.

* Operating System: Linux
* Distribution: Gentoo
* Compiler: GCC 11.2.0