### PR TITLE
BUGFIX: change mutex life cycle to camera connection period and correct some pthread function calls

### DIFF
--- a/indi-sv305/sv305_ccd.h
+++ b/indi-sv305/sv305_ccd.h
@@ -230,8 +230,8 @@ class Sv305CCD : public INDI::CCD
         friend void ::ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n);
 
         // Threading - streaming mutex
-        pthread_cond_t cv         = PTHREAD_COND_INITIALIZER;
-        pthread_mutex_t condMutex = PTHREAD_MUTEX_INITIALIZER;
+        pthread_cond_t cv;
+        pthread_mutex_t condMutex;
 };
 
 #endif // SV305_CCD_H


### PR DESCRIPTION
BUGFIX: mutex life cycle to camera connection period
- Once the camera is closed and reconnected to the camera, the driver freezes without unlocking the mutex for the next camera disconnect.
- Corrected the life cycle of mutex, cond and thread of pthread from the scope of existence of Sv305CCD object to the scope of Sv305CCD::Connect to Sv305CCD::Disconnect.
- Before the correction, the state of the previous mutex was inherited at the second connection, causing a freeze on pthead_lock at the time of Disconnect.

BUGFIX: cancel streaming thread at Disconnect camera.

BUGFIX: some pthread_cond_signal was moved within the period when mutex is locked.
- pthread_cond_signal must be called during mutex lock.

BUGFIX: Fixed a case where a function exits within the mutex lock period of streamVideo.