### PR TITLE
Fix ASICamera version

### DIFF
--- a/libasi/CMakeLists.txt
+++ b/libasi/CMakeLists.txt
@@ -7,7 +7,7 @@ project (libasi)
 # Using ASI ST4 SDK Version 1.0 updated on 2018-07-23
 # Using ASI EAF SDK Version 1.4 updated on 2021-05-17
 
-set (ASICAM_VERSION "1.21.3")
+set (ASICAM_VERSION "1.21")
 set (ASICAM_SOVERSION "1")
 
 set (ASIEFW_VERSION "1.7")


### PR DESCRIPTION
Latest version is 1.21, not 1.21.3 (https://astronomy-imaging-camera.com/software-drivers)