### PR TITLE
Fixing 2 Compile Errors in MacOS due to Deprecated Functions in C++ 17

### DIFF
--- a/libapogee/helpers.cpp
+++ b/libapogee/helpers.cpp
@@ -89,8 +89,12 @@ const std::string &separator)
  std::string help::FixPath(const std::string & inDir)
  {
      std::string result = inDir;
-
-     std::replace_if(result.begin(), result.end(), std::bind2nd(std::equal_to<int8_t>(),'\\'), '/');
+     
+     #if __cplusplus >= 201103L
+     	std::replace_if(result.begin(), result.end(), bind(std::equal_to<int8_t>(), placeholders::_1,'\\'), '/');
+     #else
+     	std::replace_if(result.begin(), result.end(), std::bind2nd(std::equal_to<int8_t>(),'\\'), '/');
+     #endif
 
     if( 0 != result.compare( result.size()-1, 1, "/" ) )
     {

--- a/libqsi/SimpleIni.h
+++ b/libqsi/SimpleIni.h
@@ -314,7 +314,11 @@ public:
 #endif
 
         /** Strict less ordering by name of key only */
-        struct KeyOrder : std::binary_function<Entry, Entry, bool> 
+        #if __cplusplus >= 201103L
+        	struct KeyOrder
+        #else
+        	struct KeyOrder : std::binary_function<Entry, Entry, bool>
+        #endif
 		{
             bool operator()(const Entry & lhs, const Entry & rhs) const 
 			{
@@ -324,7 +328,11 @@ public:
         };
 
         /** Strict less ordering by order, and then name of key */
-        struct LoadOrder : std::binary_function<Entry, Entry, bool> 
+        #if __cplusplus >= 201103L
+        	struct LoadOrder
+        #else
+        	struct LoadOrder : std::binary_function<Entry, Entry, bool>
+        #endif
 		{
             bool operator()(const Entry & lhs, const Entry & rhs) const 
 			{


### PR DESCRIPTION
Two functions were deprecated in C++ 17 that are causing issues when building INDI 3rdParty in Clang when switching the compiler standard from C++ 11 to C++ 17.  These include std::binary_function and std::bind2nd.  This commit should fix that.