### PR TITLE
fix(3rd-party): fix mgen, ahp-xc and pentax errors on fedora.

### DIFF
--- a/indi-ahp-xc/indi_ahp_xc.cpp
+++ b/indi-ahp-xc/indi_ahp_xc.cpp
@@ -633,43 +633,44 @@ AHP_XC::AHP_XC()
     IntegrationRequest = 0.0;
     InIntegration = false;
 
-    autocorrelationsB = static_cast<IBLOB*>(malloc(1));
-    crosscorrelationsB = static_cast<IBLOB*>(malloc(1));
-    plotB = static_cast<IBLOB*>(malloc(1));
+    // These allocations are uninitialised placeholders
 
-    lineStatsN = static_cast<INumber*>(malloc(1));
-    lineStatsNP = static_cast<INumberVectorProperty*>(malloc(1));
+    autocorrelationsB = static_cast<IBLOB*>(malloc(sizeof(IBLOB)));
+    crosscorrelationsB = static_cast<IBLOB*>(malloc(sizeof(IBLOB)));
+    plotB = static_cast<IBLOB*>(malloc(sizeof(IBLOB)));
 
-    lineEnableS = static_cast<ISwitch*>(malloc(1));
-    lineEnableSP = static_cast<ISwitchVectorProperty*>(malloc(1));
+    lineStatsN = static_cast<INumber*>(malloc(sizeof(INumber)));
+    lineStatsNP = static_cast<INumberVectorProperty*>(malloc(sizeof(INumberVectorProperty)));
 
-    linePowerS = static_cast<ISwitch*>(malloc(1));
-    linePowerSP = static_cast<ISwitchVectorProperty*>(malloc(1));
+    lineEnableS = static_cast<ISwitch*>(malloc(sizeof(ISwitch)));
+    lineEnableSP = static_cast<ISwitchVectorProperty*>(malloc(sizeof(ISwitchVectorProperty)));
 
-    lineActiveEdgeS = static_cast<ISwitch*>(malloc(1));
-    lineActiveEdgeSP = static_cast<ISwitchVectorProperty*>(malloc(1));
+    linePowerS = static_cast<ISwitch*>(malloc(sizeof(ISwitch)));
+    linePowerSP = static_cast<ISwitchVectorProperty*>(malloc(sizeof(ISwitchVectorProperty)));
 
-    lineEdgeTriggerS = static_cast<ISwitch*>(malloc(1));
-    lineEdgeTriggerSP = static_cast<ISwitchVectorProperty*>(malloc(1));
+    lineActiveEdgeS = static_cast<ISwitch*>(malloc(sizeof(ISwitch)));
+    lineActiveEdgeSP = static_cast<ISwitchVectorProperty*>(malloc(sizeof(ISwitchVectorProperty)));
 
-    lineLocationN = static_cast<INumber*>(malloc(1));
-    lineLocationNP = static_cast<INumberVectorProperty*>(malloc(1));
+    lineEdgeTriggerS = static_cast<ISwitch*>(malloc(sizeof(ISwitch)));
+    lineEdgeTriggerSP = static_cast<ISwitchVectorProperty*>(malloc(sizeof(ISwitchVectorProperty)));
 
-    lineDelayN = static_cast<INumber*>(malloc(1));
-    lineDelayNP = static_cast<INumberVectorProperty*>(malloc(1));
+    lineLocationN = static_cast<INumber*>(malloc(sizeof(INumber)));
+    lineLocationNP = static_cast<INumberVectorProperty*>(malloc(sizeof(INumberVectorProperty)));
 
-    correlationsN = static_cast<INumber*>(malloc(1));
+    lineDelayN = static_cast<INumber*>(malloc(sizeof(INumber)));
+    lineDelayNP = static_cast<INumberVectorProperty*>(malloc(sizeof(INumberVectorProperty)));
 
-    autocorrelations_str = static_cast<dsp_stream_p*>(malloc(1));
-    crosscorrelations_str = static_cast<dsp_stream_p*>(malloc(1));
-    plot_str = static_cast<dsp_stream_p*>(malloc(1));
+    correlationsN = static_cast<INumber*>(malloc(sizeof(INumber)));
 
-    framebuffer = static_cast<double*>(malloc(1));
-    totalcounts = static_cast<double*>(malloc(1));
-    totalcorrelations = static_cast<ahp_xc_correlation*>(malloc(1));
-    delay = static_cast<double*>(malloc(1));
-    baselines = static_cast<baseline**>(malloc(1));
+    autocorrelations_str = static_cast<dsp_stream_p*>(malloc(sizeof(dsp_stream_p)));
+    crosscorrelations_str = static_cast<dsp_stream_p*>(malloc(sizeof(dsp_stream_p)));
+    plot_str = static_cast<dsp_stream_p*>(malloc(sizeof(dsp_stream_p)));
 
+    framebuffer = static_cast<double*>(malloc(sizeof(double)));
+    totalcounts = static_cast<double*>(malloc(sizeof(double)));
+    totalcorrelations = static_cast<ahp_xc_correlation*>(malloc(sizeof(ahp_xc_correlation)));
+    delay = static_cast<double*>(malloc(sizeof(double)));
+    baselines = static_cast<baseline**>(malloc(sizeof(baseline)));
 }
 
 bool AHP_XC::Disconnect()

--- a/indi-mgen/mgen.h
+++ b/indi-mgen/mgen.h
@@ -75,8 +75,26 @@ class IOError : std::exception
 /** \brief One word in the I/O protocol */
 typedef unsigned char IOByte;
 
-/** \brief A buffer of protocol words */
-typedef std::vector<IOByte> IOBuffer;
+/** \brief A buffer of protocol words
+ *
+ * Those three constructors are implemented here to work around C++14 warnings about out-of-bounds copies on std::vector
+ */
+class IOBuffer : public std::vector<IOByte>
+{
+  public:
+    IOBuffer(IOBuffer const &b): std::vector<IOByte>(b.size())
+    {
+      assign(b.begin(),b.end());
+    }
+    IOBuffer(std::initializer_list<IOByte> const &b): std::vector<IOByte>(b.size())
+    {
+      assign(b.begin(),b.end());
+    }
+    IOBuffer(std::size_t s = 0): std::vector<IOByte>(s)
+    {
+      /* no-op */
+    }
+};
 
 /** \internal Logging helpers */
 /** @{ */

--- a/indi-pentax/pentax_ccd.cpp
+++ b/indi-pentax/pentax_ccd.cpp
@@ -504,7 +504,7 @@ bool PentaxCCD::StopStreaming()
 ISwitch * PentaxCCD::create_switch(const char * basestr, std::vector<string> options, int setidx)
 {
 
-    ISwitch * sw     = static_cast<ISwitch *>(calloc(sizeof(ISwitch), options.size()));
+    ISwitch * sw     = static_cast<ISwitch *>(calloc(options.size(), sizeof(ISwitch)));
     ISwitch * one_sw = sw;
 
     char sw_name[MAXINDINAME];

--- a/indi-pentax/pktriggercord_ccd.cpp
+++ b/indi-pentax/pktriggercord_ccd.cpp
@@ -706,7 +706,7 @@ bool PkTriggerCordCCD::grabImage()
 ISwitch * PkTriggerCordCCD::create_switch(const char * basestr, string options[], size_t numOptions, int setidx)
 {
 
-    ISwitch * sw     = static_cast<ISwitch *>(calloc(sizeof(ISwitch), numOptions));
+    ISwitch * sw     = static_cast<ISwitch *>(calloc(numOptions, sizeof(ISwitch)));
     ISwitch * one_sw = sw;
 
     char sw_name[MAXINDINAME];


### PR DESCRIPTION
### fix(indi-mgen): work around C++14 out-of-bounds warnings.

This is a tentative PR to fix out-of-bounds warnings emitted by C++14 when building indi-mgen.

The implementation restricts the set of function candidates the compiler selects from when using an initialiser list on IOBuffer: `IOBuffer{opcode,literal,literal...}`, and makes sure to allocate space before copying the list data.

### fix(indi-ahp-xc): silence warnings by allocating placeholders with their real size.

@iliaplatone I considered that placeholders with their real sizes instead of 1 byte everywhere wasn't that problematic. Feel free to comment.

### fix(indi-pentax): fix calloc argument order.

`calloc(sizeof,sizeof)` expects the number of items as first argument, and the size of each as second.