### PR TITLE
Change maximum position for astromechfoc from 9999 to 32767.

### DIFF
--- a/indi-astromechfoc/astromech_focuser.cpp
+++ b/indi-astromechfoc/astromech_focuser.cpp
@@ -37,7 +37,7 @@
 static std::unique_ptr<astromechanics_foc> Astromechanics_foc(new astromechanics_foc());
 
 // Delay for receiving messages
-#define FOC_POSMAX_HARDWARE 9999
+#define FOC_POSMAX_HARDWARE 32767
 #define FOC_POSMIN_HARDWARE 0
 
 bool astromechanics_foc::Disconnect()


### PR DESCRIPTION
I was unable to get a 400mm f/2.8 III on a Lens Controller Mark II
to span its entire focus range with the default settings.

With the range [0,32767] it appears to span the whole range, though
it's hard to be sure if the lens is going as far beyond infinity as
lens supports.  Sending 32768 or a higher value to the device makes
it start reporting a negative position number,  so I am pretty sure
that is too far.