### PR TITLE
starbook-ten: fix negative dec handling

### DIFF
--- a/indi-starbook-ten/starbook_ten.cpp
+++ b/indi-starbook-ten/starbook_ten.cpp
@@ -454,7 +454,7 @@ StarbookTen::sxfmt(double x) {
 
     int w = (int)x;
     double frac = x-w;
-    double mins = frac * 60.0;
+    double mins = fabs(frac) * 60.0;
 
     snprintf(buf, sizeof(buf)-1, "%d+%02.5lf", w, mins);
 


### PR DESCRIPTION
Before the fix, the output was (note the spurious `-`):

    ra=2.55, dec=-2.55, ra=2+33.00000&dec=-2+-33.00000
    ra=2.5, dec=-2.9, ra=2+30.00000&dec=-2+-54.00000

After the fix:

    ra=2.55, dec=-2.55, ?ra=2+33.00000&dec=-2+33.00000
    ra=2.5, dec=-2.9, ?ra=2+30.00000&dec=-2+54.00000

The spurious `-` seems to be interpreted as then going to e.g. -4.7 when asked to go to -5.3.

Reported-by: Hans Jürgen Mayer