### PR TITLE
Setting an environment variable for the arm ci build on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,10 +28,10 @@ jobs:
         run: $(command -v sudo) bsdtar -xvf packages/indi-core-package.tar --strip-components=1 -C / || true
 
       - name: Build INDI 3rd Party Libraries
-        run: indi-3rdparty/scripts/indi-3rdparty-libs-build.sh
+        run: export CMAKE_OSX_ARCHITECTURES="arm64"; indi-3rdparty/scripts/indi-3rdparty-libs-build.sh
 
       - name: Install INDI 3rd Party Libraries
-        run: indi-3rdparty/scripts/indi-3rdparty-libs-install.sh
+        run: export CMAKE_OSX_ARCHITECTURES="arm64"; indi-3rdparty/scripts/indi-3rdparty-libs-install.sh
 
       - name: Build INDI 3rd Party Drivers
         run: indi-3rdparty/scripts/indi-3rdparty-build.sh


### PR DESCRIPTION
Trying to fix the arm ci build on indi 3rd Party on MacOS.  While CMAKE_OSX_ARCHITECTURES gets set in craft and locally on the OS, it doesn't appear to get set in the CI build on GitHub