### PR TITLE
webcam: fix build failure

### DIFF
--- a/indi-webcam/CMakeLists.txt
+++ b/indi-webcam/CMakeLists.txt
@@ -44,6 +44,8 @@ if (CFITSIO_FOUND)
   include_directories(${CFITSIO_INCLUDE_DIR})
 endif (CFITSIO_FOUND)
 
+include(CMakeCommon)
+
 ########### OpenCV ###############
 set(webcam_SRCS
    ${CMAKE_CURRENT_SOURCE_DIR}/indi_webcam.cpp )


### PR DESCRIPTION
When compiling `indi-webcam` version 1.9.5 I got the following error message:

```
[1/2] /usr/bin/x86_64-pc-linux-gnu-g++  -I/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam_build -I/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam -I/usr/include/libindi  -g -std=c++0x -O2 -pipe -Wno-deprecated-declarations -MD -MT CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o -MF CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o.d -o CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o -c /var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam/indi_webcam.cpp
FAILED: CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++  -I/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam_build -I/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam -I/usr/include/libindi  -g -std=c++0x -O2 -pipe -Wno-deprecated-declarations -MD -MT CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o -MF CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o.d -o CMakeFiles/indi_webcam_ccd.dir/indi_webcam.cpp.o -c /var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam/indi_webcam.cpp
/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam/indi_webcam.cpp: In member function ‘virtual bool indi_webcam::initProperties()’:
/var/tmp/portage/sci-libs/indilib-driver-webcam-1.9.5/work/indi-3rdparty-1.9.5/indi-webcam/indi_webcam.cpp:493:52: error: could not convert ‘{"INDI_RGB", "RGB", 8, true}’ from ‘<brace-enclosed initializer list>’ to ‘INDI::CCD::CaptureFormat’
  493 |     CaptureFormat rgb = {"INDI_RGB", "RGB", 8, true};
      |                                                    ^
      |                                                    |
      |                                                    <brace-enclosed initializer list>
```

This issue seems to be introduced in commit 3b62bcb3cae93062421d041fe38b8e4eb09595c2.

This patch fixes the build issue by including `CMakeCommon` in the `CMakeLists.txt` file like for the other drivers.

 * Operating System: Linux
 * Distribution: Gentoo
 * Compiler: GCC 11.2.0