### PR TITLE
SVBONYCCD: Workaround for an issue that rarely retrieves the previous iamge.

### DIFF
--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -1,3 +1,9 @@
+indi-svbony (1.4.1) bionic; urgency=low
+
+	* SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.
+
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 12 Mar. 2024 14:00:00 +0900
+
 indi-svbony (1.3.8) bionic; urgency=low
 
   * SVBONY CCD firmware and SDK version information logs added

--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -1,6 +1,6 @@
 indi-svbony (1.4.1) bionic; urgency=low
 
-	* SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.
+  * SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.
 
  -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 12 Mar. 2024 14:00:00 +0900
 

--- a/indi-svbony/CMakeLists.txt
+++ b/indi-svbony/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SVBONY_VERSION_MAJOR 1)
 set (SVBONY_VERSION_MINOR 4)
-set (SVBONY_VERSION_PATCH 0)
+set (SVBONY_VERSION_PATCH 1)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-svbony/README
+++ b/indi-svbony/README
@@ -69,6 +69,7 @@ Limitations
 Changelog
 =========
 
+	+ 1.4.1 : SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.
 	+ 1.3.8 : SVBONY CCD firmware and SDK version information logs added.
 	+ 1.3.7 : Fixed Conflict of private variables in SVBONYCCD class.
 	+ 1.3.6 : Disabled workaround code for bug #666 "the problem that the last exposure image may be read in soft trigger mode".

--- a/indi-svbony/svbony_base.cpp
+++ b/indi-svbony/svbony_base.cpp
@@ -79,6 +79,16 @@ bool SVBONYBase::SetROIFormat(int x, int y, int w, int h, int bin)
     return true;
 }
 
+#ifdef WORKAROUND_latest_image_can_be_getten_next_time
+// Discard unretrieved exposure data
+void SVBONYBase::discardVideoData()
+{
+    unsigned char* imageBuffer = PrimaryCCD.getFrameBuffer();
+    SVB_ERROR_CODE status = SVBGetVideoData(mCameraInfo.CameraID, imageBuffer, PrimaryCCD.getFrameBufferSize(),  1000);
+    LOGF_DEBUG("Discard unretrieved exposure data: SVBGetVideoData:result=%d", status);
+}
+#endif
+
 void SVBONYBase::workerStreamVideo(const std::atomic_bool &isAboutToQuit)
 {
     SVB_ERROR_CODE ret;
@@ -175,6 +185,11 @@ void SVBONYBase::workerExposure(const std::atomic_bool &isAboutToQuit, float dur
         LOGF_ERROR("Failed to start video capture (%s).", Helpers::toString(ret));
         return;
     }
+
+#ifdef WORKAROUND_latest_image_can_be_getten_next_time
+    // Discard unretrieved exposure data
+    discardVideoData();
+#endif
 
     PrimaryCCD.setExposureDuration(duration);
 

--- a/indi-svbony/svbony_base.h
+++ b/indi-svbony/svbony_base.h
@@ -35,6 +35,10 @@
 #include <indiccd.h>
 #include <inditimer.h>
 
+// WORKAROUND for bug #655
+// If defined following symbol, get buffered image data before to set exposure duration.
+#define WORKAROUND_latest_image_can_be_getten_next_time
+
 class SingleWorker;
 class SVBONYBase : public INDI::CCD
 {
@@ -95,6 +99,10 @@ class SVBONYBase : public INDI::CCD
         /** Send CCD image to client */
         void sendImage(SVB_IMG_TYPE type, float duration);
 
+#ifdef WORKAROUND_latest_image_can_be_getten_next_time
+        // Discard unretrieved exposure data
+        void discardVideoData();
+#endif
     protected:
         double mTargetTemperature;
         double mCurrentTemperature;


### PR DESCRIPTION
ISSUE #655 regarding SVBONY Camera SDK still reproduces rarely.
The workaround code for this issue has been re-implemented.