### PR TITLE
SVBONY CCD firmware and SDK version information logs added

### DIFF
--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -1,3 +1,9 @@
+indi-svbony (1.3.8) bionic; urgency=low
+
+  * SVBONY CCD firmware and SDK version information logs added
+
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Wed, 2 Jul 2023 06:00:00 +0900
+
 indi-svbony (1.3.7) bionic; urgency=low
 
   * Fixed Conflict of private variables in SVBONYCCD class.

--- a/indi-svbony/CMakeLists.txt
+++ b/indi-svbony/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SVBONY_VERSION_MAJOR 1)
 set (SVBONY_VERSION_MINOR 3)
-set (SVBONY_VERSION_PATCH 7)
+set (SVBONY_VERSION_PATCH 8)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-svbony/README
+++ b/indi-svbony/README
@@ -69,6 +69,7 @@ Limitations
 Changelog
 =========
 
+	+ 1.3.8 : SVBONY CCD firmware and SDK version information logs added.
 	+ 1.3.7 : Fixed Conflict of private variables in SVBONYCCD class.
 	+ 1.3.6 : Disabled workaround code for bug #666 "the problem that the last exposure image may be read in soft trigger mode".
 	+ 1.3.5 : Added process to initialize Camera parameters when Camera is connected.

--- a/indi-svbony/doc/svbony-doc.md
+++ b/indi-svbony/doc/svbony-doc.md
@@ -71,7 +71,7 @@ Family :		CCDs
 Manufacturer :		SVBONY  
 Platforms :		Linux (Intel, ARM),Mac OS X 64 bits  
 Author :		Blaise-Florentin Collin & Tetsuya Kakura  
-Version :		1.3.3  
+Version :		1.3.8  
 
 ![SV305 camera](./SV305.jpg)
 

--- a/indi-svbony/svbony_ccd.cpp
+++ b/indi-svbony/svbony_ccd.cpp
@@ -226,7 +226,7 @@ bool SVBONYCCD::Connect()
         LOGF_INFO("Camera Firmware Version:%s", cameraFirmwareVersion);
     }
     else {
-        LOG_ERROR("Error, getting Camera Firmware Version failed.\n");
+        LOG_ERROR("Error, getting Camera Firmware Version failed.");
     }
     // Get SVBONY Camera SDK Version
     SDKVersion = SVBGetSDKVersion();

--- a/indi-svbony/svbony_ccd.cpp
+++ b/indi-svbony/svbony_ccd.cpp
@@ -219,6 +219,19 @@ bool SVBONYCCD::Connect()
         return false;
     }
 
+    // Get Camera Firmware Version
+    status = SVBGetCameraFirmwareVersion(cameraID, cameraFirmwareVersion);
+    if (status == SVB_SUCCESS)
+    {
+        LOGF_INFO("Camera Firmware Version:%s", cameraFirmwareVersion);
+    }
+    else {
+        LOG_ERROR("Error, getting Camera Firmware Version failed.\n");
+    }
+    // Get SVBONY Camera SDK Version
+    SDKVersion = SVBGetSDKVersion();
+    LOGF_INFO("SVBONY Camera SDK Version:%s", SDKVersion);
+
     // wait a bit for the camera to get ready
     usleep(0.5 * 1e6);
 

--- a/indi-svbony/svbony_ccd.h
+++ b/indi-svbony/svbony_ccd.h
@@ -109,6 +109,11 @@ class SVBONYCCD : public INDI::CCD
         // pixel size
         float pixelSize;
 
+        // Camera Firmware version number
+        char cameraFirmwareVersion[65];
+        // SVBONY Camera SDK version number
+        const char* SDKVersion;
+
         // hCamera mutex protection
         pthread_mutex_t cameraID_mutex;
 


### PR DESCRIPTION
Added code to SVBONYCCD::Connect() to output the version of SVBONY Camera's firmware and SDK as information log.
This information is used when users inquire about issues.