### PR TITLE
BUGFIX #944: toupcam EFW driver

### DIFF
--- a/indi-toupbase/indi_toupwheel.cpp
+++ b/indi-toupbase/indi_toupwheel.cpp
@@ -200,6 +200,7 @@ bool ToupWheel::SelectFilter(int targetFilter)
         LOGF_ERROR("Failed to select filter wheel %d. %s", targetFilter, errorCodes(rc).c_str());
         return false;
     }
+    SetTimer(getCurrentPollingPeriod());
     return true;
 }
 


### PR DESCRIPTION
TimerHit did not work because SetTimer was not called when the filter was set.
Due to this issue, the capture module cannot start capturing while waiting for the filter to be set.