### PR TITLE
Allow ZWO CCDs to be nicknamed, associated by the serial numbers in their firmware.

### DIFF
--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -350,7 +350,7 @@ bool ASIBase::initProperties()
 
     NicknameTP[0].fill("nickname", "nickname", mNickname);
     NicknameTP.fill(getDeviceName(), "NICKNAME", "Nickname", INFO_TAB, IP_RW, 60, IPS_IDLE);
-    
+
     int maxBin = 1;
 
     for (const auto &supportedBin : mCameraInfo.SupportedBins)
@@ -496,8 +496,11 @@ bool ASIBase::updateProperties()
 
         deleteProperty(BlinkNP.getName());
         deleteProperty(SDKVersionSP.getName());
-        deleteProperty(SerialNumberTP.getName());
-        deleteProperty(NicknameTP.getName());
+        if (!mSerialNumber.empty())
+        {
+            deleteProperty(SerialNumberTP.getName());
+            deleteProperty(NicknameTP.getName());
+        }
         deleteProperty(ADCDepthNP.getName());
     }
 

--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -345,6 +345,12 @@ bool ASIBase::initProperties()
     SDKVersionSP[0].fill("VERSION", "Version", ASIGetSDKVersion());
     SDKVersionSP.fill(getDeviceName(), "SDK", "SDK", INFO_TAB, IP_RO, 60, IPS_IDLE);
 
+    SerialNumberTP[0].fill("SN#", "SN#", mSerialNumber);
+    SerialNumberTP.fill(getDeviceName(), "Serial Number", "Serial Number", INFO_TAB, IP_RO, 60, IPS_IDLE);
+
+    NicknameTP[0].fill("nickname", "nickname", mNickname);
+    NicknameTP.fill(getDeviceName(), "NICKNAME", "Nickname", INFO_TAB, IP_RW, 60, IPS_IDLE);
+    
     int maxBin = 1;
 
     for (const auto &supportedBin : mCameraInfo.SupportedBins)
@@ -458,6 +464,8 @@ bool ASIBase::updateProperties()
         defineProperty(BlinkNP);
         defineProperty(ADCDepthNP);
         defineProperty(SDKVersionSP);
+        defineProperty(SerialNumberTP);
+        defineProperty(NicknameTP);
     }
     else
     {
@@ -485,6 +493,8 @@ bool ASIBase::updateProperties()
 
         deleteProperty(BlinkNP.getName());
         deleteProperty(SDKVersionSP.getName());
+        deleteProperty(SerialNumberTP.getName());
+        deleteProperty(NicknameTP.getName());
         deleteProperty(ADCDepthNP.getName());
     }
 

--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -464,8 +464,11 @@ bool ASIBase::updateProperties()
         defineProperty(BlinkNP);
         defineProperty(ADCDepthNP);
         defineProperty(SDKVersionSP);
-        defineProperty(SerialNumberTP);
-        defineProperty(NicknameTP);
+        if (!mSerialNumber.empty())
+        {
+            defineProperty(SerialNumberTP);
+            defineProperty(NicknameTP);
+        }
     }
     else
     {

--- a/indi-asi/asi_base.h
+++ b/indi-asi/asi_base.h
@@ -142,6 +142,8 @@ class ASIBase : public INDI::CCD
 
         INDI::PropertyNumber  ADCDepthNP   {1};
         INDI::PropertyText    SDKVersionSP {1};
+        INDI::PropertyText    SerialNumberTP {1};
+        INDI::PropertyText    NicknameTP {1};
 
         INDI::PropertyNumber  BlinkNP {2};
         enum
@@ -157,7 +159,7 @@ class ASIBase : public INDI::CCD
             FLIP_VERTICAL
         };
 
-        std::string mCameraName, mCameraID;
+        std::string mCameraName, mCameraID, mSerialNumber, mNickname;
         ASI_CAMERA_INFO mCameraInfo;
         uint8_t mExposureRetry {0};
         ASI_IMG_TYPE mCurrentVideoFormat;

--- a/indi-asi/asi_camera_test.cpp
+++ b/indi-asi/asi_camera_test.cpp
@@ -21,6 +21,7 @@
 
 #include <ASICamera2.h>
 #include "stdio.h"
+#include <string.h>
 #include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
@@ -48,9 +49,28 @@ int  main()
     {
         ASIGetCameraProperty(&ASICameraInfo, i);
         printf("%d %s\n", i, ASICameraInfo.Name);
+
+        if(ASIOpenCamera(ASICameraInfo.CameraID) != ASI_SUCCESS) {
+          printf("failed to open camera id %d\n", ASICameraInfo.CameraID);
+        }
+        
+        ASI_SN asi_sn;
+        if (ASIGetSerialNumber(i, &asi_sn) == ASI_SUCCESS) {
+          printf("serial number for %d: ", i);
+          for (int i = 0; i < 8; ++i)
+            printf("%02x", asi_sn.id[i] & 0xff);
+          printf("\n");
+        } else {
+          printf("Serial number for %d is unavailable\n", i);
+        }
+
+        if(ASICloseCamera(ASICameraInfo.CameraID) != ASI_SUCCESS) {
+          printf("failed to close camera id %d\n", ASICameraInfo.CameraID);
+        }
+        
     }
 
-    printf("\nselect one to privew\n");
+    printf("\nselect one to preview\n");
     if (scanf("%d", &CamNum) != 1)
     {
         fprintf(stderr, "Error no input. Assuming camera 0");
@@ -65,6 +85,8 @@ int  main()
     }
     ASIInitCamera(CamNum);
 
+    ASIGetCameraProperty(&ASICameraInfo, CamNum);
+    
     printf("%s information\n", ASICameraInfo.Name);
     int iMaxWidth, iMaxHeight;
     iMaxWidth = ASICameraInfo.MaxWidth;

--- a/indi-asi/asi_camera_test.cpp
+++ b/indi-asi/asi_camera_test.cpp
@@ -50,24 +50,29 @@ int  main()
         ASIGetCameraProperty(&ASICameraInfo, i);
         printf("%d %s\n", i, ASICameraInfo.Name);
 
-        if(ASIOpenCamera(ASICameraInfo.CameraID) != ASI_SUCCESS) {
-          printf("failed to open camera id %d\n", ASICameraInfo.CameraID);
-        }
-        
-        ASI_SN asi_sn;
-        if (ASIGetSerialNumber(i, &asi_sn) == ASI_SUCCESS) {
-          printf("serial number for %d: ", i);
-          for (int i = 0; i < 8; ++i)
-            printf("%02x", asi_sn.id[i] & 0xff);
-          printf("\n");
-        } else {
-          printf("Serial number for %d is unavailable\n", i);
+        if(ASIOpenCamera(ASICameraInfo.CameraID) != ASI_SUCCESS)
+        {
+            printf("failed to open camera id %d\n", ASICameraInfo.CameraID);
         }
 
-        if(ASICloseCamera(ASICameraInfo.CameraID) != ASI_SUCCESS) {
-          printf("failed to close camera id %d\n", ASICameraInfo.CameraID);
+        ASI_SN asi_sn;
+        if (ASIGetSerialNumber(i, &asi_sn) == ASI_SUCCESS)
+        {
+            printf("serial number for %d: ", i);
+            for (int i = 0; i < 8; ++i)
+                printf("%02x", asi_sn.id[i] & 0xff);
+            printf("\n");
         }
-        
+        else
+        {
+            printf("Serial number for %d is unavailable\n", i);
+        }
+
+        if(ASICloseCamera(ASICameraInfo.CameraID) != ASI_SUCCESS)
+        {
+            printf("failed to close camera id %d\n", ASICameraInfo.CameraID);
+        }
+
     }
 
     printf("\nselect one to preview\n");
@@ -86,7 +91,7 @@ int  main()
     ASIInitCamera(CamNum);
 
     ASIGetCameraProperty(&ASICameraInfo, CamNum);
-    
+
     printf("%s information\n", ASICameraInfo.Name);
     int iMaxWidth, iMaxHeight;
     iMaxWidth = ASICameraInfo.MaxWidth;

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -100,8 +100,10 @@ static class Loader
 
                 ASI_SN serialNumber;
                 std::string serialNumberStr = "";
-                if(ASIOpenCamera(cameraInfo.CameraID) == ASI_SUCCESS) {
-                    if (ASIGetSerialNumber(cameraInfo.CameraID, &serialNumber) == ASI_SUCCESS) {
+                if(ASIOpenCamera(cameraInfo.CameraID) == ASI_SUCCESS)
+                {
+                    if (ASIGetSerialNumber(cameraInfo.CameraID, &serialNumber) == ASI_SUCCESS)
+                    {
                         ASICloseCamera(cameraInfo.CameraID);
                         char snChars[100];
                         auto &sn = serialNumber;
@@ -147,23 +149,28 @@ static class Loader
 
 namespace
 {
-  
+
 // trim from start (in place)
-static inline void ltrim(std::string &s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+static inline void ltrim(std::string &s)
+{
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch)
+    {
         return !std::isspace(ch);
     }));
 }
 
 // trim from end (in place)
-static inline void rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+static inline void rtrim(std::string &s)
+{
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch)
+    {
         return !std::isspace(ch);
     }).base(), s.end());
 }
 
 // trim from both ends (in place)
-static inline void trim(std::string &s) {
+static inline void trim(std::string &s)
+{
     ltrim(s);
     rtrim(s);
 }
@@ -201,7 +208,7 @@ void ASICCD::loadNicknames()
 {
     const std::string filename = GetHomeDirectory() + NICKNAME_FILE;
     mNicknames.clear();
-    
+
     LilXML *xmlHandle = newLilXML();
     XMLEle *rootXmlNode = nullptr;
     char errorMessage[512] = {0};
@@ -210,11 +217,11 @@ void ASICCD::loadNicknames()
     {
         rootXmlNode = readXMLFile(file, xmlHandle, errorMessage);
         fclose(file);
-    } 
+    }
     delLilXML(xmlHandle);
 
     if (rootXmlNode == nullptr)
-      return;
+        return;
 
     XMLEle *currentXmlNode = nextXMLEle(rootXmlNode, 1);
     while (currentXmlNode)
@@ -222,11 +229,11 @@ void ASICCD::loadNicknames()
         const char *id = findXMLAttValu(currentXmlNode, ATTRIBUTE);
         if (id != nullptr)
         {
-          std::string name = pcdataXMLEle(currentXmlNode);
-          if (!name.empty())
-            trim(name);
-          if (!name.empty())
-            mNicknames[id] = name;
+            std::string name = pcdataXMLEle(currentXmlNode);
+            if (!name.empty())
+                trim(name);
+            if (!name.empty())
+                mNicknames[id] = name;
         }
         currentXmlNode = nextXMLEle(rootXmlNode, 0);
     }
@@ -256,7 +263,7 @@ void ASICCD::saveNicknames()
     delXMLEle(rootXmlNode);
 }
 
- 
+
 bool ASICCD::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
     if (dev != nullptr && !strcmp(dev, getDeviceName()))
@@ -283,7 +290,9 @@ bool ASICCD::ISNewText(const char *dev, const char *name, char *texts[], char *n
                 }
                 saveNicknames();
                 LOG_INFO("The driver must now be restarted for this change to take effect.");
-            } else {
+            }
+            else
+            {
                 LOG_INFO("Can't apply nickname change--serial number not known.");
             }
             NicknameTP.apply();
@@ -302,7 +311,7 @@ ASICCD::ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
     mCameraInfo = camInfo;
     mSerialNumber = serialNumber;
 
-    loadNicknames();    
+    loadNicknames();
     if (!serialNumber.empty())
     {
         auto nickname = mNicknames[mSerialNumber];
@@ -313,7 +322,7 @@ ASICCD::ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
             mNickname = nickname;
             LOGF_INFO("Using nickname %s for serial number %s.", nickname.c_str(), mSerialNumber.c_str());
             return;
-        }      
+        }
     }
 
     setDeviceName(cameraName.c_str());

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -296,8 +296,8 @@ bool ASICCD::ISNewText(const char *dev, const char *name, char *texts[], char *n
                 LOG_INFO("Can't apply nickname change--serial number not known.");
             }
             NicknameTP.apply();
+            return true;
         }
-        return true;
     }
     return INDI::CCD::ISNewText(dev, name, texts, names, n);
 }

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -21,6 +21,8 @@
 */
 
 #include "asi_ccd.h"
+#include <unistd.h>
+#include <pwd.h>
 
 #include <map>
 //#define USE_SIMULATION
@@ -96,7 +98,21 @@ static class Loader
                     continue;
                 }
 
-                ASICCD *asiCcd = new ASICCD(cameraInfo, uniqueName.make(cameraInfo));
+                ASI_SN serialNumber;
+                std::string serialNumberStr = "";
+                if(ASIOpenCamera(cameraInfo.CameraID) == ASI_SUCCESS) {
+                    if (ASIGetSerialNumber(cameraInfo.CameraID, &serialNumber) == ASI_SUCCESS) {
+                        ASICloseCamera(cameraInfo.CameraID);
+                        char snChars[100];
+                        auto &sn = serialNumber;
+                        sprintf(snChars, "%02x%02x%02x%02x%02x%02x%02x%02x", sn.id[0], sn.id[1],
+                                sn.id[2], sn.id[3], sn.id[4], sn.id[5], sn.id[6], sn.id[7]);
+                        snChars[16] = 0;
+                        serialNumberStr = std::string(snChars);
+                    }
+                }
+
+                ASICCD *asiCcd = new ASICCD(cameraInfo, uniqueName.make(cameraInfo), serialNumberStr);
                 cameras[id] = std::shared_ptr<ASICCD>(asiCcd);
                 if (isHotPlug)
                     asiCcd->ISGetProperties(nullptr);
@@ -129,12 +145,177 @@ static class Loader
         };
 } loader;
 
+namespace
+{
+  
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
+}
+
+std::string GetHomeDirectory()
+{
+    // Check first the HOME environmental variable
+    const char *HomeDir = getenv("HOME");
+
+    // ...otherwise get the home directory of the current user.
+    if (!HomeDir)
+    {
+        HomeDir = getpwuid(getuid())->pw_dir;
+    }
+    return (HomeDir ? std::string(HomeDir) : "");
+}
+
+}  // namespace
+
+// Nicknames are stored in an xml-format NICKNAME_FILE in a format like the below.
+// Nicknames are assoicated with the serial number of the camera, and are entered/changed
+// with NicknameTP. Since the device-name can't be changed once the driver is running,
+// changes to nicknames can only take effect at the next INDI startup.
+// <Nicknames>
+//  <Nickname id="serialNumber1">nickname1</Nickname>
+//  <Nickname id="serialNumber2">nickname2</Nickname>
+//  <Nickname id="serialNumber3">nickname3</Nickname>
+// </Nicknames>
+
+#define ROOTNODE "Nicknames"
+#define ENTRYNODE "Nickname"
+#define ATTRIBUTE "SerialNumber"
+
+void ASICCD::loadNicknames()
+{
+    const std::string filename = GetHomeDirectory() + NICKNAME_FILE;
+    mNicknames.clear();
+    
+    LilXML *xmlHandle = newLilXML();
+    XMLEle *rootXmlNode = nullptr;
+    char errorMessage[512] = {0};
+    FILE *file = fopen(filename.c_str(), "r");
+    if (file)
+    {
+        rootXmlNode = readXMLFile(file, xmlHandle, errorMessage);
+        fclose(file);
+    } 
+    delLilXML(xmlHandle);
+
+    if (rootXmlNode == nullptr)
+      return;
+
+    XMLEle *currentXmlNode = nextXMLEle(rootXmlNode, 1);
+    while (currentXmlNode)
+    {
+        const char *id = findXMLAttValu(currentXmlNode, ATTRIBUTE);
+        if (id != nullptr)
+        {
+          std::string name = pcdataXMLEle(currentXmlNode);
+          if (!name.empty())
+            trim(name);
+          if (!name.empty())
+            mNicknames[id] = name;
+        }
+        currentXmlNode = nextXMLEle(rootXmlNode, 0);
+    }
+
+    delXMLEle(rootXmlNode);
+}
+
+void ASICCD::saveNicknames()
+{
+    const std::string filename = GetHomeDirectory() + NICKNAME_FILE;
+    XMLEle *rootXmlNode = nullptr;
+    XMLEle *oneElement = nullptr;
+
+    FILE *file = fopen(filename.c_str(), "w");
+
+    rootXmlNode = addXMLEle(nullptr, ROOTNODE);
+
+    for (const auto &kv : mNicknames)
+    {
+        oneElement = addXMLEle(rootXmlNode, ENTRYNODE);
+        addXMLAtt(oneElement, ATTRIBUTE, kv.first.c_str());
+        editXMLEle(oneElement, kv.second.c_str());
+    }
+
+    prXMLEle(file, rootXmlNode, 0);
+    fclose(file);
+    delXMLEle(rootXmlNode);
+}
+
+ 
+bool ASICCD::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
+{
+    if (dev != nullptr && !strcmp(dev, getDeviceName()))
+    {
+        if (NicknameTP.isNameMatch(name))
+        {
+            IUUpdateText(&NicknameTP, texts, names, n);
+            NicknameTP.setState(IPS_OK);
+            IDSetText(&NicknameTP, nullptr);
+            if (!mSerialNumber.empty())
+            {
+                loadNicknames();  // another camera may have updated its nickname.
+                std::string newNickname = texts[0];
+                trim(newNickname);
+                if (newNickname.empty())
+                {
+                    mNicknames.erase(mSerialNumber);
+                    LOGF_INFO("Nickname for %s removed.", mSerialNumber.c_str());
+                }
+                else
+                {
+                    mNicknames[mSerialNumber] = newNickname;
+                    LOGF_INFO("Nickname for %s changed to %s.", mSerialNumber.c_str(), newNickname.c_str());
+                }
+                saveNicknames();
+                LOG_INFO("The driver must now be restarted for this change to take effect.");
+            } else {
+                LOG_INFO("Can't apply nickname change--serial number not known.");
+            }
+            NicknameTP.apply();
+        }
+        return true;
+    }
+    return INDI::CCD::ISNewText(dev, name, texts, names, n);
+}
+
 ///////////////////////////////////////////////////////////////////////
 /// Constructor for multi-camera driver.
 ///////////////////////////////////////////////////////////////////////
-ASICCD::ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName) : ASIBase()
+ASICCD::ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
+               const std::string &serialNumber) : ASIBase()
 {
-    mCameraName = cameraName;
     mCameraInfo = camInfo;
+    mSerialNumber = serialNumber;
+
+    loadNicknames();    
+    if (!serialNumber.empty())
+    {
+        auto nickname = mNicknames[mSerialNumber];
+        if (!nickname.empty())
+        {
+            setDeviceName(nickname.c_str());
+            mCameraName = nickname;
+            mNickname = nickname;
+            LOGF_INFO("Using nickname %s for serial number %s.", nickname.c_str(), mSerialNumber.c_str());
+            return;
+        }      
+    }
+
     setDeviceName(cameraName.c_str());
+    mCameraName = cameraName;
 }

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -27,5 +27,14 @@
 class ASICCD : public ASIBase
 {
     public:
-        explicit ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName);
+        explicit ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
+                  const std::string &serialNumber);
+    protected:
+        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+  
+    private:
+        void loadNicknames();
+        void saveNicknames();
+        const std::string NICKNAME_FILE = "/.indi/ZWONicknames.xml";
+        std::map<std::string, std::string> mNicknames;
 };

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -28,10 +28,10 @@ class ASICCD : public ASIBase
 {
     public:
         explicit ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
-                  const std::string &serialNumber);
+                        const std::string &serialNumber);
     protected:
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-  
+
     private:
         void loadNicknames();
         void saveNicknames();


### PR DESCRIPTION
This will allow multiple cameras of the same type to be used, and have the proper one reliably used, e.g. using the imaging ccd for imaging and the one configured for guiding used for that. Also allows more human-readable device names.