### PR TITLE
Fix build with system JSON library

### DIFF
--- a/indi-qhy/CMakeLists.txt
+++ b/indi-qhy/CMakeLists.txt
@@ -13,6 +13,16 @@ find_package(Nova REQUIRED)
 find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
+if(INDI_JSONLIB)
+    set(JSONLIB "")
+    message(STATUS "Using indi bundled json library")
+else(INDI_JSONLIB)
+    find_package(nlohmann_json REQUIRED)
+    add_definitions(-D_USE_SYSTEM_JSONLIB)
+    set(JSONLIB nlohmann_json::nlohmann_json)
+    message(STATUS "Using system provided Niels Lohmann's json library")
+endif(INDI_JSONLIB)
+
 set(INDI_QHY_VERSION_MAJOR 2)
 set(INDI_QHY_VERSION_MINOR 8)
 


### PR DESCRIPTION
This commit fixes the following build failure:

```
[1/8] /usr/bin/x86_64-pc-linux-gnu-g++ -DCALLBACK_MODE_SUPPORT -I/var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy_build -I/var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy -I/usr/include/libindi -I/usr/include/libqhy -I/usr/include/libusb-1.0  -march=native -O2 -pipe -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE -O1 -Wa,--noexecstack  -Wall -Wextra -Wno-unused-but-set-variable -Wno-format-truncation -g -Wno-error -std=gnu++14 -fPIE -MD -MT CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o -MF CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o.d -o CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o -c /var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy/qhy_focuser.cpp
FAILED: CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o 
/usr/bin/x86_64-pc-linux-gnu-g++ -DCALLBACK_MODE_SUPPORT -I/var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy_build -I/var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy -I/usr/include/libindi -I/usr/include/libqhy -I/usr/include/libusb-1.0  -march=native -O2 -pipe -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE -O1 -Wa,--noexecstack  -Wall -Wextra -Wno-unused-but-set-variable -Wno-format-truncation -g -Wno-error -std=gnu++14 -fPIE -MD -MT CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o -MF CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o.d -o CMakeFiles/indi_qhy_focuser.dir/qhy_focuser.cpp.o -c /var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy/qhy_focuser.cpp
/var/tmp/portage/sci-libs/indilib-driver-qhy-2.0.7/work/indi-3rdparty-2.0.7/indi-qhy/qhy_focuser.cpp:34:10: fatal error: indijson.hpp: No such file or directory
   34 | #include <indijson.hpp>
      |          ^~~~~~~~~~~~~~
compilation terminated.
```