### PR TITLE
libqhy: fix soversion

### DIFF
--- a/libqhy/CMakeLists.txt
+++ b/libqhy/CMakeLists.txt
@@ -3,7 +3,7 @@ project (libqhy)
 
 # QHY SDK 24.04.01
 set (LIBQHY_VERSION "24.4.1")
-set (LIBQHY_SOVERSION "24")
+set (LIBQHY_SOVERSION "20")
 
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")


### PR DESCRIPTION
the binary file actually has the SONAME libqhyccd.so.20 and is also distributed in the official SDK as libqhyccd.so.20. This changes the SOVERSION to match that.