### PR TITLE
Fix problem where QHY firmware would get installed to the wrong directory

### DIFF
--- a/libqhy/CMakeLists.txt
+++ b/libqhy/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties (qhyccd PROPERTIES VERSION ${LIBQHY_VERSION} SOVERSION ${L
 
 if (APPLE)
 
-  set (FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy/firmware" CACHE STRING "QHY firmware installation directory")
+	set (QHY_FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy/firmware" CACHE STRING "QHY firmware installation directory")
 
   set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd.dylib")
 
@@ -24,7 +24,7 @@ if (APPLE)
 
 elseif (UNIX AND NOT WIN32)
 
-  set (FIRMWARE_INSTALL_DIR "/lib/firmware/qhy" CACHE STRING "QHY firmware installation directory")
+	set (QHY_FIRMWARE_INSTALL_DIR "/lib/firmware/qhy" CACHE STRING "QHY firmware installation directory")
 
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
     set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv6.bin")
@@ -49,7 +49,7 @@ install (FILES qhyccd.h qhyccderr.h qhyccdcamdef.h qhyccdstruct.h DESTINATION in
 install (
    CODE "
    file(GLOB QHY_FIRMWARE ${CMAKE_CURRENT_SOURCE_DIR}/firmware/*) \n
-   file(INSTALL DESTINATION ${FIRMWARE_INSTALL_DIR} TYPE FILE FILES \${QHY_FIRMWARE})"
+   file(INSTALL DESTINATION ${QHY_FIRMWARE_INSTALL_DIR} TYPE FILE FILES \${QHY_FIRMWARE})"
 )
 
 # Install library

--- a/libqhy/CMakeLists.txt
+++ b/libqhy/CMakeLists.txt
@@ -16,7 +16,7 @@ set_target_properties (qhyccd PROPERTIES VERSION ${LIBQHY_VERSION} SOVERSION ${L
 
 if (APPLE)
 
-	set (QHY_FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy/firmware" CACHE STRING "QHY firmware installation directory")
+  set (QHY_FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy/firmware" CACHE STRING "QHY firmware installation directory")
 
   set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd.dylib")
 
@@ -24,7 +24,7 @@ if (APPLE)
 
 elseif (UNIX AND NOT WIN32)
 
-	set (QHY_FIRMWARE_INSTALL_DIR "/lib/firmware/qhy" CACHE STRING "QHY firmware installation directory")
+  set (QHY_FIRMWARE_INSTALL_DIR "/lib/firmware/qhy" CACHE STRING "QHY firmware installation directory")
 
   if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
     set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv6.bin")


### PR DESCRIPTION
QHY firmware is being installed to /lib/firmware, and not /lib/firmware/qhy. All the udev rules point to /lib/firmware/qhy. I believe this happens because the persistent cache is being used for the variable FIRMWARE_INSTALL_DIR (the CACHE keyword), and is being overridden by previously set firmware dirs in other 3rdparty library projects. Changing it to QHY_FIRMWARE_DIR, so it has a unique name, resolves the issue.