### PR TITLE
Fix broken humidity reading after reconnect of device

### DIFF
--- a/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
+++ b/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
@@ -71,8 +71,11 @@ bool AAGCloudWatcher::Handshake()
 
         if (m_FirmwareVersion >= 5.6)
         {
-            addParameter("WEATHER_HUMIDITY", "Relative Humidity (%)", 0, 100, 10);
-            setCriticalParameter("WEATHER_HUMIDITY");
+            // add humidity parameter, if not already present
+            if (!ParametersNP.findWidgetByName("WEATHER_HUMIDITY")) {
+                addParameter("WEATHER_HUMIDITY", "Relative Humidity (%)", 0, 100, 10);
+                setCriticalParameter("WEATHER_HUMIDITY");
+            }
         }
 
         return true;


### PR DESCRIPTION
I noticed, that my cloudwatcher was showing mutliple humidity values in the parameters tab. All are zero and kstars observatory tab was not showing humidity value. This happens, when kstars disconnects and reconnects the driver. Each time the handshake method is called, adding another parameter.

This fix simply checks if the parameter already exists before adding it. 