### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/indi-eqmod/mach_gettime.cpp
+++ b/indi-eqmod/mach_gettime.cpp
@@ -1,7 +1,7 @@
 /* complete rewrite May 2017, Rumen G.Bogdanovski */
 #include <time.h>
 
-#ifdef __MACH__ /* Mac OSX prior Sierra is missing clock_gettime() */
+#if defined(__MACH__) && defined(__APPLE__) /* Mac OSX prior Sierra is missing clock_gettime() */
 #include <mach/clock.h>
 #include <mach/mach.h>
 void get_utc_time(struct timespec *ts)

--- a/indi-eqmod/mach_gettime.h
+++ b/indi-eqmod/mach_gettime.h
@@ -3,7 +3,7 @@
 #ifndef mach_time_h
 #define mach_time_h
 
-#ifdef __MACH__ /* Mac OSX prior Sierra is missing clock_gettime() */
+#if defined(__MACH__) && defined(__APPLE__) /* Mac OSX prior Sierra is missing clock_gettime() */
 #include <mach/clock.h>
 #include <mach/mach.h>
 void get_utc_time(struct timespec *ts);


### PR DESCRIPTION
As said on lines 4 and 6, this check is only intended for OSX.
```
/* Mac OSX prior Sierra is missing clock_gettime() */
```

Hurd also uses Mach, but does not have the same shortcomings as OSX in this area.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```