### PR TITLE
WIP: (CAUX) Implement predictive tracking with PID corrections in AltAz mode.

### DIFF
--- a/indi-celestronaux/CMakeLists.txt
+++ b/indi-celestronaux/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
 set(CAUX_VERSION_MAJOR 1)
-set(CAUX_VERSION_MINOR 3)
+set(CAUX_VERSION_MINOR 4)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_celestronaux.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_celestronaux.xml )

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1342,12 +1342,12 @@ void CelestronAUX::resetTracking()
     //    m_TrackStartSteps[AXIS_AZ] = EncoderNP[AXIS_AZ].getValue();
     //    m_TrackStartSteps[AXIS_ALT] = EncoderNP[AXIS_ALT].getValue();
 
-    m_Controllers[AXIS_AZ].reset(new PID(1, 100000, -100000, Axis1PIDNP[Propotional].getValue(),
+    m_Controllers[AXIS_AZ].reset(new PID(getPollingPeriod()/1000.0, 10000, -10000, Axis1PIDNP[Propotional].getValue(),
                                          Axis1PIDNP[Derivative].getValue(), Axis1PIDNP[Integral].getValue()));
-    m_Controllers[AXIS_AZ]->setIntegratorLimits(-2000, 2000);
-    m_Controllers[AXIS_ALT].reset(new PID(1, 100000, -100000, Axis2PIDNP[Propotional].getValue(),
+    m_Controllers[AXIS_AZ]->setIntegratorLimits(-10000, 10000);
+    m_Controllers[AXIS_ALT].reset(new PID(getPollingPeriod()/1000.0, 10000, -10000, Axis2PIDNP[Propotional].getValue(),
                                           Axis2PIDNP[Derivative].getValue(), Axis2PIDNP[Integral].getValue()));
-    m_Controllers[AXIS_ALT]->setIntegratorLimits(-2000, 2000);
+    m_Controllers[AXIS_ALT]->setIntegratorLimits(-10000, 10000);
     m_TrackingElapsedTimer.restart();
     m_GuideOffset[AXIS_AZ] = m_GuideOffset[AXIS_ALT] = 0;
 }
@@ -1884,7 +1884,10 @@ void CelestronAUX::TimerHit()
             else if (m_MountType == ALT_AZ)
             {
                 TelescopeDirectionVector TDV;
+                TelescopeDirectionVector futureTDV;
                 INDI::IHorizontalCoordinates targetMountAxisCoordinates { 0, 0 };
+                INDI::IHorizontalCoordinates futureMountAxisCoordinates { 0, 0 };
+                double JDoffset { 10.0/(60 * 60 * 24) } ; // ten seconds into the future
 
                 // Start by transforming tracking target celestial coordinates to telescope coordinates.
                 if (TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
@@ -1892,15 +1895,36 @@ void CelestronAUX::TimerHit()
                 {
                     // If mount is Alt-Az then that's all we need to do
                     AltitudeAzimuthFromTelescopeDirectionVector(TDV, targetMountAxisCoordinates);
+                    TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                                  JDoffset, futureTDV);
+                    AltitudeAzimuthFromTelescopeDirectionVector(futureTDV, futureMountAxisCoordinates);
+
                 }
                 // If transformation failed.
                 else
                 {
+                    double JDnow {ln_get_julian_from_sys()};
                     INDI::IEquatorialCoordinates EquatorialCoordinates { 0, 0 };
                     EquatorialCoordinates.rightascension  = m_SkyTrackingTarget.rightascension;
                     EquatorialCoordinates.declination = m_SkyTrackingTarget.declination;
-                    INDI::EquatorialToHorizontal(&EquatorialCoordinates, &m_Location, ln_get_julian_from_sys(), &targetMountAxisCoordinates);
+                    INDI::EquatorialToHorizontal(&EquatorialCoordinates, &m_Location, JDnow, &targetMountAxisCoordinates);
+                    INDI::EquatorialToHorizontal(&EquatorialCoordinates, &m_Location, JDnow+JDoffset, &futureMountAxisCoordinates);
                 }
+
+
+                // Calculate expected tracking rates
+                double predRate[2] = {0, 0};
+                predRate[AXIS_AZ] = range180(AzimuthToDegrees(futureMountAxisCoordinates.azimuth - targetMountAxisCoordinates.azimuth))/10;
+                predRate[AXIS_ALT] = (futureMountAxisCoordinates.altitude - targetMountAxisCoordinates.altitude)/10;
+                
+                LOGF_DEBUG("Predicted positions (AZ):  %9.4f  %9.4f (now, future, degs)", AzimuthToDegrees(targetMountAxisCoordinates.azimuth),
+                                                                                          AzimuthToDegrees(futureMountAxisCoordinates.azimuth)) ;
+                LOGF_DEBUG("Predicted positions (AL):  %9.4f  %9.4f (now, future, degs)", targetMountAxisCoordinates.altitude,
+                                                                                          futureMountAxisCoordinates.altitude);
+                LOGF_DEBUG("Predicted Rates (AZ, ALT): %9.4f  %9.4f (arcsec/s)", 3600*predRate[AXIS_AZ], 3600*predRate[AXIS_ALT]);
+
+                predRate[AXIS_AZ] = 3600 * predRate[AXIS_AZ] * 1024;
+                predRate[AXIS_ALT] = 3600 * predRate[AXIS_ALT] * 1024;
 
                 // Now add the guiding offsets.
                 targetMountAxisCoordinates.azimuth += m_GuideOffset[AXIS_AZ];
@@ -1919,7 +1943,7 @@ void CelestronAUX::TimerHit()
 
                 // Offset in degrees
                 double offsetAngle[2] = {0, 0};
-                offsetAngle[AXIS_AZ] = (targetMountAxisCoordinates.azimuth - currentAltAz.azimuth);
+                offsetAngle[AXIS_AZ] = range180(targetMountAxisCoordinates.azimuth - currentAltAz.azimuth);
                 offsetAngle[AXIS_ALT] = (targetMountAxisCoordinates.altitude - currentAltAz.altitude);
 
                 int32_t offsetSteps[2] = {0, 0};
@@ -1929,46 +1953,51 @@ void CelestronAUX::TimerHit()
                 offsetSteps[AXIS_AZ] = offsetAngle[AXIS_AZ] * STEPS_PER_DEGREE;
                 offsetSteps[AXIS_ALT] = offsetAngle[AXIS_ALT] * STEPS_PER_DEGREE;
 
-                // Only apply trackinf IF we're still on the same side of the curve
+                // Only apply tracking IF we're still on the same side of the curve
                 // If we switch over, let's settle for a bit
-                if (m_LastOffset[AXIS_AZ] * offsetSteps[AXIS_AZ] >= 0 || m_OffsetSwitchSettle[AXIS_AZ]++ > 3)
+                // This seems to not be required. To be removed after extensive testing
+                // if (m_LastOffset[AXIS_AZ] * offsetSteps[AXIS_AZ] >= 0 || m_OffsetSwitchSettle[AXIS_AZ]++ > 3)
                 {
                     m_OffsetSwitchSettle[AXIS_AZ] = 0;
                     m_LastOffset[AXIS_AZ] = offsetSteps[AXIS_AZ];
                     targetSteps[AXIS_AZ] = DegreesToEncoders(AzimuthToDegrees(targetMountAxisCoordinates.azimuth));
-                    trackRates[AXIS_AZ] = m_Controllers[AXIS_AZ]->calculate(targetSteps[AXIS_AZ], EncoderNP[AXIS_AZ].getValue());
-
-                    LOGF_DEBUG("Tracking AZ Now: %.f Target: %d Offset: %d Rate: %.2f", EncoderNP[AXIS_AZ].getValue(), targetSteps[AXIS_AZ],
+                    trackRates[AXIS_AZ] = predRate[AXIS_AZ] + m_Controllers[AXIS_AZ]->calculate(0, -offsetSteps[AXIS_AZ]);
+                    LOGF_DEBUG("Predicted AZ Rate: %8.2f", predRate[AXIS_AZ]);
+                    LOGF_DEBUG("Tracking AZ Now: %8.f Target: %8d Offset: %8d Rate: %8.2f", EncoderNP[AXIS_AZ].getValue(), targetSteps[AXIS_AZ],
                                offsetSteps[AXIS_AZ], trackRates[AXIS_AZ]);
 #ifdef DEBUG_PID
-                    LOGF_DEBUG("Tracking AZ P: %f I: %f D: %f",
+                    LOGF_DEBUG("Tracking AZ P: %8.1f I: %8.1f D: %8.1f O: %8.1f",
                                m_Controllers[AXIS_AZ]->propotionalTerm(),
                                m_Controllers[AXIS_AZ]->integralTerm(),
-                               m_Controllers[AXIS_AZ]->derivativeTerm());
+                               m_Controllers[AXIS_AZ]->derivativeTerm(),
+                               trackRates[AXIS_AZ] - predRate[AXIS_AZ]);
 #endif
 
-                    // Use PID to determine appropiate tracking rate
+                    // Set the tracking rate 
                     trackByRate(AXIS_AZ, trackRates[AXIS_AZ]);
                 }
 
-                // Only apply trackinf IF we're still on the same side of the curve
+                // Only apply tracking IF we're still on the same side of the curve
                 // If we switch over, let's settle for a bit
-                if (m_LastOffset[AXIS_ALT] * offsetSteps[AXIS_ALT] >= 0 || m_OffsetSwitchSettle[AXIS_ALT]++ > 3)
+                // This seems to not be required. To be removed after extensive testing
+                // if (m_LastOffset[AXIS_ALT] * offsetSteps[AXIS_ALT] >= 0 || m_OffsetSwitchSettle[AXIS_ALT]++ > 3)
                 {
                     m_OffsetSwitchSettle[AXIS_ALT] = 0;
                     m_LastOffset[AXIS_ALT] = offsetSteps[AXIS_ALT];
                     targetSteps[AXIS_ALT]  = DegreesToEncoders(targetMountAxisCoordinates.altitude);
-                    trackRates[AXIS_ALT] = m_Controllers[AXIS_ALT]->calculate(targetSteps[AXIS_ALT], EncoderNP[AXIS_ALT].getValue());
+                    trackRates[AXIS_ALT] = predRate[AXIS_ALT] + m_Controllers[AXIS_ALT]->calculate(0, -offsetSteps[AXIS_ALT]);
 
-                    LOGF_DEBUG("Tracking AL Now: %.f Target: %d Offset: %d Rate: %.2f", EncoderNP[AXIS_ALT].getValue(), targetSteps[AXIS_ALT],
+                    LOGF_DEBUG("Predicted AL Rate: %8.2f", predRate[AXIS_ALT]);
+                    LOGF_DEBUG("Tracking AL Now: %8.f Target: %8d Offset: %8d Rate: %8.2f", EncoderNP[AXIS_ALT].getValue(), targetSteps[AXIS_ALT],
                                offsetSteps[AXIS_ALT], trackRates[AXIS_ALT]);
 #ifdef DEBUG_PID
-                    LOGF_DEBUG("Tracking AL P: %f I: %f D: %f",
+                    LOGF_DEBUG("Tracking AL P: %8.1f I: %8.1f D: %8.1f O: %8.1f",
                                m_Controllers[AXIS_ALT]->propotionalTerm(),
                                m_Controllers[AXIS_ALT]->integralTerm(),
-                               m_Controllers[AXIS_ALT]->derivativeTerm());
+                               m_Controllers[AXIS_ALT]->derivativeTerm(),
+                               trackRates[AXIS_ALT] - predRate[AXIS_ALT]);
 #endif
-                    trackByRate(AXIS_ALT, trackRates[AXIS_ALT]);
+                    trackByRate(AXIS_ALT, trackRates[AXIS_ALT]);                    
                 }
                 break;
             }
@@ -2661,6 +2690,9 @@ bool CelestronAUX::Abort()
 /// Rate is Celestron specific and roughly equals 80 ticks per 1 motor step
 /// rate = 80 would cause the motor to spin at a rate of 1 step/s
 /// Have to check if 80 is specific to my Evolution 6" or not.
+/// Based on AUXBUS scanner data, other sources and real hardware
+/// the actual rate multiplier is 1024*360*60*60/2^24 = 79.1015625.
+/// The rate passed here should be 1024 * angular rate in arsec/s.
 /////////////////////////////////////////////////////////////////////////////////////
 bool CelestronAUX::trackByRate(INDI_HO_AXIS axis, int32_t rate)
 {

--- a/indi-celestronaux/simulator/nse_simulator.py
+++ b/indi-celestronaux/simulator/nse_simulator.py
@@ -30,9 +30,10 @@ async def timer(seconds_to_sleep=1,telescope=None):
     t=time()
     while True :
         await asyncio.sleep(seconds_to_sleep)
+        cur_t = time()
         if telescope : 
-            telescope.tick(time()-t)
-        t=time()
+            telescope.tick(cur_t-t)
+        t=cur_t
 
 async def handle_port2000(reader, writer):
     '''

--- a/indi-celestronaux/simulator/nse_telescope.py
+++ b/indi-celestronaux/simulator/nse_telescope.py
@@ -374,11 +374,13 @@ class NexStarScope:
         return b''
 
     def get_model(self, data, snd, rcv):
+        return bytes.fromhex('1687') # NSEvo
         return bytes.fromhex('1485') # AVX
+        
 
     def set_pos_guiderate(self, data, snd, rcv):
-        # The 1.1 factor is experimental to fit the actual hardware
-        a=1.1*(2**24/1000/360/60/60)*unpack_int3(data) # (transform to rot/sec)
+        # The 1024 factor is taken from the AUXBUS scanner to fit the actual hardware
+        a=(2**24/1024/360/60/60)*unpack_int3(data) # (transform to rot/sec)
         self.guiding = a>0
         if trg_names[rcv] == 'ALT':
             self.alt_guiderate=a
@@ -387,8 +389,8 @@ class NexStarScope:
         return b''
 
     def set_neg_guiderate(self, data, snd, rcv):
-        # The 1.1 factor is experimental to fit the actual hardware
-        a=1.1*(2**24/1000/360/60/60)*unpack_int3(data) # (transform to rot/sec)
+        # The 1024 factor is taken from the AUXBUS scanner to fit the actual hardware
+        a=(2**24/1024/360/60/60)*unpack_int3(data) # (transform to rot/sec)
         self.guiding = a>0
         if trg_names[rcv] == 'ALT':
             self.alt_guiderate=-a

--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -1429,8 +1429,8 @@ int gphoto_read_exposure_fd(gphoto_driver *gphoto, int fd)
                     return GP_OK;
                 }
                 DEBUGFDEVICE(device, INDI::Logger::DBG_DEBUG, "Event timed out #%d, retrying...", ++timeoutCounter);
-                // So retry for 5 seconds before giving up
-                if (timeoutCounter >= 10)
+                // So retry for 900 seconds before giving up to accomodate internal dark frame in new Canon DSLR
+                if (timeoutCounter >= 900)
                 {
                     pthread_mutex_unlock(&gphoto->mutex);
                     return -1;

--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -1429,8 +1429,8 @@ int gphoto_read_exposure_fd(gphoto_driver *gphoto, int fd)
                     return GP_OK;
                 }
                 DEBUGFDEVICE(device, INDI::Logger::DBG_DEBUG, "Event timed out #%d, retrying...", ++timeoutCounter);
-                // So retry for 900 seconds before giving up to accomodate internal dark frame in new Canon DSLR
-                if (timeoutCounter >= 900)
+                // So retry for 5 seconds before giving up
+                if (timeoutCounter >= 10)
                 {
                     pthread_mutex_unlock(&gphoto->mutex);
                     return -1;


### PR DESCRIPTION
This is a first attempt to implement tracking in AltAz mode with calculated track rates and PID controlled fine-tuning. The most of the tracking is handled by Horiz<->Eq transformation. The PID is used only to correct the small drift, probably caused by from the skew in clock rates (to be verified). The test results: show RMS tracking noise below 0.1 arcsec for Alt < 80 deg. This is essentially LSB of the hardware.