### PR TITLE
indi-gphoto: Fix open() call

### DIFF
--- a/indi-gphoto/gphoto_ccd.cpp
+++ b/indi-gphoto/gphoto_ccd.cpp
@@ -1460,7 +1460,7 @@ bool GPhotoCCD::grabImage()
     {
         if (isSimulation())
         {
-            int fd = open(UploadFileT[0].text, O_RDONLY | S_IRUSR);
+            int fd = open(UploadFileT[0].text, O_RDONLY);
             struct stat sb;
 
             // Get file size


### PR DESCRIPTION
S_IRUSR is a valid "mode" parameter for O_CREAT and O_TMPFILE.

S_IRUSR is not a valid "flags" parameter, and in addition to being
wrong it is architecture dependent which flag happens to have the
same value.

@knro This was introduced by commit aa3d611039728f4702ecbd477e35bcd39f3eb710.