### PR TITLE
Add nlohmann/json to list of indi-qhy dependencies

### DIFF
--- a/indi-qhy/README
+++ b/indi-qhy/README
@@ -25,6 +25,11 @@ Requirements
   fxload that can upload FX3 EZUSB firmware files is required. Some distributions include an old version that do not support the fx3 flag.
   Compile a compatible version (https://github.com/lhondareyte/fxload.git) to support FX3.
 
++ nlohmann-json
+
+	@nlohmann's JSON for Modern C++ library (https://github.com/nlohmann/json) is required to build this driver using CMake.
+	It can be installed via APT as 'nlohmann-json3-dev' on Debian-based distros.
+
 Installation
 ============
 

--- a/indi-qhy/README
+++ b/indi-qhy/README
@@ -6,7 +6,7 @@ This package provides QHY CCD/CMOS and Filter Wheels INDI driver.
 Requirements
 ============
 
-+ INDI >= v1.9.6 (http://www.indilib.org)
++ INDI >= v2.1.0 (http://www.indilib.org)
 
 	You need to install both indi and indi-devel to build this package.
 	

--- a/indi-qhy/README
+++ b/indi-qhy/README
@@ -19,11 +19,13 @@ Requirements
 	libusb-1 is required.
 	
 + libqhy
-	libqhy SDK is required.
+
+	libqhy SDK (located in ../libqhy/) is required.
 	
 + fxload
-  fxload that can upload FX3 EZUSB firmware files is required. Some distributions include an old version that do not support the fx3 flag.
-  Compile a compatible version (https://github.com/lhondareyte/fxload.git) to support FX3.
+
+	fxload that can upload FX3 EZUSB firmware files is required. Some distributions include an old version that do not support the fx3 flag.
+	Compile a compatible version (https://github.com/lhondareyte/fxload.git) to support FX3.
 
 + nlohmann-json
 


### PR DESCRIPTION
I initially got this error when trying to `cmake -DCMAKE_INSTALL_PREFIX=/usr .` in indi-qhy:

```
CMake Error at CMakeLists.txt:20 (find_package):
  By not providing "Findnlohmann_json.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "nlohmann_json", but CMake did not find one.

  Could not find a package configuration file provided by "nlohmann_json"
  with any of the following names:

    nlohmann_jsonConfig.cmake
    nlohmann_json-config.cmake

  Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
  "nlohmann_json_DIR" to a directory containing one of the above files.  If
  "nlohmann_json" provides a separate development package or SDK, be sure it
  has been installed.
```

After running a `sudo apt install nlohmann-json3-dev`, the above command worked just fine.

This PR adds this currently unmentioned dependency to the requirements list in the indi-qhy README file.