### PR TITLE
Update 99-ogmacam.rules

### DIFF
--- a/libogmacam/99-ogmacam.rules
+++ b/libogmacam/99-ogmacam.rules
@@ -8,3 +8,4 @@
 # grained permission setting.
 
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0547", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="9745", MODE="0666"


### PR DESCRIPTION
Add TP AP26MC Camera USB ID to rules.  

My permissions were not correct with the Ogma IMX571 Mono camera I just got.