### PR TITLE
add missing build dependency to README

### DIFF
--- a/indi-libcamera/README.md
+++ b/indi-libcamera/README.md
@@ -3,6 +3,12 @@ with IMX219. It is still under heavy development and not ready for production.
 
 COMPILING
 
+Install additional build dependency:
+
+```
+sudo apt-get install libboost-program-options1.74-dev
+```
+
 Go to the directory where  you unpacked indi_asi sources and do:
 
 ```


### PR DESCRIPTION
Encountered build issues due to the missing libboost-program-options dependency, so I figured it may help out others if this was mentioned in some place.