### PR TITLE
Fix TEC temperature range initialisation

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -463,8 +463,10 @@ bool ToupBase::Connect()
     {
         int tecRange = 0;
         FP(get_Option(m_Handle, CP(OPTION_TECTARGET_RANGE), &tecRange));
-        TemperatureN[0].min = TemperatureN[0].value = tecRange & 0xffff;
-        TemperatureN[0].max = (tecRange >> 16) & 0xffff;
+        TemperatureN[0].min = (static_cast<short>(tecRange & 0xffff))/10.0;
+        TemperatureN[0].max
+                = (static_cast<short>((tecRange >> 16) & 0xffff)) / 10.0;
+        TemperatureN[0].value = 0; // reasonable default
     }
 
     {


### PR DESCRIPTION
Fix TEC temperature range initialisation (missing cast, missing scaling), set 0 degree as starting point instead of indicated minimum.