### PR TITLE
Create compile_commands.json when running cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 
 include(GNUInstallDirs)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 ## Some files like libnova.h and libusb.h are in in subdirectories of the include directory
 ## For the CMAKE Modules, they find the subdirectory, so then something like ln_types.h should be #include ln_types.h
 ## But some packages and drivers write their header files like this: #include libnova/ln_types.h


### PR DESCRIPTION
Set the CMake flag to create the compile_commands.json file which allows clangd to index the project and provide code completion, and cross-referencing in advanced text editors and IDE-s. #1144 