### PR TITLE
BUGFIX: SVBONY CCD: Stop cooling at disconnection

### DIFF
--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -1,3 +1,9 @@
+indi-svbony (1.4.2) bionic; urgency=low
+
+  * BUGFIX: SVBONYCCD: Stop cooling at disconnection
+
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 6 Aug. 2024 4:00:00 +0900
+
 indi-svbony (1.4.1) bionic; urgency=low
 
   * SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.

--- a/indi-svbony/CMakeLists.txt
+++ b/indi-svbony/CMakeLists.txt
@@ -8,7 +8,7 @@ include(GNUInstallDirs)
 
 set (SVBONY_VERSION_MAJOR 1)
 set (SVBONY_VERSION_MINOR 4)
-set (SVBONY_VERSION_PATCH 1)
+set (SVBONY_VERSION_PATCH 2)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)

--- a/indi-svbony/svbony_base.cpp
+++ b/indi-svbony/svbony_base.cpp
@@ -675,6 +675,9 @@ bool SVBONYBase::Disconnect()
     if (isSimulation() == false)
     {
         SVBStopVideoCapture(mCameraInfo.CameraID);
+        if (HasCooler()) {
+            activateCooler(false);
+        }
         SVBCloseCamera(mCameraInfo.CameraID);
     }
 


### PR DESCRIPTION
BUGFIX: SVBONY CCD: Stop cooling at disconnection
The INDI CCD driver did not turn off the cooling, and the cooling remained on even after disconnecting EKOS.
This issue has been fixed.