### PR TITLE
Fix timestamp in indi-svbony debian changelog

### DIFF
--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -2,13 +2,13 @@ indi-svbony (1.4.2) bionic; urgency=low
 
   * BUGFIX: SVBONYCCD: Stop cooling at disconnection
 
- -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 6 Aug. 2024 04:00:00 +0900
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 6 Aug 2024 04:00:00 +0900
 
 indi-svbony (1.4.1) bionic; urgency=low
 
   * SVBONYCCD: Workaround for an issue that rarely retrieves the previous image.
 
- -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 12 Mar. 2024 14:00:00 +0900
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 12 Mar 2024 14:00:00 +0900
 
 indi-svbony (1.3.8) bionic; urgency=low
 

--- a/debian/indi-svbony/changelog
+++ b/debian/indi-svbony/changelog
@@ -2,7 +2,7 @@ indi-svbony (1.4.2) bionic; urgency=low
 
   * BUGFIX: SVBONYCCD: Stop cooling at disconnection
 
- -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 6 Aug. 2024 4:00:00 +0900
+ -- Tetsuya Kakura <jcpgm@outlook.jp>  Tue, 6 Aug. 2024 04:00:00 +0900
 
 indi-svbony (1.4.1) bionic; urgency=low
 


### PR DESCRIPTION
This fixes timestamp formatting of debian/changelog which resulted in following debian packaging error:
`dpkg-deb: error: unable to parse timestamp '': Success`