### PR TITLE
Update skywatcher.cpp

### DIFF
--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -536,6 +536,9 @@ void Skywatcher::InquireBoardVersion(char **boardinfo)
         case 0x0A:
             strcpy(boardinfo[0], "Star Adventurer");
             break;
+	case 0x0C:
+            strcpy(boardinfo[0], "Star Adventurer GTi");
+            break;
         case 0x20:
             strcpy(boardinfo[0], "EQ8-R Pro");
             break;
@@ -650,7 +653,7 @@ bool Skywatcher::HasPPEC()
 
 bool Skywatcher::HasSnapPort1()
 {
-    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06 ||  MountCode == 0x0A || MountCode == 0x23
+    return MountCode == 0x04 ||  MountCode == 0x05 ||  MountCode == 0x06 ||  MountCode == 0x0A || MountCode == 0x0C || MountCode == 0x23
            || MountCode == 0xA5;
 }
 


### PR DESCRIPTION
Added detection of the mount code 0x0C identifying StarAdventurer GTi as opposed to the "old" StarAdventurer(s)