### PR TITLE
Fix properly override of FIRMWARE_INSTALL_DIR

### DIFF
--- a/libfishcamp/CMakeLists.txt
+++ b/libfishcamp/CMakeLists.txt
@@ -10,14 +10,14 @@ find_package(INDI REQUIRED)
 include_directories( ${INDI_INCLUDE_DIR})
 
 IF(APPLE)
-set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/fishcamp")
-    ##This one is needed for homebrew
-include_directories( "/usr/local/include")
-    ## This one is needed for Craft
-include_directories("${CMAKE_INSTALL_PREFIX}/include")
+  set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/fishcamp")
+  ##This one is needed for homebrew
+  include_directories( "/usr/local/include")
+  ## This one is needed for Craft
+  include_directories("${CMAKE_INSTALL_PREFIX}/include")
 ELSE(APPLE)
-set(FIRMWARE_INSTALL_DIR "/lib/firmware")
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+  set(FIRMWARE_INSTALL_DIR "/lib/firmware" CACHE STRING "libfishcamp firmware installation dir")
+  set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
 ENDIF(APPLE)
 #***********************************************************
 find_package(USB1 REQUIRED)
@@ -44,6 +44,6 @@ INSTALL(TARGETS fishcamp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install( FILES gdr_usb.hex Guider_mono_rev16_intel.srec DESTINATION ${FIRMWARE_INSTALL_DIR})
 IF(NOT APPLE)
-install(FILES 99-fishcamp.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  install(FILES 99-fishcamp.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 ENDIF(NOT APPLE)
 

--- a/libsbig/CMakeLists.txt
+++ b/libsbig/CMakeLists.txt
@@ -21,7 +21,7 @@ if (APPLE)
 
 elseif (UNIX AND NOT WIN32)
 
-  set (FIRMWARE_INSTALL_DIR "/lib/firmware")
+  set (FIRMWARE_INSTALL_DIR "/lib/firmware" CACHE STRING "sbig firmware installation directory")
 
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
     set_property (TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_armhf.bin")


### PR DESCRIPTION
Also reformat libfishcamp CMakeLists

This fix #547 

Attached cmake_install file pre and post fix where it can be seen the fix working

[cmake_install-post.txt](https://github.com/indilib/indi-3rdparty/files/8110323/cmake_install-post.txt)
[cmake_install-post-libfishcamp.txt](https://github.com/indilib/indi-3rdparty/files/8110324/cmake_install-post-libfishcamp.txt)
[cmake_install-pre.txt](https://github.com/indilib/indi-3rdparty/files/8110325/cmake_install-pre.txt)
[cmake_install-pre-libfishcamp.txt](https://github.com/indilib/indi-3rdparty/files/8110326/cmake_install-pre-libfishcamp.txt)
