### PR TITLE
Improvement: Added driver alias 'SVBONY CCD’.

### DIFF
--- a/indi-sv305/indi_sv305_ccd.xml.cmake
+++ b/indi-sv305/indi_sv305_ccd.xml.cmake
@@ -5,5 +5,9 @@
                 <driver name="SVBONY SV305">indi_sv305_ccd</driver>
                 <version>@SV305_VERSION_MAJOR@.@SV305_VERSION_MINOR@</version>
 	</device>
+        <device label="SVBONY CCD" mdpd="true" manufacturer="SVBONY">
+                <driver name="SVBONY CCD">indi_sv305_ccd</driver>
+                <version>@SV305_VERSION_MAJOR@.@SV305_VERSION_MINOR@</version>
+	</device>
 </devGroup>
 </driversList>


### PR DESCRIPTION
- Added device alias 'SVBONY CCD' to driver name 'SVBONY SV305' in indi_sv305_ccd.xml.cmake.
- Since some users do not realize that the driver name 'SVBONY SV305' is a driver for SV405CC or SV905C, a generic name was set.