### PR TITLE
StarGO V 1.13.2 | Second code position needed to be corrected to fix the MacOS crash

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.13.2) jammy; urgency=medium
+
+  * Second code position needed to be corrected to fix the MacOS crash
+
+ -- Wolfgang Reissenberger <sterne-jaeger@openfuture.de>  Sun, 06 Aug 2023 14:42:39 +0200
+
 indi-avalon (1.13.1) jammy; urgency=medium
 
   * Bug fix for updated version numbers

--- a/indi-avalon/lx200stargo.cpp
+++ b/indi-avalon/lx200stargo.cpp
@@ -530,7 +530,7 @@ bool LX200StarGo::ReadScopeStatus()
         }
     }
 
-    char parkHomeStatus[1] = {0};
+    char parkHomeStatus[AVALON_RESPONSE_BUFFER_LENGTH] = {0};
     if (! getParkHomeStatus(parkHomeStatus))
     {
         LOG_ERROR("Cannot determine scope status, failed to determine park/sync state.");


### PR DESCRIPTION
The first fix missed a second code position that needed to be corrected.