### PR TITLE
Fix sendingWithoutHC 0x40 0xc0 and logging

### DIFF
--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -226,7 +226,7 @@ class CelestronAUX :
         {
             return m_Location.latitude >= 0;
         }
-        void startupWithoutHC();
+        bool startupWithoutHC();
         bool getModel(AUXTargets target);
         bool getVersion(AUXTargets target);
         void getVersions();


### PR DESCRIPTION
In the previous related commit, the hex value
data[0] = (m_MountType == EQ_GEM) ? 0x40 : 00;
was overwritten with data[0] = 0xc0 before 0x40 is sent.
In addition logging of the startupWithoutHC result is introduced.