### PR TITLE
Fixing the craft CI build for drivers that are not arm compatible yet.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(WITH_AHP_GT Off)
     set(WITH_TICFOCUSER-NG Off)
     # The drivers below are not yet compatible with Apple Silicon since their libraries are not universal binaries
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    if(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
         SET(WITH_ASICAM Off)
         SET(WITH_SBIG Off)
         SET(WITH_ATIK Off)

--- a/indi-nightscape/nstest-main.cpp
+++ b/indi-nightscape/nstest-main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
     //long imgszmax = 3448*2574*2 + DEFAULT_CHUNK_SIZE;
     int zonestart = 0;
     int zoneend = 0;
-    int lcount = 0;
+    //int lcount = 0;
     int scount = 0;
     int in_exp = 0;
     int old_busy_flag = 0;
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
         {
             usleep(2000);
         }
-        lcount++;
+        //lcount++;
         if (!interrupted && scount  == 1 && !done_first)
         {
             fprintf(stderr, "settemp %f\n", temp);


### PR DESCRIPTION
I was using the variable CMAKE_SYSTEM_PROCESSOR to differentiate between the ARM and X86 builds on MacOS to determine which drivers to build.  This worked on my system, but not in the Craft CI build for KStars.  I think that CMAKE_OSX_ARCHITECTURES should work in the CI build as well.  Also I found a build error in a driver due to an unused variable