### PR TITLE
BUGFIX: indi_sv305_ccd: One previous shooting data retrieval is performed at the time of shooting. #655

### DIFF
--- a/indi-sv305/sv305_ccd.cpp
+++ b/indi-sv305/sv305_ccd.cpp
@@ -762,6 +762,9 @@ bool Sv305CCD::StartExposure(float duration)
 
     pthread_mutex_lock(&cameraID_mutex);
 
+    // Discard unretrieved exposure data
+    discardVideoData();
+
     // set exposure time (s -> us)
     status = SVBSetControlValue(cameraID, SVB_EXPOSURE, (long)(duration * 1000000L), SVB_FALSE);
     if(status != SVB_SUCCESS)
@@ -793,6 +796,13 @@ bool Sv305CCD::StartExposure(float duration)
     return true;
 }
 
+// Discard unretrieved exposure data
+void Sv305CCD::discardVideoData()
+{
+    unsigned char* imageBuffer = PrimaryCCD.getFrameBuffer();
+    SVB_ERROR_CODE status = SVBGetVideoData(cameraID, imageBuffer, PrimaryCCD.getFrameBufferSize(),  1000);
+    LOGF_DEBUG("Discard unretrieved exposure data: SVBGetVideoData:result=%d", status);
+}
 
 //
 bool Sv305CCD::AbortExposure()

--- a/indi-sv305/sv305_ccd.h
+++ b/indi-sv305/sv305_ccd.h
@@ -214,6 +214,9 @@ class Sv305CCD : public INDI::CCD
         // update CCD Params
         bool updateCCDParams();
 
+        // Discard unretrieved exposure data
+        void discardVideoData();
+
         // save settings
         virtual bool saveConfigItems(FILE *fp) override;
 

--- a/libsv305/CMakeLists.txt
+++ b/libsv305/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.0)
 project (libsv305)
 
-set (SVBCAMERASDK_VERSION "1.9.4")
+set (SVBCAMERASDK_VERSION "1.9.6")
 set (SVBCAMERASDK_SOVERSION "1")
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")


### PR DESCRIPTION
- When Sv305CCD::StartExposure is executed, call SVBGetVideoData and discard any unretrieved data.
- This process avoids reading the previous data that has not been read.