### PR TITLE
Fix exposure edge situations

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1423,6 +1423,13 @@ bool ToupBase::activateCooler(bool enable)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 bool ToupBase::StartExposure(float duration)
 {
+    // Abort any running exposure before starting a new one
+    if (InExposure)
+    {
+        LOG_WARN("Exposure already in progress. Aborting previous exposure before starting a new one.");
+        AbortExposure();
+    }
+
     PrimaryCCD.setExposureDuration(static_cast<double>(duration));
 
     HRESULT rc = 0;

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -250,7 +250,7 @@ bool ToupBase::initProperties()
     ///////////////////////////////////////////////////////////////////////////////////
     /// Timeout Factor
     ///////////////////////////////////////////////////////////////////////////////////
-    IUFillNumber(&m_TimeoutFactorN, "Timeout", "Factor", "%.2f", 1, 1.2, 0.01, 1.02);
+    IUFillNumber(&m_TimeoutFactorN, "Timeout", "Factor", "%.2f", 1, 1.3, 0.01, 1.2);
     IUFillNumberVector(&m_TimeoutFactorNP, &m_TimeoutFactorN, 1, getDeviceName(), "TIMEOUT_FACTOR", "Timeout", OPTIONS_TAB,
                        IP_RW, 60, IPS_IDLE);
 


### PR DESCRIPTION
This PR:
- Adds a check on a running exposure when a new exposure is requested, and aborts the running exposure before starting the new one.
- Adds a timer to detect an exposure timeout, with a timeout factor between 1.01 and 1.30 applied to the exposure duration to define the delay after which the exposure is considered in error.

Fixes #1091 