### PR TITLE
starbook-ten: fix guide bug

### DIFF
--- a/indi-starbook-ten/indi_starbook_ten.cpp
+++ b/indi-starbook-ten/indi_starbook_ten.cpp
@@ -181,6 +181,7 @@ INDIStarbookTen::initProperties()
 bool
 INDIStarbookTen::updateProperties()
 {
+    bool r = true;
     INDI::Telescope::updateProperties();
 
     if (isConnected())
@@ -190,7 +191,7 @@ INDIStarbookTen::updateProperties()
         defineProperty(&GuideRateNP);
         defineProperty(&HomeSP);
 
-        return fetchStartupInfo();
+        r = fetchStartupInfo();
     }
     else
     {
@@ -198,11 +199,11 @@ INDIStarbookTen::updateProperties()
         deleteProperty(StateTP.name);
         deleteProperty(GuideRateNP.name);
         deleteProperty(HomeSP.name);
-
-        return true;
     }
 
     GI::updateProperties();
+
+    return r;
 }
 
 


### PR DESCRIPTION
GI::updateProperties() wasn't getting called as the code was unreachable. This results in guide appearing to be available, but trying to guide wouldn't actually send any guide pulse.