### PR TITLE
feat(atik): add gain/offset control outside of CCD_CONTROLS.

### DIFF
--- a/indi-atik/atik_ccd.h
+++ b/indi-atik/atik_ccd.h
@@ -164,6 +164,14 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
             COOLER_OFF,
         };
 
+        // Gain Control
+        INumberVectorProperty GainNP;
+        INumber GainN[1];
+
+        // Offset Control
+        INumberVectorProperty OffsetNP;
+        INumber OffsetN[1];
+
         // Gain & Offset Custom Properties
         INumber ControlN[2];
         INumberVectorProperty ControlNP;


### PR DESCRIPTION
This MR adds two properties to the Atik driver, `CCD_GAIN` and `CCD_OFFSET`, allowing adjustment of gain and offset in the same way as `CCD_CONTROLS[0]` and `CCD_CONTROLS[1]`. These properties should behave like those of the QHY driver.

I don't have a APX at hand, I expect the properties to work identically on Horizon, Horizon2 and APX, but I don't iknow if they will be setup properly for APX.