### PR TITLE
New Feature for Touptek Indi Driver: Binning average/add option

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1961,8 +1961,6 @@ bool ToupBase::UpdateCCDFrame(int x, int y, int w, int h)
         return false;
     }
 
-    m_DownloadEstimation = 10000.0; // Experimental: Set Download Estimation to high default value otherwise the next larger frame will time out
-
     // Set UNBINNED coords
     PrimaryCCD.setFrame(x, y, w, h);
 

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1337,10 +1337,10 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState * states, 
         if (!strcmp(name, BinningModeSP.name))
         {
             IUUpdateSwitch(&BinningModeSP, states, names, n);            
-            auto mode = (BinningModeS[TC_BINNING_AVG].s == ISS_ON) ? TC_BINNING_AVG : TC_BINNING_ADD
+            auto mode = (BinningModeS[TC_BINNING_AVG].s == ISS_ON) ? TC_BINNING_AVG : TC_BINNING_ADD;
             m_BinningMode = mode;
             updateBinningMode(PrimaryCCD.getBinX(),mode);
-            LOGF_DEBUG("Set Binning Mode %s", mode == TC_BINNING_AVG ? "AVG" : "ADD);
+            LOGF_DEBUG("Set Binning Mode %s", mode == TC_BINNING_AVG ? "AVG" : "ADD");
             saveConfig(true, BinningModeSP.name);
             return true;
         }

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -2025,20 +2025,20 @@ bool ToupBase::UpdateCCDFrame(int x, int y, int w, int h)
 bool ToupBase::updateBinningMode(int binx, int mode)
 {
     
-    LOGF_ERROR("updateBinningMode%d",mode);
+    LOGF_DEBUG("Function: updateBinningMode(binx:%d,mode:%s)",binx,(mode==BINNING_MODE_ADD) ? "BINNING_MODE_ADD" : "BINNING_MODE_AVG");
 
     int binningMode = binx;
-    LOGF_ERROR("Experimental: binningMode: %x before",binningMode);
+    
     if ((mode == BINNING_MODE_AVG) && (binx>1))
     {
         binningMode = binx | 0x80;  
     }
-    LOGF_ERROR("Experimental: binningMode: %x after",binningMode);
+    LOGF_DEBUG("binningMode code to set: 0x%x",binningMode);
 
     HRESULT rc = FP(put_Option(m_CameraHandle, CP(OPTION_BINNING), binningMode));
     if (FAILED(rc))
     {
-        LOGF_ERROR("Binning %dx%d is not support. %s", binningMode, binningMode, errorCodes[rc].c_str());
+        LOGF_ERROR("Binning %dx%d with Option 0x%x is not support. %s", binx , binx, binningMode, errorCodes[rc].c_str());
         return false;
     }
     
@@ -2056,8 +2056,12 @@ bool ToupBase::UpdateCCDBin(int binx, int biny)
     //        LOG_ERROR("Only 1x1, 2x2, 3x3, and 4x4 modes are supported.");
     //        return false;
     //    }
+    if (binx !=biny)
+    {
+        LOG_ERROR("Binning dimensions must be equal");
+        return false;
+    }
 
-    // TODO add option to select between additive vs. average binning
     return updateBinningMode(binx,m_BinningMode);
 } 
 

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1961,6 +1961,8 @@ bool ToupBase::UpdateCCDFrame(int x, int y, int w, int h)
         return false;
     }
 
+    m_DownloadEstimation = 10000.0; // Experimental: Set Download Estimation to high default value otherwise the next larger frame will time out
+
     // Set UNBINNED coords
     PrimaryCCD.setFrame(x, y, w, h);
 

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -153,7 +153,7 @@ bool ToupBase::initProperties()
     INDI::CCD::initProperties();
 
     ///////////////////////////////////////////////////////////////////////////////////
-    /// Cooler Control
+    /// Binning Mode Control
     ///////////////////////////////////////////////////////////////////////////////////
     IUFillSwitch(&BinningModeS[0], "BINNING_MODE_AVG", "AVG", ISS_OFF);
     IUFillSwitch(&BinningModeS[1], "BINNING_MODE_ADD", "Add", ISS_ON);

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -155,8 +155,8 @@ bool ToupBase::initProperties()
     ///////////////////////////////////////////////////////////////////////////////////
     /// Binning Mode Control
     ///////////////////////////////////////////////////////////////////////////////////
-    IUFillSwitch(&BinningModeS[0], "BINNING_MODE_AVG", "AVG", ISS_OFF);
-    IUFillSwitch(&BinningModeS[1], "BINNING_MODE_ADD", "Add", ISS_ON);
+    IUFillSwitch(&BinningModeS[TC_BINNING_AVG], "BINNING_MODE_AVG", "AVG", ISS_OFF);
+    IUFillSwitch(&BinningModeS[TC_BINNING_ADD], "BINNING_MODE_ADD", "Add", ISS_ON);
     IUFillSwitchVector(&BinningModeSP, BinningModeS, 2, getDeviceName(), "CCD_BINNING_MODE", "Binning Mode", IMAGE_SETTINGS_TAB, IP_WO,
                        ISR_1OFMANY, 0, IPS_IDLE);
     
@@ -1345,15 +1345,15 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState * states, 
             if (BinningModeS[TC_BINNING_AVG].s == ISS_ON)
             {
 
-                m_BinningMode = BINNING_MODE_AVG;
-                updateBinningMode(PrimaryCCD.getBinX(),BINNING_MODE_AVG);
+                m_BinningMode = TC_BINNING_AVG;
+                updateBinningMode(PrimaryCCD.getBinX(),TC_BINNING_AVG);
                 LOG_DEBUG("Set Binning Mode AVG");
             }
                 
             else
             {
-                m_BinningMode = BINNING_MODE_ADD;
-                updateBinningMode(PrimaryCCD.getBinX(),BINNING_MODE_ADD);
+                m_BinningMode = TC_BINNING_ADD;
+                updateBinningMode(PrimaryCCD.getBinX(),TC_BINNING_ADD);
                 LOG_DEBUG("Set Binning Mode ADD");
             }
             return true;
@@ -2025,11 +2025,11 @@ bool ToupBase::UpdateCCDFrame(int x, int y, int w, int h)
 bool ToupBase::updateBinningMode(int binx, int mode)
 {
     
-    LOGF_DEBUG("Function: updateBinningMode(binx:%d,mode:%s)",binx,(mode==BINNING_MODE_ADD) ? "BINNING_MODE_ADD" : "BINNING_MODE_AVG");
+    LOGF_DEBUG("Function: updateBinningMode(binx:%d,mode:%s)",binx,(mode==TC_BINNING_ADD) ? "TC_BINNING_ADD" : "TC_BINNING_AVG");
 
     int binningMode = binx;
     
-    if ((mode == BINNING_MODE_AVG) && (binx>1))
+    if ((mode == TC_BINNING_AVG) && (binx>1))
     {
         binningMode = binx | 0x80;  
     }

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -457,11 +457,11 @@ class ToupBase : public INDI::CCD
         //#############################################################################
         ISwitchVectorProperty BinningModeSP;
         ISwitch BinningModeS[2];
-        enum
+        typedef enum
         {
             TC_BINNING_AVG,
             TC_BINNING_ADD,
-        };
+        } BINNING_MODE;
 
 
         ISwitchVectorProperty CoolerSP;
@@ -647,13 +647,9 @@ class ToupBase : public INDI::CCD
             GAIN_HDR
         };
 
-        typedef enum
-        {
-            BINNING_MODE_AVG,
-            BINNING_MODE_ADD
-        } BINNING_MODE;
+        
 
-        BINNING_MODE m_BinningMode = BINNING_MODE_ADD;
+        BINNING_MODE m_BinningMode = TC_BINNING_ADD;
         uint8_t m_CurrentVideoFormat = TC_VIDEO_COLOR_RGB;
         INDI_PIXEL_FORMAT m_CameraPixelFormat = INDI_RGB;
         eTriggerMode m_CurrentTriggerMode = TRIGGER_VIDEO;

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -418,6 +418,8 @@ class ToupBase : public INDI::CCD
         // Get the current Bayer string used
         const char *getBayerString();
 
+        bool updateBinningMode(int binx, int mode);
+
         //#############################################################################
         // Callbacks
         //#############################################################################
@@ -453,6 +455,15 @@ class ToupBase : public INDI::CCD
         //#############################################################################
         // Properties
         //#############################################################################
+        ISwitchVectorProperty BinningModeSP;
+        ISwitch BinningModeS[2];
+        enum
+        {
+            TC_BINNING_AVG,
+            TC_BINNING_ADD,
+        };
+
+
         ISwitchVectorProperty CoolerSP;
         ISwitch CoolerS[2];
         enum
@@ -636,6 +647,13 @@ class ToupBase : public INDI::CCD
             GAIN_HDR
         };
 
+        typedef enum
+        {
+            BINNING_MODE_AVG,
+            BINNING_MODE_ADD
+        } BINNING_MODE;
+
+        BINNING_MODE m_BinningMode = BINNING_MODE_ADD;
         uint8_t m_CurrentVideoFormat = TC_VIDEO_COLOR_RGB;
         INDI_PIXEL_FORMAT m_CameraPixelFormat = INDI_RGB;
         eTriggerMode m_CurrentTriggerMode = TRIGGER_VIDEO;


### PR DESCRIPTION
The new feature will allow the user to select two different binning modes: "add "or "average" in the INDI control panel 
A new control is added to the Image Control Tab.

I have already presented this work in the INDI Forum. So I want to start my first pull request.

[https://indilib.org/forum/ccds-dslrs/11690-touptek-camera-binning-mode-option-average-add.html](url)

The new feature will allow the user to select two different binning modes add or average in the INDI control panel.
A new control is added to the Image Control Tab.

This feature is offered by the touptek cameras and is documented in the Touptek SDK Documentation

Please note that this is my first pull request to this project. The coding may not follow all the best practices for this project.  

I have tested with a Touptek IMX 571 Color Camera and the corresponding mono model: ATR3CMOS26000KPA and  ATR3CMOS26000KMA.

The compatibility with other cameras has to be tested.
