### PR TITLE
BUGFIX: indi_sv305_ccd: garbage data in last line (Issue #654)

### DIFF
--- a/indi-sv305/sv305_ccd.h
+++ b/indi-sv305/sv305_ccd.h
@@ -127,9 +127,6 @@ class Sv305CCD : public INDI::CCD
         // ROI actual size
         int ROI_width;
         int ROI_height;
-        // INDI properties
-        INumber ROI_N[4];
-        INumberVectorProperty ROI_NP; 
 
         // streaming ?
         bool streaming;

--- a/indi-sv305/sv305_ccd.h
+++ b/indi-sv305/sv305_ccd.h
@@ -123,7 +123,13 @@ class Sv305CCD : public INDI::CCD
 
         // ROI offsets
         int x_offset;
-	    int y_offset;
+	int y_offset;
+        // ROI actual size
+        int ROI_width;
+        int ROI_height;
+        // INDI properties
+        INumber ROI_N[4];
+        INumberVectorProperty ROI_NP; 
 
         // streaming ?
         bool streaming;


### PR DESCRIPTION
- In sv305_ccd.cpp, I implemented a process to get the ROI actually set by SVBGetROIFormat.
- After setting the ROI with SVBSetROIFormat, I need to get the actual ROI with SVBGetROIFormat, because the ROI obtained with SVBGetROIFormat may differ from the value specified with SVBSetROIFormat.
- Issue #654 was raised because this feature was not implemented.
