### PR TITLE
indi-eqmod: recover transient error after 200ms, retry 75 times.

### DIFF
--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -1726,7 +1726,7 @@ bool Skywatcher::dispatch_command(SkywatcherCommand cmd, SkywatcherAxis axis, ch
             {
                 if (i > 0)
                 {
-                    LOGF_WARN("%s() : serial port read failed for %dms (%d retries), assess cable quality.", __FUNCTION__, (i*EQMOD_TIMEOUT)/1000, i);
+                    LOGF_WARN("%s() : serial port read failed for %dms (%d retries), verify mount link.", __FUNCTION__, (i*EQMOD_TIMEOUT)/1000, i);
                 }
                 return true;
             }

--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -1723,7 +1723,13 @@ bool Skywatcher::dispatch_command(SkywatcherCommand cmd, SkywatcherAxis axis, ch
         try
         {
             if (read_eqmod())
+            {
+                if (i > 0)
+                {
+                    LOGF_WARN("%s() : serial port read failed for %dms (%d retries), assess cable quality.", __FUNCTION__, (i*EQMOD_TIMEOUT)/1000, i);
+                }
                 return true;
+            }
         }
         catch (EQModError)
         {
@@ -1749,8 +1755,7 @@ bool Skywatcher::read_eqmod()
     {
         //Have to onsider cases when we read ! (error) or 0x01 (buffer overflow)
         // Read until encountring a CR
-        //if ((err_code = tty_read_section(PortFD, response, 0x0D, 15, &nbytes_read)) != TTY_OK)
-        if ((err_code = tty_read_section(PortFD, response, 0x0D, EQMOD_TIMEOUT, &nbytes_read)) != TTY_OK)
+        if ((err_code = tty_read_section_expanded(PortFD, response, 0x0D, 0, EQMOD_TIMEOUT, &nbytes_read)) != TTY_OK)
         {
             char ttyerrormsg[ERROR_MSG_LENGTH];
             tty_error_msg(err_code, ttyerrormsg, ERROR_MSG_LENGTH);

--- a/indi-eqmod/skywatcher.h
+++ b/indi-eqmod/skywatcher.h
@@ -336,6 +336,6 @@ class Skywatcher
 
         bool snapportstatus[NUMBER_OF_SKYWATCHERAXIS];
 
-        const uint8_t EQMOD_TIMEOUT = 5;
-        const uint8_t EQMOD_MAX_RETRY = 3;
+        const long EQMOD_TIMEOUT = 200000; // us
+        const uint8_t EQMOD_MAX_RETRY = 75;
 };

--- a/indi-eqmod/skywatcher.h
+++ b/indi-eqmod/skywatcher.h
@@ -337,5 +337,5 @@ class Skywatcher
         bool snapportstatus[NUMBER_OF_SKYWATCHERAXIS];
 
         const long EQMOD_TIMEOUT = 200000; // us
-        const uint8_t EQMOD_MAX_RETRY = 75;
+        const uint8_t EQMOD_MAX_RETRY = 10;
 };


### PR DESCRIPTION
This PR reduces the amount of time `indi_eqmod_telescope` waits for the mount to answer on the serial port.

The original timeout was 5 seconds, which is high enough to cause safety issues when moving at a high slew rate, and causes spikes difficult to explain while guiding.

Obviously, there should not be any serial communication issues for the mount to operate safely. However, it may happen that transient errors appear when oxydisation weakens cable connections, or causes a capacitive effect on the RX line which smoothens voltage changes.

Serial communication at 9600 bauds roughly translates to 960 payload bytes per second, and `eqmod` communication is less than 10 bytes per payload. Roughly 11 milliseconds are needed for a payload to be read, neglecting firmware processing time.

The timeout is reduced from 5 seconds to 200ms to limit flooding when communication fails, and the `tty_read_section` is replaced with `tty_read_section_expanded` to manage that sub-second value. A log is output when more than one attempt was made to read from the serial port (probably not a good idea in the execution context, but 200ms+ were just lost anyway).

To preserve the original configuration, the number of retries is raised to 75, though that does make little sense now.