### PR TITLE
mgen: fix ftdi deprecation differently.

### DIFF
--- a/indi-mgen/mgen_device.cpp
+++ b/indi-mgen/mgen_device.cpp
@@ -44,8 +44,11 @@
 #include "mgen_device.h"
 
 // There is no official way to detect the version of the FTDI library from headers, hence this ugly method
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 int ftdi_tcioflush() __attribute__((weak));
 int ftdi_tcioflush(struct ftdi_context *ftdi) { return ftdi_usb_purge_buffers(ftdi); }
+#pragma GCC diagnostic pop
 
 MGenDevice::MGenDevice()
     : _lock(), ftdi(NULL), is_device_connected(false), tried_turn_on(false), mode(OPM_UNKNOWN), vid(0), pid(0)

--- a/indi-mgen/mgen_device.cpp
+++ b/indi-mgen/mgen_device.cpp
@@ -44,9 +44,8 @@
 #include "mgen_device.h"
 
 // There is no official way to detect the version of the FTDI library from headers, hence this ugly method
-#if defined(ftdi_tcioflush)
-#define ftdi_usb_purge_buffers ftdi_tcioflush
-#endif
+int ftdi_tcioflush() __attribute__((weak));
+int ftdi_tcioflush(struct ftdi_context *ftdi) { return ftdi_usb_purge_buffers(ftdi); }
 
 MGenDevice::MGenDevice()
     : _lock(), ftdi(NULL), is_device_connected(false), tried_turn_on(false), mode(OPM_UNKNOWN), vid(0), pid(0)
@@ -257,7 +256,7 @@ int MGenDevice::setOpMode(IOMode const _mode)
             _E("failed setting device line properties to 8-N-1 (%d: %s)", res, ftdi_get_error_string(ftdi));
         }
         /* Purge I/O buffers */
-        else if ((res = ftdi_usb_purge_buffers(ftdi)) < 0)
+        else if ((res = ftdi_tcioflush(ftdi)) < 0)
         {
             _E("failed purging I/O buffers (%d: %s)", res, ftdi_get_error_string(ftdi));
         }


### PR DESCRIPTION
This PR attempts a different approach to manage FTDI 1.4/1.5 deprecated symbol `ftdi_usb_purge_buffers`.