### PR TITLE
mgen: fix ftdi deprecation.

### DIFF
--- a/indi-mgen/mgen_device.cpp
+++ b/indi-mgen/mgen_device.cpp
@@ -43,6 +43,11 @@
 #include "mgenautoguider.h"
 #include "mgen_device.h"
 
+// There is no official way to detect the version of the FTDI library from headers, hence this ugly method
+#if defined(ftdi_tcioflush)
+#define ftdi_usb_purge_buffers ftdi_tcioflush
+#endif
+
 MGenDevice::MGenDevice()
     : _lock(), ftdi(NULL), is_device_connected(false), tried_turn_on(false), mode(OPM_UNKNOWN), vid(0), pid(0)
 {


### PR DESCRIPTION
This PR fixes the use of a deprecated function from the FTDI library v1.5 in the mgen autoguider driver.