### PR TITLE
BUGFIX: Disable auto saving parameters

### DIFF
--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -269,6 +269,15 @@ bool Sv305CCD::Connect()
     // wait a bit for the camera to get ready
     usleep(0.5 * 1e6);
 
+    // disable suto save param
+    status = SVBSetAutoSaveParam(cameraID, SVB_FALSE);
+    if (status != SVB_SUCCESS)
+    {
+        LOG_ERROR("Error, disable auto save param failed.\n");
+        pthread_mutex_unlock(&cameraID_mutex);
+        return false;
+    }
+
     // get camera properties
     status = SVBGetCameraProperty(cameraID, &cameraProperty);
     if (status != SVB_SUCCESS)


### PR DESCRIPTION
- Disable auto saving parameters by SVBONY Camera SDK to avoid the following problems
> In the case of the Raspberry PI, the driver may freeze the next time you try to open the camera if there is a parameter file automatically saved by the SDK.
- The fix has no impact. Parameter auto saving by SDK is unnecessary because INDI itself originally saves the configurations.