### PR TITLE
libmeadecam missing into toupcam dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ endif(WITH_AHP_GT)
 
 #toupbase dependencies
 if (WITH_TOUPBASE)
+add_subdirectory(libmeadecam)
 add_subdirectory(libtoupcam)
 add_subdirectory(libaltaircam)
 add_subdirectory(libbressercam)


### PR DESCRIPTION
Without this, the toupcam drivers (altair_ccd, etc...) are not built into indi-full.