### PR TITLE
Send AUX commands to MC imitating attached HC

### DIFF
--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -226,11 +226,11 @@ class CelestronAUX :
         {
             return m_Location.latitude >= 0;
         }
+        void startupWithoutHC();
         bool getModel(AUXTargets target);
         bool getVersion(AUXTargets target);
         void getVersions();
         void hex_dump(char *buf, AUXBuffer data, size_t size);
-
 
         double AzimuthToDegrees(double degree);
         double DegreesToAzimuth(double degree);


### PR DESCRIPTION
When no HC is attached, the following three commands needs to be send to the motor controller (MC): MC_SET_POSITION, MC_SET_CORDWRAP_POSITION and MC_CORDWRAP_ON. These three commands are also send by the HC to the MC during HC startup and quick align process.