### PR TITLE
Fix building DEB package on Debian systems

### DIFF
--- a/debian/libahp-gt/changelog
+++ b/debian/libahp-gt/changelog
@@ -2,4 +2,4 @@ libahp-gt (1.5.8) xenial; urgency=low
 
    * Initial Release.
 
-  -- Ilia Platone <info@iliaplatone.com>  Fri, 18 Nov 2022 20:00:00 +0200
+ -- Ilia Platone <info@iliaplatone.com>  Fri, 18 Nov 2022 20:00:00 +0200


### PR DESCRIPTION
Building DEB package libahp-gt on Debian bullseye
results first in warning:

```
dpkg-gencontrol: warning:
debian/changelog(l5): found end of file where expected more change data or trailer
```

and subsequent error:

`dpkg-deb: building package 'libahp-gt' in '../libahp-gt_1.5.8_amd64.deb'. dpkg-deb: error: unable to parse timestamp '': Success dh_builddeb: error: dpkg-deb --build debian/libahp-gt .. returned exit code 2 dh_builddeb: error: Aborting due to earlier error`

This error is due to incorrect formatted changelog. It looks like the additional space character is tolerated on Ubuntu systems, but not on Debian systems.