### PR TITLE
IMPROVEMENT: indi_sv305_ccd: Capture format can be selected in the Ekos Camera module.

### DIFF
--- a/indi-sv305/sv305_ccd.h
+++ b/indi-sv305/sv305_ccd.h
@@ -200,10 +200,10 @@ class Sv305CCD : public INDI::CCD
                 { "FORMAT_Y16", "Y 16 bits", 16, false, -1, ISS_OFF }
         };
         SVB_IMG_TYPE *switch2frameFormatDefinitionsIndex;
-        ISwitch *FormatS;
-        ISwitchVectorProperty FormatSP;
         SVB_IMG_TYPE frameFormat; // currenct Frame format
         const char* bayerPatternMapping[4] = {"RGGB", "BGGR", "GRBG", "GBRG"};
+        
+        virtual bool SetCaptureFormat(uint8_t index) override;
 
         // exposure timing
         int timerID;


### PR DESCRIPTION
Improvements to Issue #662

* Capture Format is now set using the `addCaptureFormat` and `SetCaptureFormat` functions.
* This means that ISwitch for Capture Format no longer needs to be configured independently and uses INDI's Standard Properties.
* This change allows the Capture Format to be manipulated using the standard INDI mechanism.

Effects of this change
* INDI control panel: Capture Format switch location changed from Main Controle tab to Image Setting tab.
* Ekos: Capture Format can be specified in the Format selector of the Camera module.