### PR TITLE
Migration to INDI Core 2.0.0 - Fix CI workflow name

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           repo: indilib/indi
           branch: master
-          workflow: default.yml
+          workflow: linux.yml
           name: indi-core-package-${{ matrix.container }}
           path: ./packages/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # INDI 3rd Party Drivers
-[![Linux](https://github.com/indilib/indi-3rdparty/actions/workflows/default.yml/badge.svg)](https://github.com/indilib/indi-3rdparty/actions)
+[![Linux](https://github.com/indilib/indi-3rdparty/actions/workflows/linux.yml/badge.svg)](https://github.com/indilib/indi-3rdparty/actions)
 [![MacOS](https://github.com/indilib/indi-3rdparty/actions/workflows/macos.yml/badge.svg)](https://github.com/indilib/indi-3rdparty/actions)
 
 INDI 3rd party drivers include all the drivers not included by default in the INDI Core Library.


### PR DESCRIPTION
In previous versions of the Linux workflow in INDI Core it was called default.yml, now it is called linux.yml.
For this reason, the previous version of the INDI Core library was being downloaded.