### PR TITLE
Workaround ASI SDK bogus GPS control default values

### DIFF
--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -1436,6 +1436,13 @@ void ASIBase::createControls(int piNumberOfControls)
         ASI_BOOL isAuto = ASI_FALSE;
         ASIGetControlValue(mCameraInfo.CameraID, cap.ControlType, &value, &isAuto);
 
+        // Workaround for apparent ASI SDK 1.31 and 1.32 bug that gives bogus default values for GPS
+        // controls on cameras that don't have GPS and fails to complete exposures if the value is written back.
+        if (cap.ControlType == ASI_GPS_START_LINE || cap.ControlType == ASI_GPS_END_LINE)
+        {
+            value = 0;
+        }
+
         if (cap.IsWritable)
         {
             LOGF_DEBUG("Adding above control as writable control number %d.", ControlNP.size());


### PR DESCRIPTION
Workaround for apparent ASI SDK 1.31 and 1.32 bug that exposes and gives bogus default values for GPS controls on cameras that don't have GPS and fails to complete exposures if the value is written back. More discussion on the issue in #867. Managed to reproduce and verify the fix on my ASI178MC.