### PR TITLE
Add missing cstdint inlcude for uint32_t

### DIFF
--- a/libricohcamerasdk/include/ricoh_camera_sdk/camera_status.hpp
+++ b/libricohcamerasdk/include/ricoh_camera_sdk/camera_status.hpp
@@ -2,6 +2,7 @@
 #ifndef RICOH_CAMERA_SDK_CAMERA_STATUS_HPP_
 #define RICOH_CAMERA_SDK_CAMERA_STATUS_HPP_
 
+#include <cstdint>
 #include <memory>
 
 #include <ricoh_camera_sdk/export.hpp>


### PR DESCRIPTION
The camera_status.hpp file uses uint32_t, which is defined in the <cstdint> header.

Including this header resolves a compilation error.
