### PR TITLE
Infer from AUX command 0x05 the mount model

### DIFF
--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -300,7 +300,9 @@ int AUXCommand::responseDataSize()
                 return 3;
             case GET_VER:
                 return 4;
-            case MC_SLEW_DONE:
+            case MC_GET_MODEL:
+                return 2;
+	    case MC_SLEW_DONE:
             case MC_SEEK_DONE:
             case MC_LEVEL_DONE:
             case MC_POLL_CORDWRAP:

--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -34,6 +34,7 @@ enum AUXCommands
     MC_GET_POSITION      = 0x01,
     MC_GOTO_FAST         = 0x02,
     MC_SET_POSITION      = 0x04,
+    MC_GET_MODEL         = 0x05,
     MC_SET_POS_GUIDERATE = 0x06,
     MC_SET_NEG_GUIDERATE = 0x07,
     MC_LEVEL_START       = 0x0b,

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -80,6 +80,19 @@ class CelestronAUX :
             REVERSE
         };
 
+        enum MountVersion
+        {
+            GPS_Nexstar       = 0x0001,
+            SLT_Nexstar       = 0x0783,
+            SE_5_4            = 0x0b83,
+            SE_8_6            = 0x0c82,
+            CPC_Deluxe        = 0x1189,
+            Series_GT         = 0x1283,
+            AVX               = 0x1485,
+            Evolution_Nexstar = 0x1687,
+            CGX               = 0x1788
+        };
+
         // Previous motion direction
         // TODO: Switch to AltAz from N-S/W-E
         typedef enum
@@ -213,6 +226,7 @@ class CelestronAUX :
         {
             return m_Location.latitude >= 0;
         }
+        bool getModel(AUXTargets target);
         bool getVersion(AUXTargets target);
         void getVersions();
         void hex_dump(char *buf, AUXBuffer data, size_t size);
@@ -288,12 +302,14 @@ class CelestronAUX :
         bool readAUXResponse(AUXCommand c);
         bool processResponse(AUXCommand &cmd);
         int sendBuffer(AUXBuffer buf);
+        void formatModelString(char *s, int n, uint16_t model);
         void formatVersionString(char *s, int n, uint8_t *verBuf);
 
         // GPS Emulation
         bool m_GPSEmulation {false};
 
         // Firmware
+        uint16_t m_ModelVersion {0};
         uint8_t m_MainBoardVersion[4] {0};
         uint8_t m_AltitudeVersion[4] {0};
         uint8_t m_AzimuthVersion[4] {0};
@@ -336,8 +352,8 @@ class CelestronAUX :
         ///////////////////////////////////////////////////////////////////////////////
 
         // Firmware
-        INDI::PropertyText FirmwareTP {7};
-        enum {FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS};
+        INDI::PropertyText FirmwareTP {8};
+        enum {FW_MODEL, FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS};
         // Mount type
         //INDI::PropertySwitch MountTypeSP {3};
 

--- a/indi-celestronaux/simulator/nse_telescope.py
+++ b/indi-celestronaux/simulator/nse_telescope.py
@@ -36,7 +36,7 @@ commands={
           'MC_GET_POSITION':0x01,
           'MC_GOTO_FAST':0x02,
           'MC_SET_POSITION':0x04,
-          'MC_GET_???':0x05,
+          'MC_GET_MODEL':0x05,
           'MC_SET_POS_GUIDERATE':0x06,
           'MC_SET_NEG_GUIDERATE':0x07,
           'MC_LEVEL_START':0x0b,
@@ -235,7 +235,7 @@ class NexStarScope:
           0x01 : NexStarScope.get_position,
           0x02 : NexStarScope.goto_fast,
           0x04 : NexStarScope.set_position,
-          0x05 : NexStarScope.cmd_0x05,
+          0x05 : NexStarScope.get_model,
           0x06 : NexStarScope.set_pos_guiderate,
           0x07 : NexStarScope.set_neg_guiderate,
           0x0b : NexStarScope.level_start,
@@ -373,8 +373,8 @@ class NexStarScope:
     def set_position(self,data, snd, rcv):
         return b''
 
-    def cmd_0x05(self, data, snd, rcv):
-        return bytes.fromhex('1685')
+    def get_model(self, data, snd, rcv):
+        return bytes.fromhex('1485') # AVX
 
     def set_pos_guiderate(self, data, snd, rcv):
         # The 1.1 factor is experimental to fit the actual hardware


### PR DESCRIPTION
Send to AUX device 0x10 (AZM motor controller) the command 0x05 (MC_GET_MODEL) to get reply which contains the mount model version string.

The command is derived from Celestron AUXBUS Scanner https://github.com/platini2/celestronauxbus
currently the following mount versions can be inferred:

0x0001 : 'Nexstar GPS',
0x0783 : 'Nexstar SLT',
0x0b83 : '4/5SE',
0x0c82 : '6/8SE',
0x1189 : 'CPC Deluxe',
0x1283 : 'GT Series',
0x1485 : 'AVX',
0x1687 : 'Nexstar Evolution',
0x1788 : 'CGX'

In a later commit the inferred mount model can be used to properly determined whether it a a GEM, AZ_ALT or FORK mount.