### PR TITLE
Touptek Driver: Allow Window Heater Levels

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -151,8 +151,7 @@ const char *ToupBase::getDefaultName()
 bool ToupBase::initProperties()
 {
     INDI::CCD::initProperties();
-
-    LOG_INFO("init properties");
+    
     ///////////////////////////////////////////////////////////////////////////////////
     /// Binning Mode Control
     ///////////////////////////////////////////////////////////////////////////////////
@@ -622,7 +621,6 @@ bool ToupBase::Disconnect()
 void ToupBase::setupParams()
 {
     HRESULT rc = 0;
-    LOG_INFO("setupParams");
     FP(put_Option(m_CameraHandle, CP(OPTION_NOFRAME_TIMEOUT), 1));
 
     // Get Firmware Info
@@ -1408,7 +1406,6 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState * states, 
 {
     if (dev != nullptr && !strcmp(dev, getDeviceName()))
     {
-
         //////////////////////////////////////////////////////////////////////
         /// Binning Mode Control
         //////////////////////////////////////////////////////////////////////
@@ -1422,8 +1419,6 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState * states, 
             saveConfig(true, BinningModeSP.name);
             return true;
         }
-
-
 
         //////////////////////////////////////////////////////////////////////
         /// Cooler Control
@@ -1454,7 +1449,7 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState * states, 
         }
 #if defined(BUILD_TOUPCAM)
 
-       //////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         /// High Fullwell Mode
         //////////////////////////////////////////////////////////////////////
         if (!strcmp(name, HighFullwellModeSP.name))

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -618,7 +618,8 @@ class ToupBase : public INDI::CCD
             TC_HEAT_ON,
             TC_HEAT_MAX,
         };
-
+        INumberVectorProperty HeatLevelNP;
+        INumber HeatLevelN[1];
 
         // Firmware Info
         ITextVectorProperty FirmwareTP;


### PR DESCRIPTION
In the INDI forum user Lanco wrote that some Toupcams allow different heater levels. The pull request implements this heater levels.

![Screeshot_HeatLevel](https://user-images.githubusercontent.com/104255100/214691026-6b9fd392-f02e-46a8-8adc-2b9c400a2cb0.jpg)

The Heater on/off button will now switch the heater to the selected level.
 
Level can be adjusted while heater is on or off.

Testing was done by measuring the power supply current for different levels.