### PR TITLE
Avalon StarGO V 1.13.3 | Manufacturer changed to Avalon-Instruments

### DIFF
--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.13.3) jammy; urgency=medium
+
+  * Manufacturer changed to Avalon-Instruments
+
+ -- Wolfgang Reissenberger <sterne-jaeger@openfuture.de>  Thu, 30 Nov 2023 12:33:39 +0100
+
 indi-avalon (1.13.2) jammy; urgency=medium
 
   * Second code position needed to be corrected to fix the MacOS crash

--- a/indi-avalon/indi_avalon.xml.cmake
+++ b/indi-avalon/indi_avalon.xml.cmake
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <driversList>
 <devGroup group="Telescopes">
-    <device label="Avalon StarGo" manufacturer="Avalon">
+    <device label="Avalon StarGo" manufacturer="Avalon-Instruments">
         <driver name="LX200 StarGo">indi_lx200stargo</driver>
         <version>@AVALON_VERSION_MAJOR@.@AVALON_VERSION_MINOR@</version>
     </device>


### PR DESCRIPTION
Unified manufacturer name for Avalon StarGO driver in line with new AvalonUD drivers.