### PR TITLE
Add sensor mode control for Player One cameras

### DIFF
--- a/debian/indi-playerone/changelog
+++ b/debian/indi-playerone/changelog
@@ -1,3 +1,9 @@
+indi-playerone (1.9) bionic; urgency=low
+
+  * Add sensor mode control for cameras that support it
+
+ -- Jarno Paananen <jarno.paananen@gmail.com>  Thu, 20 Jul 2023 01:16:17 +0300
+
 indi-playerone (1.8) bionic; urgency=low
 
   * Update PlayerOneCamera SDK v3.4.0

--- a/indi-playerone/CMakeLists.txt
+++ b/indi-playerone/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
 set(PLAYERONE_VERSION_MAJOR 1)
-set(PLAYERONE_VERSION_MINOR 8)
+set(PLAYERONE_VERSION_MINOR 9)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_playerone.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_playerone.xml)

--- a/indi-playerone/playerone_base.h
+++ b/indi-playerone/playerone_base.h
@@ -53,7 +53,7 @@ class POABase : public INDI::CCD
         virtual bool AbortExposure() override;
 
     protected:
-    
+
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
@@ -77,7 +77,7 @@ class POABase : public INDI::CCD
         virtual bool saveConfigItems(FILE *fp) override;
 
         virtual bool SetCaptureFormat(uint8_t index) override;
-    
+
         /** Get the current Bayer string used */
         const char *getBayerString() const;
 
@@ -146,10 +146,12 @@ class POABase : public INDI::CCD
         INDI::PropertySwitch  ControlSP {0};
         INDI::PropertySwitch  VideoFormatSP {0};
 
-        INDI::PropertyNumber  ADCDepthNP   {1};
+        INDI::PropertyNumber  ADCDepthNP {1};
         INDI::PropertyText    SDKVersionSP {1};
         INDI::PropertyText    SerialNumberTP {1};
         INDI::PropertyText    NicknameTP {1};
+
+        INDI::PropertySwitch  SensorModeSP {0};
 
         INDI::PropertyNumber  BlinkNP {2};
         enum
@@ -157,7 +159,7 @@ class POABase : public INDI::CCD
             BLINK_COUNT,
             BLINK_DURATION
         };
-    
+
         INDI::PropertySwitch  FlipSP {2};
         enum
         {


### PR DESCRIPTION
After 6 years with Atik 383L+ I finally upgraded my imaging camera to Player One Poseidon-M PRO. While playing around with it I noticed that setting sensor mode of the camera was not supported, which was understandable as most cameras don't have more than one, but Poseidon has two modes, low noise and normal. The SDK has nice functions to enumerate the modes and even get some description for them so adding the functionality was very straight forward.

Additionally I made some clean ups and ran through astyle which caused some diff noise to old code.