### PR TITLE
more linux rules for ZWO EFWs

### DIFF
--- a/libasi/99-asi.rules
+++ b/libasi/99-asi.rules
@@ -12,3 +12,6 @@ ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="03c3", MODE="0666", RUN+="/bin
 
 # For parent hub power control
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="03c3", MODE="0666", RUN+="/bin/sh -c 'chmod 666 /sys$devpath/../power/level'"
+
+# access EFWmini through a system libusb
+KERNEL=="hidraw*", ATTRS{idVendor}=="03c3", MODE="0666", TAG+="uaccess"


### PR DESCRIPTION
I've spent the last couple of days scratching my head about how to get RAW16 working for my ASI1600MM using the libasi directly (no indi-asi) until finally it started working magically when I installed indi-asi ... even though my code is completely independent of INDI.

A lot of head scratching led me to finally realise that your udev rules were what fixed my problems, and when I took a look at your rules I noticed that you're missing this line that I personally have needed to be able to control my ZWO EFWmini so I thought you might appreciate the payback.

I'll try my best to align my rules with yours here incase anybody installs both. I've actually been using

```
# ZWO USB device access
SUBSYSTEM=="usb", ATTR{idVendor}=="03c3", GROUP="plugdev", MODE="0660", TAG+="uaccess"

# ZWO EFW HID device access
KERNEL=="hidraw*", ATTRS{idVendor}=="03c3", GROUP="plugdev", MODE="0660", TAG+="uaccess"
```

i.e. GROUP access, which is more secure than your default of mode 0666... and I'd encourage you to change the file to do that as well.

I'm also personally preferring to use kernel startup options for the usbfs size but I can appreciate that there is no way to automate that cleanly. It's unfortunate that it's a global setting and not per device.