### PR TITLE
Clean up udev and firmware installation directory

### DIFF
--- a/indi-armadillo-platypus/CMakeLists.txt
+++ b/indi-armadillo-platypus/CMakeLists.txt
@@ -1,86 +1,95 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_lunatico CXX C)
+project(indi_lunatico CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
 
-SET(CMAKE_CXX_STANDARD 17)
-SET(RULES_INSTALL_DIR "/lib/udev/rules.d/")
+set(CMAKE_CXX_STANDARD 17)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 find_package(INDI REQUIRED)
 
-set (LUNATICO_VERSION_MAJOR 2)
-set (LUNATICO_VERSION_MINOR 2)
+set(LUNATICO_VERSION_MAJOR 2)
+set(LUNATICO_VERSION_MINOR 2)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_lunatico.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_lunatico.xml )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_lunatico.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_lunatico.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
 
 include(CMakeCommon)
 
 ########### Lunatico Seletek Rotator ###########
-set(seletekrotator_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/seletek_rotator.cpp
-   )
+set(seletekrotator_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/seletek_rotator.cpp)
 
 add_executable(indi_seletek_rotator ${seletekrotator_SRCS})
-target_link_libraries(indi_seletek_rotator ${INDI_LIBRARIES} )
-install(TARGETS indi_seletek_rotator RUNTIME DESTINATION bin )
+target_link_libraries(indi_seletek_rotator ${INDI_LIBRARIES})
+install(TARGETS indi_seletek_rotator RUNTIME DESTINATION bin)
 
 ########### Lunatico DragonFly Dome ###########
-set(dragonfly_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/dragonfly_dome.cpp
-   )
+set(dragonfly_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/dragonfly_dome.cpp)
 
 add_executable(indi_dragonfly_dome ${dragonfly_SRCS})
-target_link_libraries(indi_dragonfly_dome ${INDI_LIBRARIES} )
-install(TARGETS indi_dragonfly_dome RUNTIME DESTINATION bin )
+target_link_libraries(indi_dragonfly_dome ${INDI_LIBRARIES})
+install(TARGETS indi_dragonfly_dome RUNTIME DESTINATION bin)
 
 ########### Lunatico DragonFly Controller ###########
-set(dragonflycontroller_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/dragonfly_controller.cpp
-   )
+set(
+  dragonflycontroller_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/dragonfly_controller.cpp
+)
 
 add_executable(indi_dragonfly ${dragonflycontroller_SRCS})
-target_link_libraries(indi_dragonfly ${INDI_LIBRARIES} )
-install(TARGETS indi_dragonfly RUNTIME DESTINATION bin )
-
+target_link_libraries(indi_dragonfly ${INDI_LIBRARIES})
+install(TARGETS indi_dragonfly RUNTIME DESTINATION bin)
 
 ########### Beaver Dome ###########
-set(beaver_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/beaver_dome.cpp
-   )
+set(beaver_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/beaver_dome.cpp)
 
 add_executable(indi_beaver_dome ${beaver_SRCS})
-target_link_libraries(indi_beaver_dome ${INDI_LIBRARIES} )
-install(TARGETS indi_beaver_dome RUNTIME DESTINATION bin )
+target_link_libraries(indi_beaver_dome ${INDI_LIBRARIES})
+install(TARGETS indi_beaver_dome RUNTIME DESTINATION bin)
 
 ########### Lunatico Seletek Armadillo & Platypus ###########
-set(indiarmadillofocuser_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/armadillo_focuser.cpp
-   )
+set(indiarmadillofocuser_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/armadillo_focuser.cpp)
 
-set(indiplatypusfocuser_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/platypus_focuser.cpp
-   )
+set(indiplatypusfocuser_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/platypus_focuser.cpp)
 
 add_executable(indi_armadillo_focus ${indiarmadillofocuser_SRCS})
 add_executable(indi_platypus_focus ${indiplatypusfocuser_SRCS})
 
-target_link_libraries(indi_armadillo_focus ${INDI_LIBRARIES} )
-target_link_libraries(indi_platypus_focus ${INDI_LIBRARIES} )
+target_link_libraries(indi_armadillo_focus ${INDI_LIBRARIES})
+target_link_libraries(indi_platypus_focus ${INDI_LIBRARIES})
 
-install(TARGETS indi_armadillo_focus RUNTIME DESTINATION bin )
-install(TARGETS indi_platypus_focus RUNTIME DESTINATION bin )
+install(TARGETS indi_armadillo_focus RUNTIME DESTINATION bin)
+install(TARGETS indi_platypus_focus RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_lunatico.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_lunatico.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-armadilloplatypus.rules DESTINATION ${RULES_INSTALL_DIR})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-armadilloplatypus.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 endif()

--- a/indi-dsi/CMakeLists.txt
+++ b/indi-dsi/CMakeLists.txt
@@ -1,80 +1,111 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi-dsi CXX C)
+project(indi-dsi CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-option(INDI_INSTALL_FIRMWARE "Install Firmwares" On)
+if(APPLE)
+  option(INDI_INSTALL_FIRMWARE "Install Firmwares" On)
+  set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/dsi")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  option(INDI_INSTALL_FIRMWARE "Install Firmwares" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+  if(NOT FIRMWARE_INSTALL_DIR)
+    set(
+      FIRMWARE_INSTALL_DIR
+      "/usr/lib/firmware"
+      CACHE STRING
+      "Base directory for firmware files"
+    )
+  endif()
+endif()
 
-IF(APPLE)
-set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/dsi")
-ELSE(APPLE)
-set(RULES_INSTALL_DIR "/lib/udev/rules.d")
-set(FIRMWARE_INSTALL_DIR "/lib/firmware")
-ENDIF()
-set (DSI_VERSION_MAJOR 0)
-set (DSI_VERSION_MINOR 4)
+set(DSI_VERSION_MAJOR 0)
+set(DSI_VERSION_MINOR 4)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(USB1 REQUIRED)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_dsi.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_dsi.xml)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_dsi.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_dsi.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIR})
 
 include(CMakeCommon)
 
 # This warning only valid for Clang above version 3.9
-IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.9)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
-ENDIF ()
-
-########### DSI ###########
-set(indidsi_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/dsi_ccd.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiDevice.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiDeviceFactory.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiPro.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiColor.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiProII.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiProIII.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorII.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorIII.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/DsiTypes.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/Util.cpp   
-   )
-
-if (APPLE)
-    set(indidsi_SRCS
-        ${indidsi_SRCS}
-        ${CMAKE_CURRENT_SOURCE_DIR}/download_fx2.cpp)
+if(
+  "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.9
+)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
 endif()
 
-IF (UNITY_BUILD)
-    ENABLE_UNITY_BUILD(indidsi indidsi_SRCS 10 cpp)
-ENDIF ()
+########### DSI ###########
+set(
+  indidsi_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/dsi_ccd.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiDevice.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiDeviceFactory.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiPro.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiColor.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiProII.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiProIII.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorII.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorIII.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/DsiTypes.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/Util.cpp
+)
+
+if(APPLE)
+  set(indidsi_SRCS ${indidsi_SRCS} ${CMAKE_CURRENT_SOURCE_DIR}/download_fx2.cpp)
+endif()
+
+if(UNITY_BUILD)
+  enable_unity_build(indidsi indidsi_SRCS 10 cpp)
+endif()
 
 add_executable(indi_dsi_ccd ${indidsi_SRCS})
 
-target_link_libraries(indi_dsi_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${USB1_LIBRARIES} )
+target_link_libraries(
+  indi_dsi_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${USB1_LIBRARIES}
+)
 
-install(TARGETS indi_dsi_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_dsi_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_dsi.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_dsi.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-meadedsi.rules DESTINATION ${RULES_INSTALL_DIR})
-ENDIF()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-meadedsi.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+endif()
 
-IF (INDI_INSTALL_FIRMWARE)
-    install(FILES meade-deepskyimager.hex DESTINATION ${FIRMWARE_INSTALL_DIR})
-ENDIF ()
+if(INDI_INSTALL_FIRMWARE)
+  install(FILES meade-deepskyimager.hex DESTINATION ${FIRMWARE_INSTALL_DIR})
+endif()

--- a/indi-ffmv/CMakeLists.txt
+++ b/indi-ffmv/CMakeLists.txt
@@ -1,50 +1,67 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi-ffmv CXX C)
+project(indi-ffmv CXX C)
 
 set(CMAKE_CXX_FLAGS "-std=c++0x ${CMAKE_CXX_FLAGS}")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-
-IF(NOT APPLE)
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-ENDIF(NOT APPLE)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(DC1394 REQUIRED)
 
-set (FFMV_VERSION_MAJOR 0)
-set (FFMV_VERSION_MINOR 3)
+set(FFMV_VERSION_MAJOR 0)
+set(FFMV_VERSION_MINOR 3)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_ffmv.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_ffmv.xml )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_ffmv.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_ffmv.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${DC1394_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${DC1394_INCLUDE_DIR})
 
 include(CMakeCommon)
 
 ########### QSI ###########
-set(indiffmv_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/ffmv_ccd.cpp
-   )
+set(indiffmv_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/ffmv_ccd.cpp)
 
 add_executable(indi_ffmv_ccd ${indiffmv_SRCS})
 
-target_link_libraries(indi_ffmv_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${DC1394_LIBRARIES} )
+target_link_libraries(
+  indi_ffmv_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${DC1394_LIBRARIES}
+)
 
-install(TARGETS indi_ffmv_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_ffmv_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_ffmv.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_ffmv.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-IF(NOT APPLE AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-fireflymv.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-ENDIF(NOT APPLE AND INDI_INSTALL_UDEV_RULES)
-
+if(NOT APPLE AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-fireflymv.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+endif(NOT APPLE AND INDI_INSTALL_UDEV_RULES)

--- a/indi-gphoto/CMakeLists.txt
+++ b/indi-gphoto/CMakeLists.txt
@@ -1,21 +1,30 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_gphoto C CXX)
+project(indi_gphoto C CXX)
 
 set(INDI_GPHOTO_VERSION_MAJOR 3)
 set(INDI_GPHOTO_VERSION_MINOR 4)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-SET(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" )
-SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG_FITS" )
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall" )
-SET(CMAKE_C_FLAGS_DEBUG "-O0 -g -DDEBUG_FITS" )
+set(BIN_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/bin")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG_FITS")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g -DDEBUG_FITS")
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
@@ -29,32 +38,68 @@ find_package(USB1 REQUIRED)
 include(CMakeCommon)
 include(CheckStructHasMember)
 
-CHECK_STRUCT_HAS_MEMBER("libraw_imgother_t" CameraTemperature "libraw/libraw_types.h" HAVE_LIBRAW_CAMERA_TEMPERATURE LANGUAGE C)
-if (HAVE_LIBRAW_CAMERA_TEMPERATURE)
+check_struct_has_member(
+  "libraw_imgother_t"
+  CameraTemperature
+  "libraw/libraw_types.h"
+  HAVE_LIBRAW_CAMERA_TEMPERATURE
+  LANGUAGE C
+)
+if(HAVE_LIBRAW_CAMERA_TEMPERATURE)
   set(LIBRAW_CAMERA_TEMPERATURE 1)
   message(STATUS "Found CameraTemperature in 'libraw/libraw_types.h'")
-endif ()
+endif()
 
-CHECK_STRUCT_HAS_MEMBER("libraw_imgother_t" SensorTemperature "libraw/libraw_types.h" HAVE_LIBRAW_SENSOR_TEMPERATURE LANGUAGE C)
-if (HAVE_LIBRAW_SENSOR_TEMPERATURE)
+check_struct_has_member(
+  "libraw_imgother_t"
+  SensorTemperature
+  "libraw/libraw_types.h"
+  HAVE_LIBRAW_SENSOR_TEMPERATURE
+  LANGUAGE C
+)
+if(HAVE_LIBRAW_SENSOR_TEMPERATURE)
   set(LIBRAW_SENSOR_TEMPERATURE 1)
   message(STATUS "Found SensorTemperature in 'libraw/libraw_types.h'")
-endif ()
+endif()
 
-CHECK_STRUCT_HAS_MEMBER("libraw_metadata_common_t" CameraTemperature "libraw/libraw_types.h" HAVE_LIBRAW_CAMERA_TEMPERATURE2 LANGUAGE C)
-if (HAVE_LIBRAW_CAMERA_TEMPERATURE2)
+check_struct_has_member(
+  "libraw_metadata_common_t"
+  CameraTemperature
+  "libraw/libraw_types.h"
+  HAVE_LIBRAW_CAMERA_TEMPERATURE2
+  LANGUAGE C
+)
+if(HAVE_LIBRAW_CAMERA_TEMPERATURE2)
   set(LIBRAW_CAMERA_TEMPERATURE2 1)
-  message(STATUS "Found CameraTemperature in libraw_metadata_common_t 'libraw/libraw_types.h'")
-endif ()
+  message(
+    STATUS
+    "Found CameraTemperature in libraw_metadata_common_t 'libraw/libraw_types.h'"
+  )
+endif()
 
-CHECK_STRUCT_HAS_MEMBER("libraw_metadata_common_t" SensorTemperature "libraw/libraw_types.h" HAVE_LIBRAW_SENSOR_TEMPERATURE2 LANGUAGE C)
-if (HAVE_LIBRAW_SENSOR_TEMPERATURE2)
+check_struct_has_member(
+  "libraw_metadata_common_t"
+  SensorTemperature
+  "libraw/libraw_types.h"
+  HAVE_LIBRAW_SENSOR_TEMPERATURE2
+  LANGUAGE C
+)
+if(HAVE_LIBRAW_SENSOR_TEMPERATURE2)
   set(LIBRAW_SENSOR_TEMPERATURE2 1)
-  message(STATUS "Found SensorTemperature in libraw_metadata_common_t 'libraw/libraw_types.h'")
-endif ()
+  message(
+    STATUS
+    "Found SensorTemperature in libraw_metadata_common_t 'libraw/libraw_types.h'"
+  )
+endif()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_gphoto.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_gphoto.xml )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_gphoto.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_gphoto.xml
+)
 
 #find_program(DCRAW_EXECUTABLE NAMES dcraw
 #    PATHS
@@ -65,64 +110,93 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_gphoto.xml.cmake ${CMAKE_CURRENT
 #    message(FATAL_ERROR "dcraw not found. Please install dcraw and try again.")
 #endif (NOT DCRAW_EXECUTABLE)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${GPHOTO2_INCLUDE_DIR})
-include_directories( ${LibRaw_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${GPHOTO2_INCLUDE_DIR})
+include_directories(${LibRaw_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIRS})
 
 ########### Gphoto ###########
-set(indigphoto_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_ccd.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_driver.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_readimage.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/dsusbdriver.cpp
-   )
+set(
+  indigphoto_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_ccd.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_driver.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_readimage.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dsusbdriver.cpp
+)
 
-IF (UNITY_BUILD)
-    ENABLE_UNITY_BUILD(indigphoto indi_gphotoSRCS 10 cpp)
-ENDIF ()
+if(UNITY_BUILD)
+  enable_unity_build(indigphoto indi_gphotoSRCS 10 cpp)
+endif()
 
-SET_SOURCE_FILES_PROPERTIES(gphoto_readimage.cpp PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")
+set_source_files_properties(
+  gphoto_readimage.cpp
+  PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations"
+)
 
 add_executable(indi_gphoto_ccd ${indigphoto_SRCS})
 
-target_link_libraries(indi_gphoto_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${GPHOTO2_LIBRARY} ${GPHOTO2_PORT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${JPEG_LIBRARIES} ${LibRaw_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(
+  indi_gphoto_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${GPHOTO2_LIBRARY}
+  ${GPHOTO2_PORT_LIBRARY}
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${JPEG_LIBRARIES}
+  ${LibRaw_LIBRARIES}
+  ${ZLIB_LIBRARIES}
+)
 
-install(TARGETS indi_gphoto_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_gphoto_ccd RUNTIME DESTINATION bin)
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_gphoto_symlink.cmake
-"exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_canon_ccd)\n
+file(
+  WRITE
+  ${CMAKE_CURRENT_BINARY_DIR}/make_gphoto_symlink.cmake
+  "exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_canon_ccd)\n
 exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_nikon_ccd)\n
 exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_pentax_ccd)\n
 exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_sony_ccd)\n
-exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_fuji_ccd)\n")
-set_target_properties(indi_gphoto_ccd PROPERTIES POST_INSTALL_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/make_gphoto_symlink.cmake)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_gphoto.xml DESTINATION ${INDI_DATA_DIR})
-
-# Build the camera test application
-add_executable(gphoto_camera_test
-    ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_camera_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_driver.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/dsusbdriver.cpp
+exec_program(\"${CMAKE_COMMAND}\" ARGS -E create_symlink indi_gphoto_ccd \$ENV{DESTDIR}${BIN_INSTALL_DIR}/indi_fuji_ccd)\n"
+)
+set_target_properties(
+  indi_gphoto_ccd
+  PROPERTIES
+    POST_INSTALL_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/make_gphoto_symlink.cmake
 )
 
-target_link_libraries(gphoto_camera_test
-    ${GPHOTO2_LIBRARY}
-    ${GPHOTO2_PORT_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${INDI_LIBRARIES}
-    ${JPEG_LIBRARIES}
-    ${LibRaw_LIBRARIES}
-    ${ZLIB_LIBRARIES}
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_gphoto.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
+
+# Build the camera test application
+add_executable(
+  gphoto_camera_test
+  ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_camera_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/gphoto_driver.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/dsusbdriver.cpp
+)
+
+target_link_libraries(
+  gphoto_camera_test
+  ${GPHOTO2_LIBRARY}
+  ${GPHOTO2_PORT_LIBRARY}
+  ${CMAKE_THREAD_LIBS_INIT}
+  ${INDI_LIBRARIES}
+  ${JPEG_LIBRARIES}
+  ${LibRaw_LIBRARIES}
+  ${ZLIB_LIBRARIES}
 )
 
 install(TARGETS gphoto_camera_test DESTINATION bin)
 
 # Disable automount for DSLR cameras
-IF (UNIX AND NOT APPLE AND INDI_INSTALL_UDEV_RULES)
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/85-disable-dslr-automout.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-ENDIF ()
+if(UNIX AND NOT APPLE AND INDI_INSTALL_UDEV_RULES)
+  install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/85-disable-dslr-automout.rules
+    DESTINATION ${UDEVRULES_INSTALL_DIR}
+  )
+endif()

--- a/indi-nightscape/CMakeLists.txt
+++ b/indi-nightscape/CMakeLists.txt
@@ -1,106 +1,153 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_nightscape CXX C)
+project(indi_nightscape CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
 find_package(Threads REQUIRED)
-FIND_PACKAGE(D2XX)
-FIND_PACKAGE(USB1 REQUIRED)
-FIND_PACKAGE(FTDI1 REQUIRED)
+find_package(D2XX)
+find_package(USB1 REQUIRED)
+find_package(FTDI1 REQUIRED)
 
-IF (D2XX_FOUND)
-set(HAVE_D2XX 1)
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_D2XX")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_D2XX")
+if(D2XX_FOUND)
+  set(HAVE_D2XX 1)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_D2XX")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_D2XX")
+endif()
 
-ENDIF()
-
-IF (APPLE)
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DARWIN_C_SOURCE")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_DARWIN_C_SOURCE")
-ENDIF()
-
+if(APPLE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DARWIN_C_SOURCE")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_DARWIN_C_SOURCE")
+endif()
 
 set(INDI_NIGHTSCAPE_VERSION_MAJOR 1)
 set(INDI_NIGHTSCAPE_VERSION_MINOR 0)
 
 #set (HAVE_SERIAL 1)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_nightscape.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_nightscape.xml )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_nightscape.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_nightscape.xml
+)
 
-
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIRS})
-include_directories( ${FTDI1_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIRS})
+include_directories(${FTDI1_INCLUDE_DIRS})
 
 include(CMakeCommon)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-error")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-error")
+set(
+  indinightscape_CORE
+  ${CMAKE_CURRENT_SOURCE_DIR}/nschannel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-u.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/nsmsg.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/nsdownload.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/nsstatus.cpp
+)
 
-SET(indinightscape_CORE
-        ${CMAKE_CURRENT_SOURCE_DIR}/nschannel.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-u.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/nsmsg.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/nsdownload.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/nsstatus.cpp)
+if(HAVE_D2XX)
+  set(
+    indinightscape_CORE
+    ${indinightscape_CORE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-ftd.cpp
+  )
+endif()
 
-IF(HAVE_D2XX) 
-	SET(indinightscape_CORE
-	     ${indinightscape_CORE}
-       ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-ftd.cpp)
-ENDIF()
+if(HAVE_SERIAL)
+  set(
+    indinightscape_CORE
+    ${indinightscape_CORE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-ser.cpp
+  )
 
-IF(HAVE_SERIAL)
-	SET(indinightscape_CORE
-	     ${indinightscape_CORE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/nschannel-ser.cpp)
-  
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_SERIAL")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_SERIAL")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_SERIAL")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_SERIAL")
+endif()
 
-ENDIF()
+set(
+  indinightscape_SRCS
+  ${indinightscape_CORE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/nightscape.cpp
+)
 
-SET(indinightscape_SRCS
-        ${indinightscape_CORE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/nightscape.cpp)
-
-SET(nstest_SRCS
-        ${indinightscape_CORE}
-        ${CMAKE_CURRENT_SOURCE_DIR}/nstest-main.cpp)
-
+set(
+  nstest_SRCS
+  ${indinightscape_CORE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/nstest-main.cpp
+)
 
 add_executable(indi_nightscape_ccd ${indinightscape_SRCS})
 
 add_executable(nstest ${nstest_SRCS})
 
-IF(HAVE_D2XX)
-	target_link_libraries(indi_nightscape_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${D2XX_LIBRARIES} ${FTDI1_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(HAVE_D2XX)
+  target_link_libraries(
+    indi_nightscape_ccd
+    ${INDI_LIBRARIES}
+    ${CFITSIO_LIBRARIES}
+    ${D2XX_LIBRARIES}
+    ${FTDI1_LIBRARIES}
+    ${USB1_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
 
-	target_link_libraries(nstest ${D2XX_LIBRARIES} ${FTDI1_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-ELSE()
-	target_link_libraries(indi_nightscape_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${FTDI1_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(
+    nstest
+    ${D2XX_LIBRARIES}
+    ${FTDI1_LIBRARIES}
+    ${USB1_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+else()
+  target_link_libraries(
+    indi_nightscape_ccd
+    ${INDI_LIBRARIES}
+    ${CFITSIO_LIBRARIES}
+    ${FTDI1_LIBRARIES}
+    ${USB1_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
 
-	target_link_libraries(nstest ${FTDI1_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-ENDIF()
+  target_link_libraries(
+    nstest
+    ${FTDI1_LIBRARIES}
+    ${USB1_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+endif()
 
-install(TARGETS indi_nightscape_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_nightscape_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_nightscape.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_nightscape.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-        if (INDI_INSTALL_UDEV_RULES)
-                install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-nightscape.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-        endif ()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-nightscape.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
 endif()

--- a/indi-orion-ssg3/CMakeLists.txt
+++ b/indi-orion-ssg3/CMakeLists.txt
@@ -1,59 +1,82 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi-orion_ssg3 CXX C)
+project(indi-orion_ssg3 CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-IF(APPLE)
-ELSE(APPLE)
-set(RULES_INSTALL_DIR "/lib/udev/rules.d")
-ENDIF()
-set (ORION_SSG3_VERSION_MAJOR 0)
-set (ORION_SSG3_VERSION_MINOR 1)
+set(ORION_SSG3_VERSION_MAJOR 0)
+set(ORION_SSG3_VERSION_MINOR 1)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(USB1 REQUIRED)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_orion_ssg3.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_orion_ssg3.xml)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_orion_ssg3.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_orion_ssg3.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIR})
 
 include(CMakeCommon)
 
 # This warning only valid for Clang above version 3.9
-IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.9)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
-ENDIF ()
+if(
+  "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.8.9
+)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
+endif()
 
 ########### DSI ###########
-set(indiorionssg3_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/orion_ssg3.c
-   ${CMAKE_CURRENT_SOURCE_DIR}/orion_ssg3_ccd.cpp
-   )
+set(
+  indiorionssg3_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/orion_ssg3.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/orion_ssg3_ccd.cpp
+)
 
-IF (UNITY_BUILD)
-    ENABLE_UNITY_BUILD(indiorionssg3 indiorionssg3_SRCS 10 cpp)
-ENDIF ()
+if(UNITY_BUILD)
+  enable_unity_build(indiorionssg3 indiorionssg3_SRCS 10 cpp)
+endif()
 
 add_executable(indi_orion_ssg3_ccd ${indiorionssg3_SRCS})
 
-target_link_libraries(indi_orion_ssg3_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${USB1_LIBRARIES} )
+target_link_libraries(
+  indi_orion_ssg3_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${USB1_LIBRARIES}
+)
 
-install(TARGETS indi_orion_ssg3_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_orion_ssg3_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_orion_ssg3.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_orion_ssg3.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-orionssg3.rules DESTINATION ${RULES_INSTALL_DIR})
-ENDIF()
-
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-orionssg3.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+endif()

--- a/indi-qsi/CMakeLists.txt
+++ b/indi-qsi/CMakeLists.txt
@@ -1,46 +1,66 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_qsi CXX C)
+project(indi_qsi CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-
-SET(RULES_INSTALL_DIR "/lib/udev/rules.d/")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
 find_package(QSI REQUIRED)
 find_package(ZLIB REQUIRED)
 
-set (QSI_VERSION_MAJOR 0)
-set (QSI_VERSION_MINOR 9)
+set(QSI_VERSION_MAJOR 0)
+set(QSI_VERSION_MINOR 9)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_qsi.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_qsi.xml )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_qsi.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_qsi.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${QSI_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${QSI_INCLUDE_DIR})
 
 include(CMakeCommon)
 
 ########### QSI ###########
-set(indiqsi_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/qsi_ccd.cpp
-   )
+set(indiqsi_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/qsi_ccd.cpp)
 
 add_executable(indi_qsi_ccd ${indiqsi_SRCS})
 
-target_link_libraries(indi_qsi_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${QSI_LIBRARIES})
+target_link_libraries(
+  indi_qsi_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${QSI_LIBRARIES}
+)
 
-install(TARGETS indi_qsi_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_qsi_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_qsi.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_qsi.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-qsi.rules DESTINATION ${RULES_INSTALL_DIR})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-qsi.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 endif()

--- a/indi-sx/CMakeLists.txt
+++ b/indi-sx/CMakeLists.txt
@@ -1,21 +1,33 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_sx CXX C)
+project(indi_sx CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
-set(RULES_INSTALL_DIR "/lib/udev/rules.d/")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-set (VERSION_MAJOR 1)
-set (VERSION_MINOR 15)
+set(VERSION_MAJOR 1)
+set(VERSION_MINOR 15)
 
-configure_file (
+configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/sxconfig.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/sxconfig.h"
-  )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_sx.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_sx.xml )
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_sx.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_sx.xml
+)
 
 find_package(CFITSIO REQUIRED)
 find_package(USB1 REQUIRED)
@@ -25,17 +37,21 @@ find_package(Threads REQUIRED)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIR})
 
 include(CMakeCommon)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-usb.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-usb.h)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config-usb.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config-usb.h
+)
 
-set(indisxccd_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/sxccd.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/sxccdusb.cpp
-   )
+set(
+  indisxccd_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/sxccd.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sxccdusb.cpp
+)
 
 add_executable(indi_sx_ccd ${indisxccd_SRCS})
 target_link_libraries(indi_sx_ccd ${INDI_LIBRARIES} ${USB1_LIBRARIES})
@@ -60,29 +76,36 @@ target_link_libraries(indi_sx_ccd ${INDI_LIBRARIES} ${USB1_LIBRARIES})
 
 #add_executable(indi_sx_wheel ${indisxwheel_SRCS})
 add_executable(indi_sx_wheel ${CMAKE_CURRENT_SOURCE_DIR}/sxwheel.cpp)
-IF (APPLE)
-set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(indi_sx_wheel ${INDI_LIBRARIES} ${LIBUSB_LIBRARIES})
-ELSEIF (WIN32)
-ELSE ()
-target_link_libraries(indi_sx_wheel ${INDI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-ENDIF()
+if(APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
+  target_link_libraries(indi_sx_wheel ${INDI_LIBRARIES} ${LIBUSB_LIBRARIES})
+elseif(WIN32)
+else()
+  target_link_libraries(
+    indi_sx_wheel
+    ${INDI_LIBRARIES}
+    ${USB1_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
+endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-target_link_libraries(indi_sx_wheel rt)
-endif (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+  target_link_libraries(indi_sx_wheel rt)
+endif(
+  CMAKE_SYSTEM_NAME MATCHES "Linux"
+  AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*"
+)
 
-set(indisxao_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/sxao.cpp
-   )
+set(indisxao_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/sxao.cpp)
 
 add_executable(indi_sx_ao ${indisxao_SRCS})
 target_link_libraries(indi_sx_ao ${INDI_LIBRARIES})
 
-set(sx_ccd_test_SRCS
-   ${CMAKE_CURRENT_SOURCE_DIR}/sxccdtest.cpp
-   ${CMAKE_CURRENT_SOURCE_DIR}/sxccdusb.cpp
-   )
+set(
+  sx_ccd_test_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/sxccdtest.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sxccdusb.cpp
+)
 
 add_executable(sx_ccd_test ${sx_ccd_test_SRCS})
 target_link_libraries(sx_ccd_test ${USB1_LIBRARIES})
@@ -91,49 +114,71 @@ install(TARGETS indi_sx_ccd RUNTIME DESTINATION bin)
 install(TARGETS indi_sx_wheel RUNTIME DESTINATION bin)
 install(TARGETS indi_sx_ao RUNTIME DESTINATION bin)
 install(TARGETS sx_ccd_test RUNTIME DESTINATION bin)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_sx.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_sx.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
 
-set (CPACK_PACKAGE_NAME "sxccd")
-set (CPACK_PACKAGE_VENDOR "CloudMakers, s. r. o.")
-set (CPACK_PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
-set (CPACK_PACKAGE_CONTACT "Peter Polakovic <peter.polakovic@cloudmakers.eu>")
-set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "INDI Driver for SX CCD, FW wheel and AO")
-set (CPACK_PACKAGE_DESCRIPTION "This driver for INDI 0.9.7 supports SXVF-xxx, SXVR-xxx, LodeStar, CoStar and SuperStar cameras with full cooler and guider port control, USB Filter Wheel and Active Optics device.")
+set(CPACK_PACKAGE_NAME "sxccd")
+set(CPACK_PACKAGE_VENDOR "CloudMakers, s. r. o.")
+set(CPACK_PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+set(CPACK_PACKAGE_CONTACT "Peter Polakovic <peter.polakovic@cloudmakers.eu>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "INDI Driver for SX CCD, FW wheel and AO")
+set(
+  CPACK_PACKAGE_DESCRIPTION
+  "This driver for INDI 0.9.7 supports SXVF-xxx, SXVR-xxx, LodeStar, CoStar and SuperStar cameras with full cooler and guider port control, USB Filter Wheel and Active Optics device."
+)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  file (WRITE "README.txt" "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}\nVersion ${CPACK_PACKAGE_VERSION}\n\n${CPACK_PACKAGE_DESCRIPTION}\n\nVisit http://www.cloudmakers.eu/indi to learn more.")
-  set (CPACK_GENERATOR "PackageMaker")
-  set (CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYRIGHT.txt")
-  set (CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.txt")
-  set (CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
-  set (CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
-elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  IF (INDI_INSTALL_UDEV_RULES)
-    install(FILES 99-sx.rules DESTINATION ${RULES_INSTALL_DIR})
-  ENDIF()
-  set (CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}\n  ${CPACK_PACKAGE_DESCRIPTION}")
-  set (CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION})
-  set (CPACK_GENERATOR "DEB;RPM")
-  set (CPACK_DEBIAN_PACKAGE_DEPENDS "indi-bin (>= 0.9.7)")
-  set (CPACK_DEBIAN_PACKAGE_SECTION "Science")
-  set (CPACK_RPM_PACKAGE_DEPENDS "indi-bin >= 0.9.7")
-  set (CPACK_RPM_PACKAGE_GROUP "Applications/Science")
-  set (CPACK_PACKAGING_INSTALL_PREFIX "/usr")
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
-    set (CPACK_GENERATOR "DEB")
-    set (CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
-    set (CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    set (CPACK_GENERATOR "DEB;RPM")
-    set (CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
-    set (CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
-    set (CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
-    set (CPACK_GENERATOR "DEB;RPM")
-    set (CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
-    set (CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
-    set (CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
-  endif ()
-endif ()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  file(
+    WRITE
+    "README.txt"
+    "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}\nVersion ${CPACK_PACKAGE_VERSION}\n\n${CPACK_PACKAGE_DESCRIPTION}\n\nVisit http://www.cloudmakers.eu/indi to learn more."
+  )
+  set(CPACK_GENERATOR "PackageMaker")
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYRIGHT.txt")
+  set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.txt")
+  set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-sx.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+  set(
+    CPACK_DEBIAN_PACKAGE_DESCRIPTION
+    "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}\n  ${CPACK_PACKAGE_DESCRIPTION}"
+  )
+  set(CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION})
+  set(CPACK_GENERATOR "DEB;RPM")
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "indi-bin (>= 0.9.7)")
+  set(CPACK_DEBIAN_PACKAGE_SECTION "Science")
+  set(CPACK_RPM_PACKAGE_DEPENDS "indi-bin >= 0.9.7")
+  set(CPACK_RPM_PACKAGE_GROUP "Applications/Science")
+  set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
+    set(CPACK_GENERATOR "DEB")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
+    set(
+      CPACK_PACKAGE_FILE_NAME
+      "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    set(CPACK_GENERATOR "DEB;RPM")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+    set(
+      CPACK_PACKAGE_FILE_NAME
+      "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
+    set(CPACK_GENERATOR "DEB;RPM")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")
+    set(CPACK_RPM_PACKAGE_ARCHITECTURE "i386")
+    set(
+      CPACK_PACKAGE_FILE_NAME
+      "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}"
+    )
+  endif()
+endif()
 
-include (CPack)
+include(CPack)

--- a/indi-toupbase/CMakeLists.txt
+++ b/indi-toupbase/CMakeLists.txt
@@ -1,11 +1,21 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_toupbase CXX C)
+project(indi_toupbase CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
@@ -26,197 +36,501 @@ find_package(SVBONYCAM REQUIRED)
 set(TOUPBASE_VERSION_MAJOR 2)
 set(TOUPBASE_VERSION_MINOR 3)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_toupbase.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_toupbase.xml)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_toupbase.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_toupbase.xml
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
-include_directories( ${TOUPCAM_INCLUDE_DIR})
-include_directories( ${ALTAIRCAM_INCLUDE_DIR})
-include_directories( ${STARSHOOTG_INCLUDE_DIR})
-include_directories( ${NNCAM_INCLUDE_DIR})
-include_directories( ${MALLINCAM_INCLUDE_DIR})
-include_directories( ${MEADECAM_INCLUDE_DIR})
-include_directories( ${OMEGONPROCAM_INCLUDE_DIR})
-include_directories( ${BRESSERCAM_INCLUDE_DIR})
-include_directories( ${OGMACAM_INCLUDE_DIR})
-include_directories( ${TSCAM_INCLUDE_DIR})
-include_directories( ${SVBONYCAM_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
+include_directories(${TOUPCAM_INCLUDE_DIR})
+include_directories(${ALTAIRCAM_INCLUDE_DIR})
+include_directories(${STARSHOOTG_INCLUDE_DIR})
+include_directories(${NNCAM_INCLUDE_DIR})
+include_directories(${MALLINCAM_INCLUDE_DIR})
+include_directories(${MEADECAM_INCLUDE_DIR})
+include_directories(${OMEGONPROCAM_INCLUDE_DIR})
+include_directories(${BRESSERCAM_INCLUDE_DIR})
+include_directories(${OGMACAM_INCLUDE_DIR})
+include_directories(${TSCAM_INCLUDE_DIR})
+include_directories(${SVBONYCAM_INCLUDE_DIR})
 
 include(CMakeCommon)
 
-set(indi_toupbase_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/indi_toupbase.cpp ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp)
-set(indi_wheel_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/indi_toupwheel.cpp ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp)
-set(indi_focuser_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/indi_focuser.cpp ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp)
+set(
+  indi_toupbase_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_toupbase.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp
+)
+set(
+  indi_wheel_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_toupwheel.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp
+)
+set(
+  indi_focuser_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_focuser.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/libtoupbase.cpp
+)
 
 ########### indi_toupcam_* ###########
 add_executable(indi_toupcam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_toupcam_ccd PRIVATE "-DBUILD_TOUPCAM")
-target_link_libraries(indi_toupcam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TOUPCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_toupcam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TOUPCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_toupcam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_toupcam_wheel PRIVATE "-DBUILD_TOUPCAM")
-target_link_libraries(indi_toupcam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TOUPCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_toupcam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TOUPCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_toupcam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_toupcam_focuser PRIVATE "-DBUILD_TOUPCAM")
-target_link_libraries(indi_toupcam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TOUPCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_toupcam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TOUPCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 add_executable(toupcam_test toupcam_test.cpp)
-target_link_libraries(toupcam_test ${TOUPCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  toupcam_test
+  ${TOUPCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_altair_* ###########
 add_executable(indi_altair_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_altair_ccd PRIVATE "-DBUILD_ALTAIRCAM")
-target_link_libraries(indi_altair_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${ALTAIRCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_altair_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${ALTAIRCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_altair_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_altair_wheel PRIVATE "-DBUILD_ALTAIRCAM")
-target_link_libraries(indi_altair_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${ALTAIRCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_altair_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${ALTAIRCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_altair_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_altair_focuser PRIVATE "-DBUILD_ALTAIRCAM")
-target_link_libraries(indi_altair_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${ALTAIRCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_altair_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${ALTAIRCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_bressercam_* ###########
 add_executable(indi_bressercam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_bressercam_ccd PRIVATE "-DBUILD_BRESSERCAM")
-target_link_libraries(indi_bressercam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${BRESSERCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_bressercam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${BRESSERCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_bressercam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_bressercam_wheel PRIVATE "-DBUILD_BRESSERCAM")
-target_link_libraries(indi_bressercam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${BRESSERCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_bressercam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${BRESSERCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_bressercam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_bressercam_focuser PRIVATE "-DBUILD_BRESSERCAM")
-target_link_libraries(indi_bressercam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${BRESSERCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_bressercam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${BRESSERCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_mallincam_* ###########
 add_executable(indi_mallincam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_mallincam_ccd PRIVATE "-DBUILD_MALLINCAM")
-target_link_libraries(indi_mallincam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MALLINCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_mallincam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MALLINCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_mallincam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_mallincam_wheel PRIVATE "-DBUILD_MALLINCAM")
-target_link_libraries(indi_mallincam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MALLINCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_mallincam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MALLINCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_mallincam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_mallincam_focuser PRIVATE "-DBUILD_MALLINCAM")
-target_link_libraries(indi_mallincam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MALLINCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_mallincam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MALLINCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_nncam_* ###########
 add_executable(indi_nncam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_nncam_ccd PRIVATE "-DBUILD_NNCAM")
-target_link_libraries(indi_nncam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${NNCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_nncam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${NNCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_nncam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_nncam_wheel PRIVATE "-DBUILD_NNCAM")
-target_link_libraries(indi_nncam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${NNCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_nncam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${NNCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_nncam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_nncam_focuser PRIVATE "-DBUILD_NNCAM")
-target_link_libraries(indi_nncam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${NNCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_nncam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${NNCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_ogmacam_* ###########
 add_executable(indi_ogmacam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_ogmacam_ccd PRIVATE "-DBUILD_OGMACAM")
-target_link_libraries(indi_ogmacam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OGMACAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_ogmacam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OGMACAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_ogmacam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_ogmacam_wheel PRIVATE "-DBUILD_OGMACAM")
-target_link_libraries(indi_ogmacam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OGMACAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_ogmacam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OGMACAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_ogmacam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_ogmacam_focuser PRIVATE "-DBUILD_OGMACAM")
-target_link_libraries(indi_ogmacam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OGMACAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_ogmacam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OGMACAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_omegonprocam_* ###########
 add_executable(indi_omegonprocam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_omegonprocam_ccd PRIVATE "-DBUILD_OMEGONPROCAM")
-target_link_libraries(indi_omegonprocam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OMEGONPROCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_omegonprocam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OMEGONPROCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_omegonprocam_wheel ${indi_wheel_SRCS})
-target_compile_definitions(indi_omegonprocam_wheel PRIVATE "-DBUILD_OMEGONPROCAM")
-target_link_libraries(indi_omegonprocam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OMEGONPROCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_compile_definitions(
+  indi_omegonprocam_wheel
+  PRIVATE "-DBUILD_OMEGONPROCAM"
+)
+target_link_libraries(
+  indi_omegonprocam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OMEGONPROCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_omegonprocam_focuser ${indi_focuser_SRCS})
-target_compile_definitions(indi_omegonprocam_focuser PRIVATE "-DBUILD_OMEGONPROCAM")
-target_link_libraries(indi_omegonprocam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${OMEGONPROCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_compile_definitions(
+  indi_omegonprocam_focuser
+  PRIVATE "-DBUILD_OMEGONPROCAM"
+)
+target_link_libraries(
+  indi_omegonprocam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${OMEGONPROCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 add_executable(omegonprocam_test omegonprocam_test.cpp)
-target_link_libraries(omegonprocam_test ${OMEGONPROCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  omegonprocam_test
+  ${OMEGONPROCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_starshootg_* ###########
 add_executable(indi_starshootg_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_starshootg_ccd PRIVATE "-DBUILD_STARSHOOTG")
-target_link_libraries(indi_starshootg_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${STARSHOOTG_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_starshootg_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${STARSHOOTG_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_starshootg_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_starshootg_wheel PRIVATE "-DBUILD_STARSHOOTG")
-target_link_libraries(indi_starshootg_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${STARSHOOTG_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_starshootg_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${STARSHOOTG_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_starshootg_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_starshootg_focuser PRIVATE "-DBUILD_STARSHOOTG")
-target_link_libraries(indi_starshootg_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${STARSHOOTG_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_starshootg_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${STARSHOOTG_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_tscam_* ###########
 add_executable(indi_tscam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_tscam_ccd PRIVATE "-DBUILD_TSCAM")
-target_link_libraries(indi_tscam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TSCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_tscam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TSCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_tscam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_tscam_wheel PRIVATE "-DBUILD_TSCAM")
-target_link_libraries(indi_tscam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TSCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_tscam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TSCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_tscam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_tscam_focuser PRIVATE "-DBUILD_TSCAM")
-target_link_libraries(indi_tscam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${TSCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_tscam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${TSCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_svbonycam_* ###########
 add_executable(indi_svbonycam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_svbonycam_ccd PRIVATE "-DBUILD_SVBONYCAM")
-target_link_libraries(indi_svbonycam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${SVBONYCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_svbonycam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${SVBONYCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_svbonycam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_svbonycam_wheel PRIVATE "-DBUILD_SVBONYCAM")
-target_link_libraries(indi_svbonycam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${SVBONYCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_svbonycam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${SVBONYCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_svbonycam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_svbonycam_focuser PRIVATE "-DBUILD_SVBONYCAM")
-target_link_libraries(indi_svbonycam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${SVBONYCAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_svbonycam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${SVBONYCAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 ########### indi_meadecam_* ###########
 add_executable(indi_meadecam_ccd ${indi_toupbase_SRCS})
 target_compile_definitions(indi_meadecam_ccd PRIVATE "-DBUILD_MEADECAM")
-target_link_libraries(indi_meadecam_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MEADECAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_meadecam_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MEADECAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_meadecam_wheel ${indi_wheel_SRCS})
 target_compile_definitions(indi_meadecam_wheel PRIVATE "-DBUILD_MEADECAM")
-target_link_libraries(indi_meadecam_wheel ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MEADECAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_meadecam_wheel
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MEADECAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 add_executable(indi_meadecam_focuser ${indi_focuser_SRCS})
 target_compile_definitions(indi_meadecam_focuser PRIVATE "-DBUILD_MEADECAM")
-target_link_libraries(indi_meadecam_focuser ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${MEADECAM_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_meadecam_focuser
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${MEADECAM_LIBRARIES}
+  ${ZLIB_LIBRARY}
+  ${CMAKE_DL_LIBS}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 #####################################
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-target_link_libraries(indi_toupcam_ccd rt)
-target_link_libraries(indi_altair_ccd rt)
-target_link_libraries(indi_bressercam_ccd rt)
-target_link_libraries(indi_mallincam_ccd rt)
-target_link_libraries(indi_nncam_ccd rt)
-target_link_libraries(indi_ogmacam_ccd rt)
-target_link_libraries(indi_omegonprocam_ccd rt)
-target_link_libraries(indi_starshootg_ccd rt)
-target_link_libraries(indi_tscam_ccd rt)
-target_link_libraries(indi_svbonycam_ccd rt)
-target_link_libraries(indi_meadecam_ccd rt)
-target_link_libraries(indi_toupcam_wheel rt)
-target_link_libraries(indi_altair_wheel rt)
-target_link_libraries(indi_bressercam_wheel rt)
-target_link_libraries(indi_mallincam_wheel rt)
-target_link_libraries(indi_nncam_wheel rt)
-target_link_libraries(indi_ogmacam_wheel rt)
-target_link_libraries(indi_omegonprocam_wheel rt)
-target_link_libraries(indi_starshootg_wheel rt)
-target_link_libraries(indi_tscam_wheel rt)
-target_link_libraries(indi_svbonycam_wheel rt)
-target_link_libraries(indi_meadecam_wheel rt)
-target_link_libraries(indi_toupcam_focuser rt)
-target_link_libraries(indi_altair_focuser rt)
-target_link_libraries(indi_bressercam_focuser rt)
-target_link_libraries(indi_mallincam_focuser rt)
-target_link_libraries(indi_nncam_focuser rt)
-target_link_libraries(indi_ogmacam_focuser rt)
-target_link_libraries(indi_omegonprocam_focuser rt)
-target_link_libraries(indi_starshootg_focuser rt)
-target_link_libraries(indi_tscam_focuser rt)
-target_link_libraries(indi_svbonycam_focuser rt)
-target_link_libraries(indi_meadecam_focuser rt)
-endif (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+  target_link_libraries(indi_toupcam_ccd rt)
+  target_link_libraries(indi_altair_ccd rt)
+  target_link_libraries(indi_bressercam_ccd rt)
+  target_link_libraries(indi_mallincam_ccd rt)
+  target_link_libraries(indi_nncam_ccd rt)
+  target_link_libraries(indi_ogmacam_ccd rt)
+  target_link_libraries(indi_omegonprocam_ccd rt)
+  target_link_libraries(indi_starshootg_ccd rt)
+  target_link_libraries(indi_tscam_ccd rt)
+  target_link_libraries(indi_svbonycam_ccd rt)
+  target_link_libraries(indi_meadecam_ccd rt)
+  target_link_libraries(indi_toupcam_wheel rt)
+  target_link_libraries(indi_altair_wheel rt)
+  target_link_libraries(indi_bressercam_wheel rt)
+  target_link_libraries(indi_mallincam_wheel rt)
+  target_link_libraries(indi_nncam_wheel rt)
+  target_link_libraries(indi_ogmacam_wheel rt)
+  target_link_libraries(indi_omegonprocam_wheel rt)
+  target_link_libraries(indi_starshootg_wheel rt)
+  target_link_libraries(indi_tscam_wheel rt)
+  target_link_libraries(indi_svbonycam_wheel rt)
+  target_link_libraries(indi_meadecam_wheel rt)
+  target_link_libraries(indi_toupcam_focuser rt)
+  target_link_libraries(indi_altair_focuser rt)
+  target_link_libraries(indi_bressercam_focuser rt)
+  target_link_libraries(indi_mallincam_focuser rt)
+  target_link_libraries(indi_nncam_focuser rt)
+  target_link_libraries(indi_ogmacam_focuser rt)
+  target_link_libraries(indi_omegonprocam_focuser rt)
+  target_link_libraries(indi_starshootg_focuser rt)
+  target_link_libraries(indi_tscam_focuser rt)
+  target_link_libraries(indi_svbonycam_focuser rt)
+  target_link_libraries(indi_meadecam_focuser rt)
+endif(
+  CMAKE_SYSTEM_NAME MATCHES "Linux"
+  AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*"
+)
 
-install(TARGETS
+install(
+  TARGETS
     indi_toupcam_ccd
     indi_altair_ccd
     indi_bressercam_ccd
@@ -250,6 +564,10 @@ install(TARGETS
     indi_tscam_focuser
     indi_svbonycam_focuser
     indi_meadecam_focuser
-    RUNTIME DESTINATION bin)
+  RUNTIME DESTINATION bin
+)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_toupbase.xml DESTINATION ${INDI_DATA_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_toupbase.xml
+  DESTINATION ${INDI_DATA_DIR}
+)

--- a/libaltaircam/CMakeLists.txt
+++ b/libaltaircam/CMakeLists.txt
@@ -1,49 +1,69 @@
 cmake_minimum_required(VERSION 3.16)
-project (libaltaircam)
+project(libaltaircam)
 
-set (LIBALTAIRCAM_VERSION "59.29176")
-set (LIBALTAIRCAM_SOVERSION "59")
+set(LIBALTAIRCAM_VERSION "59.29176")
+set(LIBALTAIRCAM_SOVERSION "59")
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-add_library (altaircam SHARED IMPORTED)
+add_library(altaircam SHARED IMPORTED)
 
-set_target_properties (altaircam PROPERTIES VERSION ${LIBALTAIRCAM_VERSION} SOVERSION ${LIBALTAIRCAM_SOVERSION})
+set_target_properties(
+  altaircam
+  PROPERTIES VERSION ${LIBALTAIRCAM_VERSION} SOVERSION ${LIBALTAIRCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET altaircam
+    PROPERTY IMPORTED_LOCATION "mac/libaltaircam.bin"
+  )
 
-  set_property (TARGET altaircam PROPERTY IMPORTED_LOCATION "mac/libaltaircam.bin")
-
-  FIX_MACOS_LIBRARIES("libaltaircam" "mac/libaltaircam.bin" "ALTAIR")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET altaircam PROPERTY IMPORTED_LOCATION "armhf/libaltaircam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET altaircam PROPERTY IMPORTED_LOCATION "arm64/libaltaircam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET altaircam PROPERTY IMPORTED_LOCATION "x64/libaltaircam.bin")
+  fix_macos_libraries("libaltaircam" "mac/libaltaircam.bin" "ALTAIR")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET altaircam
+      PROPERTY IMPORTED_LOCATION "armhf/libaltaircam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET altaircam
+      PROPERTY IMPORTED_LOCATION "arm64/libaltaircam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET altaircam
+      PROPERTY IMPORTED_LOCATION "x64/libaltaircam.bin"
+    )
   else()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  IF (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-altaircam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  ENDIF()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-altaircam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES altaircam.h DESTINATION include/libaltaircam)
+install(FILES altaircam.h DESTINATION include/libaltaircam)
 
 # Install library
-install_imported (TARGETS altaircam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS altaircam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libapogee/CMakeLists.txt
+++ b/libapogee/CMakeLists.txt
@@ -1,52 +1,73 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(libapogee C CXX)
+project(libapogee C CXX)
 
 option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 include(CMakeCommon)
 
 set(APOGEE_VERSION "3.2")
 set(APOGEE_SOVERSION "3")
 
-IF(APPLE)
-set(CONF_DIR "/usr/local/lib/indi/DriverSupport/" CACHE STRING "Base configuration directory")
-ELSE(APPLE)
-set(CONF_DIR "/etc" CACHE STRING "Base configuration directory")
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-ENDIF()
+if(APPLE)
+  set(
+    CONF_DIR
+    "/usr/local/lib/indi/DriverSupport/"
+    CACHE STRING
+    "Base configuration directory"
+  )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+
+  set(CONF_DIR "/etc" CACHE STRING "Base configuration directory")
+endif()
 
 # IMPORTANT: When update libapogee code to upstream. Do not forget to save apgHelper.cpp as the configuration file
 # is hardcoded in the upstream version while it is used from configuration file here.
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
 
 find_package(USB1 REQUIRED)
 find_package(CURL REQUIRED)
 find_package(INDI REQUIRED)
 
-if (CMAKE_VERSION VERSION_LESS 3.12.0)
-set(CURL ${CURL_LIBRARIES})
+if(CMAKE_VERSION VERSION_LESS 3.12.0)
+  set(CURL ${CURL_LIBRARIES})
 else()
-set(CURL CURL::libcurl)
+  set(CURL CURL::libcurl)
 endif()
 
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/linux)
-include_directories( ${CURL_INCLUDE_DIR})
-include_directories( ${USB1_INCLUDE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/linux)
+include_directories(${CURL_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIR})
 
 # This is for craft builds
 include_directories("${CMAKE_INSTALL_PREFIX}/include")
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 
 # Less error prone with libapogee upstream updates since they do not use CMake
-file(GLOB libapogee_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/linux/*.cpp)
+file(
+  GLOB libapogee_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/linux/*.cpp
+)
 
 # Windows file
 list(REMOVE_ITEM libapogee_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/COMHelper.cpp")
@@ -55,21 +76,29 @@ list(REMOVE_ITEM libapogee_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/AspenFx2.cpp")
 
 add_library(apogee SHARED ${libapogee_SRCS})
 
-set_target_properties(apogee PROPERTIES VERSION ${APOGEE_VERSION} SOVERSION ${APOGEE_SOVERSION})
+set_target_properties(
+  apogee
+  PROPERTIES VERSION ${APOGEE_VERSION} SOVERSION ${APOGEE_SOVERSION}
+)
 
 target_link_libraries(apogee ${USB1_LIBRARIES} ${CURL})
 
 install(TARGETS apogee LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 file(GLOB libapogee_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
-install( FILES ${libapogee_HEADERS} DESTINATION include/libapogee COMPONENT Devel)
+install(
+  FILES ${libapogee_HEADERS}
+  DESTINATION include/libapogee
+  COMPONENT Devel
+)
 
 install(
-   CODE "
+  CODE
+    "
    file(GLOB APOGEE_CONF ${CMAKE_CURRENT_SOURCE_DIR}/conf/*) \n
    file(INSTALL DESTINATION ${CONF_DIR}/Apogee/camera TYPE FILE FILES \${APOGEE_CONF})"
- )
+)
 
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES 99-apogee.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-ENDIF()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(FILES 99-apogee.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+endif()

--- a/libasi/CMakeLists.txt
+++ b/libasi/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project (libasi)
+project(libasi)
 
 # Using ASI Camera SDK Version 1.39 updated on 2025-08-26
 # Using ASI EFW SDK Version 1.7 updated on 2021-05-17
@@ -7,98 +7,196 @@ project (libasi)
 # Using ASI EAF SDK Version 1.6 updated on 2023-03-16
 # Using ASI CAA SDK Version 1.0 updated on 2025-01-09
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+set(ASICAM_VERSION "1.39")
+set(ASICAM_SOVERSION "1")
 
-set (ASICAM_VERSION "1.39")
-set (ASICAM_SOVERSION "1")
+set(ASIEFW_VERSION "1.7")
+set(ASIEFW_SOVERSION "1")
 
-set (ASIEFW_VERSION "1.7")
-set (ASIEFW_SOVERSION "1")
+set(ASIST4_VERSION "1.0")
+set(ASIST4_SOVERSION "1")
 
-set (ASIST4_VERSION "1.0")
-set (ASIST4_SOVERSION "1")
+set(ASIEAF_VERSION "1.6")
+set(ASIEAF_SOVERSION "1")
 
-set (ASIEAF_VERSION "1.6")
-set (ASIEAF_SOVERSION "1")
+set(ASICAA_VERSION "1.0")
+set(ASICAA_SOVERSION "1")
 
-set (ASICAA_VERSION "1.0")
-set (ASICAA_SOVERSION "1")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-add_library (ASICamera2  SHARED IMPORTED)
-add_library (EFWFilter   SHARED IMPORTED)
-add_library (USB2ST4Conv SHARED IMPORTED)
-add_library (EAFFocuser  SHARED IMPORTED)
-add_library (CAARotator  SHARED IMPORTED)
+add_library(ASICamera2 SHARED IMPORTED)
+add_library(EFWFilter SHARED IMPORTED)
+add_library(USB2ST4Conv SHARED IMPORTED)
+add_library(EAFFocuser SHARED IMPORTED)
+add_library(CAARotator SHARED IMPORTED)
 
-set_target_properties (ASICamera2  PROPERTIES VERSION ${ASICAM_VERSION} SOVERSION ${ASICAM_SOVERSION})
-set_target_properties (EFWFilter   PROPERTIES VERSION ${ASIEFW_VERSION} SOVERSION ${ASIEFW_SOVERSION})
-set_target_properties (USB2ST4Conv PROPERTIES VERSION ${ASIST4_VERSION} SOVERSION ${ASIST4_SOVERSION})
-set_target_properties (EAFFocuser  PROPERTIES VERSION ${ASIEAF_VERSION} SOVERSION ${ASIEAF_SOVERSION})
-set_target_properties (CAARotator  PROPERTIES VERSION ${ASICAA_VERSION} SOVERSION ${ASICAA_SOVERSION})
+set_target_properties(
+  ASICamera2
+  PROPERTIES VERSION ${ASICAM_VERSION} SOVERSION ${ASICAM_SOVERSION}
+)
+set_target_properties(
+  EFWFilter
+  PROPERTIES VERSION ${ASIEFW_VERSION} SOVERSION ${ASIEFW_SOVERSION}
+)
+set_target_properties(
+  USB2ST4Conv
+  PROPERTIES VERSION ${ASIST4_VERSION} SOVERSION ${ASIST4_SOVERSION}
+)
+set_target_properties(
+  EAFFocuser
+  PROPERTIES VERSION ${ASIEAF_VERSION} SOVERSION ${ASIEAF_SOVERSION}
+)
+set_target_properties(
+  CAARotator
+  PROPERTIES VERSION ${ASICAA_VERSION} SOVERSION ${ASICAA_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET ASICamera2
+    PROPERTY IMPORTED_LOCATION "mac/libASICamera2.bin"
+  )
+  set_property(
+    TARGET EFWFilter
+    PROPERTY IMPORTED_LOCATION "mac/libEFWFilter.bin"
+  )
+  set_property(
+    TARGET USB2ST4Conv
+    PROPERTY IMPORTED_LOCATION "mac/libUSB2ST4Conv.bin"
+  )
+  set_property(
+    TARGET EAFFocuser
+    PROPERTY IMPORTED_LOCATION "mac/libEAFFocuser.bin"
+  )
+  set_property(
+    TARGET CAARotator
+    PROPERTY IMPORTED_LOCATION "mac/libCAARotator.bin"
+  )
 
-  set_property (TARGET ASICamera2  PROPERTY IMPORTED_LOCATION "mac/libASICamera2.bin")
-  set_property (TARGET EFWFilter   PROPERTY IMPORTED_LOCATION "mac/libEFWFilter.bin")
-  set_property (TARGET USB2ST4Conv PROPERTY IMPORTED_LOCATION "mac/libUSB2ST4Conv.bin")
-  set_property (TARGET EAFFocuser  PROPERTY IMPORTED_LOCATION "mac/libEAFFocuser.bin")
-  set_property (TARGET CAARotator  PROPERTY IMPORTED_LOCATION "mac/libCAARotator.bin")
-
-  FIX_MACOS_LIBRARIES("libASICamera2" "mac/libASICamera2.bin" "ASI/ZWO")
-  FIX_MACOS_LIBRARIES("libEFWFilter" "mac/libEFWFilter.bin" "ASI/ZWO")
-  FIX_MACOS_LIBRARIES("libUSB2ST4Conv" "mac/libUSB2ST4Conv.bin" "ASI/ZWO")
-  FIX_MACOS_LIBRARIES("libEAFFocuser" "mac/libEAFFocuser.bin" "ASI/ZWO")
-  FIX_MACOS_LIBRARIES("libCAARotator" "mac/libCAARotator.bin" "ASI/ZWO")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET ASICamera2  PROPERTY IMPORTED_LOCATION "armv6/libASICamera2.bin")
-    set_property (TARGET EFWFilter   PROPERTY IMPORTED_LOCATION "armv6/libEFWFilter.bin")
-    set_property (TARGET USB2ST4Conv PROPERTY IMPORTED_LOCATION "armv6/libUSB2ST4Conv.bin")
-    set_property (TARGET EAFFocuser  PROPERTY IMPORTED_LOCATION "armv6/libEAFFocuser.bin")
-    set_property (TARGET CAARotator  PROPERTY IMPORTED_LOCATION "armv6/libCAARotator.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET ASICamera2  PROPERTY IMPORTED_LOCATION "armv8/libASICamera2.bin")
-    set_property (TARGET EFWFilter   PROPERTY IMPORTED_LOCATION "armv8/libEFWFilter.bin")
-    set_property (TARGET USB2ST4Conv PROPERTY IMPORTED_LOCATION "armv8/libUSB2ST4Conv.bin")
-    set_property (TARGET EAFFocuser  PROPERTY IMPORTED_LOCATION "armv8/libEAFFocuser.bin")
-    set_property (TARGET CAARotator  PROPERTY IMPORTED_LOCATION "armv8/libCAARotator.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    set_property (TARGET ASICamera2  PROPERTY IMPORTED_LOCATION "x64/libASICamera2.bin")
-    set_property (TARGET EFWFilter   PROPERTY IMPORTED_LOCATION "x64/libEFWFilter.bin")
-    set_property (TARGET USB2ST4Conv PROPERTY IMPORTED_LOCATION "x64/libUSB2ST4Conv.bin")
-    set_property (TARGET EAFFocuser  PROPERTY IMPORTED_LOCATION "x64/libEAFFocuser.bin")
-    set_property (TARGET CAARotator  PROPERTY IMPORTED_LOCATION "x64/libCAARotator.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
-    set_property (TARGET ASICamera2  PROPERTY IMPORTED_LOCATION "x86/libASICamera2.bin")
-    set_property (TARGET EFWFilter   PROPERTY IMPORTED_LOCATION "x86/libEFWFilter.bin")
-    set_property (TARGET USB2ST4Conv PROPERTY IMPORTED_LOCATION "x86/libUSB2ST4Conv.bin")
-    set_property (TARGET EAFFocuser  PROPERTY IMPORTED_LOCATION "x86/libEAFFocuser.bin")
-    set_property (TARGET CAARotator  PROPERTY IMPORTED_LOCATION "x86/libCAARotator.bin")
-  endif ()
+  fix_macos_libraries("libASICamera2" "mac/libASICamera2.bin" "ASI/ZWO")
+  fix_macos_libraries("libEFWFilter" "mac/libEFWFilter.bin" "ASI/ZWO")
+  fix_macos_libraries("libUSB2ST4Conv" "mac/libUSB2ST4Conv.bin" "ASI/ZWO")
+  fix_macos_libraries("libEAFFocuser" "mac/libEAFFocuser.bin" "ASI/ZWO")
+  fix_macos_libraries("libCAARotator" "mac/libCAARotator.bin" "ASI/ZWO")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET ASICamera2
+      PROPERTY IMPORTED_LOCATION "armv6/libASICamera2.bin"
+    )
+    set_property(
+      TARGET EFWFilter
+      PROPERTY IMPORTED_LOCATION "armv6/libEFWFilter.bin"
+    )
+    set_property(
+      TARGET USB2ST4Conv
+      PROPERTY IMPORTED_LOCATION "armv6/libUSB2ST4Conv.bin"
+    )
+    set_property(
+      TARGET EAFFocuser
+      PROPERTY IMPORTED_LOCATION "armv6/libEAFFocuser.bin"
+    )
+    set_property(
+      TARGET CAARotator
+      PROPERTY IMPORTED_LOCATION "armv6/libCAARotator.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET ASICamera2
+      PROPERTY IMPORTED_LOCATION "armv8/libASICamera2.bin"
+    )
+    set_property(
+      TARGET EFWFilter
+      PROPERTY IMPORTED_LOCATION "armv8/libEFWFilter.bin"
+    )
+    set_property(
+      TARGET USB2ST4Conv
+      PROPERTY IMPORTED_LOCATION "armv8/libUSB2ST4Conv.bin"
+    )
+    set_property(
+      TARGET EAFFocuser
+      PROPERTY IMPORTED_LOCATION "armv8/libEAFFocuser.bin"
+    )
+    set_property(
+      TARGET CAARotator
+      PROPERTY IMPORTED_LOCATION "armv8/libCAARotator.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    set_property(
+      TARGET ASICamera2
+      PROPERTY IMPORTED_LOCATION "x64/libASICamera2.bin"
+    )
+    set_property(
+      TARGET EFWFilter
+      PROPERTY IMPORTED_LOCATION "x64/libEFWFilter.bin"
+    )
+    set_property(
+      TARGET USB2ST4Conv
+      PROPERTY IMPORTED_LOCATION "x64/libUSB2ST4Conv.bin"
+    )
+    set_property(
+      TARGET EAFFocuser
+      PROPERTY IMPORTED_LOCATION "x64/libEAFFocuser.bin"
+    )
+    set_property(
+      TARGET CAARotator
+      PROPERTY IMPORTED_LOCATION "x64/libCAARotator.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
+    set_property(
+      TARGET ASICamera2
+      PROPERTY IMPORTED_LOCATION "x86/libASICamera2.bin"
+    )
+    set_property(
+      TARGET EFWFilter
+      PROPERTY IMPORTED_LOCATION "x86/libEFWFilter.bin"
+    )
+    set_property(
+      TARGET USB2ST4Conv
+      PROPERTY IMPORTED_LOCATION "x86/libUSB2ST4Conv.bin"
+    )
+    set_property(
+      TARGET EAFFocuser
+      PROPERTY IMPORTED_LOCATION "x86/libEAFFocuser.bin"
+    )
+    set_property(
+      TARGET CAARotator
+      PROPERTY IMPORTED_LOCATION "x86/libCAARotator.bin"
+    )
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-asi.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-asi.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (
+install(
   FILES ASICamera2.h EFW_filter.h USB2ST4_Conv.h EAF_focuser.h CAA_API.h
   DESTINATION include/libasi
 )
 
 # Install library
-install_imported (
+install_imported(
   TARGETS ASICamera2 EFWFilter USB2ST4Conv EAFFocuser CAARotator
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/libastroasis/CMakeLists.txt
+++ b/libastroasis/CMakeLists.txt
@@ -1,60 +1,100 @@
 cmake_minimum_required(VERSION 3.16)
-project (libastroasis)
+project(libastroasis)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-set (OASIS_FOCUSER_VERSION "2.0.2")
-set (OASIS_FOCUSER_SOVERSION "2")
+set(OASIS_FOCUSER_VERSION "2.0.2")
+set(OASIS_FOCUSER_SOVERSION "2")
 
-set (OASIS_FILTER_WHEEL_VERSION "1.2.1")
-set (OASIS_FILTER_WHEEL_SOVERSION "1")
+set(OASIS_FILTER_WHEEL_VERSION "1.2.1")
+set(OASIS_FILTER_WHEEL_SOVERSION "1")
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (oasisfocuser     SHARED IMPORTED)
-add_library (oasisfilterwheel SHARED IMPORTED)
+add_library(oasisfocuser SHARED IMPORTED)
+add_library(oasisfilterwheel SHARED IMPORTED)
 
-set_target_properties (oasisfocuser     PROPERTIES VERSION ${OASIS_FOCUSER_VERSION} SOVERSION ${OASIS_FOCUSER_SOVERSION})
-set_target_properties (oasisfilterwheel PROPERTIES VERSION ${OASIS_FILTER_WHEEL_VERSION} SOVERSION ${OASIS_FILTER_WHEEL_SOVERSION})
+set_target_properties(
+  oasisfocuser
+  PROPERTIES
+    VERSION ${OASIS_FOCUSER_VERSION}
+    SOVERSION ${OASIS_FOCUSER_SOVERSION}
+)
+set_target_properties(
+  oasisfilterwheel
+  PROPERTIES
+    VERSION ${OASIS_FILTER_WHEEL_VERSION}
+    SOVERSION ${OASIS_FILTER_WHEEL_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET oasisfocuser
+    PROPERTY IMPORTED_LOCATION "mac/liboasisfocuser.bin"
+  )
+  set_property(
+    TARGET oasisfilterwheel
+    PROPERTY IMPORTED_LOCATION "mac/liboasisfilterwheel.bin"
+  )
 
-  set_property (TARGET oasisfocuser     PROPERTY IMPORTED_LOCATION "mac/liboasisfocuser.bin")
-  set_property (TARGET oasisfilterwheel PROPERTY IMPORTED_LOCATION "mac/liboasisfilterwheel.bin")
-
-  FIX_MACOS_LIBRARIES("liboasisfocuser"     "mac/liboasisfocuser.bin" "ASTROASIS")
-  FIX_MACOS_LIBRARIES("liboasisfilterwheel" "mac/liboasisfilterwheel.bin" "ASTROASIS")
-
-elseif (UNIX AND NOT WIN32)
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET oasisfocuser     PROPERTY IMPORTED_LOCATION "armhf/liboasisfocuser.bin")
-    set_property (TARGET oasisfilterwheel PROPERTY IMPORTED_LOCATION "armhf/liboasisfilterwheel.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET oasisfocuser     PROPERTY IMPORTED_LOCATION "arm64/liboasisfocuser.bin")
-    set_property (TARGET oasisfilterwheel PROPERTY IMPORTED_LOCATION "arm64/liboasisfilterwheel.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET oasisfocuser     PROPERTY IMPORTED_LOCATION "x64/liboasisfocuser.bin")
-    set_property (TARGET oasisfilterwheel PROPERTY IMPORTED_LOCATION "x64/liboasisfilterwheel.bin")
-  else ()
-    message (FATAL_ERROR "x86-32 architecture is not supported.")
-  endif ()
+  fix_macos_libraries("liboasisfocuser"     "mac/liboasisfocuser.bin" "ASTROASIS")
+  fix_macos_libraries("liboasisfilterwheel" "mac/liboasisfilterwheel.bin" "ASTROASIS")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET oasisfocuser
+      PROPERTY IMPORTED_LOCATION "armhf/liboasisfocuser.bin"
+    )
+    set_property(
+      TARGET oasisfilterwheel
+      PROPERTY IMPORTED_LOCATION "armhf/liboasisfilterwheel.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET oasisfocuser
+      PROPERTY IMPORTED_LOCATION "arm64/liboasisfocuser.bin"
+    )
+    set_property(
+      TARGET oasisfilterwheel
+      PROPERTY IMPORTED_LOCATION "arm64/liboasisfilterwheel.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET oasisfocuser
+      PROPERTY IMPORTED_LOCATION "x64/liboasisfocuser.bin"
+    )
+    set_property(
+      TARGET oasisfilterwheel
+      PROPERTY IMPORTED_LOCATION "x64/liboasisfilterwheel.bin"
+    )
+  else()
+    message(FATAL_ERROR "x86-32 architecture is not supported.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-astroasis.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-astroasis.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install library
-install_imported (TARGETS oasisfocuser     DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install_imported (TARGETS oasisfilterwheel DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS oasisfocuser     DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS oasisfilterwheel DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Install header files
-install (FILES AOFocus.h          DESTINATION include/libastroasis)
-install (FILES OasisFilterWheel.h DESTINATION include/libastroasis)
+install(FILES AOFocus.h DESTINATION include/libastroasis)
+install(FILES OasisFilterWheel.h DESTINATION include/libastroasis)

--- a/libatik/CMakeLists.txt
+++ b/libatik/CMakeLists.txt
@@ -1,61 +1,100 @@
 cmake_minimum_required(VERSION 3.16)
-project (libatik)
+project(libatik)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 # Built with SDK API 2024.11.26_2038
-set (ATIK_VERSION "2.2.22")
-set (ATIK_SOVERSION "2")
+set(ATIK_VERSION "2.2.22")
+set(ATIK_SOVERSION "2")
 
-set (FLYCAPTURE_VERSION "2.13.3.31")
-set (FLYCAPTURE_SOVERSION "2")
+set(FLYCAPTURE_VERSION "2.13.3.31")
+set(FLYCAPTURE_SOVERSION "2")
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (atikcameras SHARED IMPORTED)
+add_library(atikcameras SHARED IMPORTED)
 
-set_target_properties (atikcameras PROPERTIES VERSION ${ATIK_VERSION} SOVERSION ${ATIK_SOVERSION})
+set_target_properties(
+  atikcameras
+  PROPERTIES VERSION ${ATIK_VERSION} SOVERSION ${ATIK_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET atikcameras
+    PROPERTY IMPORTED_LOCATION "mac/libatikcameras.bin"
+  )
 
-  set_property (TARGET atikcameras  PROPERTY IMPORTED_LOCATION "mac/libatikcameras.bin")
+  fix_macos_libraries("libatikcameras" "mac/libatikcameras.bin" "ATIK")
 
-  FIX_MACOS_LIBRARIES("libatikcameras" "mac/libatikcameras.bin" "ATIK")
-  
   # Install library
-  install_imported (TARGETS atikcameras DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  install_imported(TARGETS atikcameras DESTINATION ${CMAKE_INSTALL_LIBDIR})
+elseif(UNIX AND NOT WIN32)
+  add_library(flycapture SHARED IMPORTED)
+  set_target_properties(
+    flycapture
+    PROPERTIES VERSION ${FLYCAPTURE_VERSION} SOVERSION ${FLYCAPTURE_SOVERSION}
+  )
 
-elseif (UNIX AND NOT WIN32)
-  add_library (flycapture  SHARED IMPORTED)
-  set_target_properties (flycapture  PROPERTIES VERSION ${FLYCAPTURE_VERSION} SOVERSION ${FLYCAPTURE_SOVERSION})
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET atikcameras PROPERTY IMPORTED_LOCATION "armhf/libatikcameras.bin")
-    set_property (TARGET flycapture  PROPERTY IMPORTED_LOCATION "armhf/libflycapture.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET atikcameras PROPERTY IMPORTED_LOCATION "arm64/libatikcameras.bin")
-    set_property (TARGET flycapture  PROPERTY IMPORTED_LOCATION "arm64/libflycapture.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET atikcameras PROPERTY IMPORTED_LOCATION "x64/libatikcameras.bin")
-    set_property (TARGET flycapture  PROPERTY IMPORTED_LOCATION "x64/libflycapture.bin")
-  else ()
-    set_property (TARGET atikcameras PROPERTY IMPORTED_LOCATION "x86/libatikcameras.bin")
-    set_property (TARGET flycapture  PROPERTY IMPORTED_LOCATION "x86/libflycapture.bin")
-  endif ()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET atikcameras
+      PROPERTY IMPORTED_LOCATION "armhf/libatikcameras.bin"
+    )
+    set_property(
+      TARGET flycapture
+      PROPERTY IMPORTED_LOCATION "armhf/libflycapture.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET atikcameras
+      PROPERTY IMPORTED_LOCATION "arm64/libatikcameras.bin"
+    )
+    set_property(
+      TARGET flycapture
+      PROPERTY IMPORTED_LOCATION "arm64/libflycapture.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET atikcameras
+      PROPERTY IMPORTED_LOCATION "x64/libatikcameras.bin"
+    )
+    set_property(
+      TARGET flycapture
+      PROPERTY IMPORTED_LOCATION "x64/libflycapture.bin"
+    )
+  else()
+    set_property(
+      TARGET atikcameras
+      PROPERTY IMPORTED_LOCATION "x86/libatikcameras.bin"
+    )
+    set_property(
+      TARGET flycapture
+      PROPERTY IMPORTED_LOCATION "x86/libflycapture.bin"
+    )
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-  set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-  install (FILES 99-atik.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-atik.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
 
   # Install library
-  install_imported (TARGETS atikcameras flycapture DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-endif ()
+  install_imported(TARGETS atikcameras flycapture DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 # Install header files
-install (FILES AtikCameras.h AtikDefs.h DESTINATION include/libatik)
+install(FILES AtikCameras.h AtikDefs.h DESTINATION include/libatik)

--- a/libbressercam/CMakeLists.txt
+++ b/libbressercam/CMakeLists.txt
@@ -1,49 +1,74 @@
 cmake_minimum_required(VERSION 3.16)
-project (libbressercam)
+project(libbressercam)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-set (LIBBRESSERCAM_VERSION "59.29176")
-set (LIBBRESSERCAM_SOVERSION "59")
+set(LIBBRESSERCAM_VERSION "59.29176")
+set(LIBBRESSERCAM_SOVERSION "59")
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (bressercam SHARED IMPORTED)
+add_library(bressercam SHARED IMPORTED)
 
-set_target_properties (bressercam PROPERTIES VERSION ${LIBBRESSERCAM_VERSION} SOVERSION ${LIBBRESSERCAM_SOVERSION})
+set_target_properties(
+  bressercam
+  PROPERTIES
+    VERSION ${LIBBRESSERCAM_VERSION}
+    SOVERSION ${LIBBRESSERCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET bressercam
+    PROPERTY IMPORTED_LOCATION "mac/libbressercam.bin"
+  )
 
-  set_property (TARGET bressercam PROPERTY IMPORTED_LOCATION "mac/libbressercam.bin")
-
-  FIX_MACOS_LIBRARIES("libbressercam" "mac/libbressercam.bin" "BRESSERCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET bressercam PROPERTY IMPORTED_LOCATION "armhf/libbressercam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET bressercam PROPERTY IMPORTED_LOCATION "arm64/libbressercam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET bressercam PROPERTY IMPORTED_LOCATION "x64/libbressercam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
-
-  # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-bressercam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  fix_macos_libraries("libbressercam" "mac/libbressercam.bin" "BRESSERCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET bressercam
+      PROPERTY IMPORTED_LOCATION "armhf/libbressercam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET bressercam
+      PROPERTY IMPORTED_LOCATION "arm64/libbressercam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET bressercam
+      PROPERTY IMPORTED_LOCATION "x64/libbressercam.bin"
+    )
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
   endif()
 
-endif ()
+  # Install udev rules
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-bressercam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES bressercam.h DESTINATION include/libbressercam)
+install(FILES bressercam.h DESTINATION include/libbressercam)
 
 # Install library
-install_imported (TARGETS bressercam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS bressercam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libfishcamp/CMakeLists.txt
+++ b/libfishcamp/CMakeLists.txt
@@ -1,32 +1,48 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(libfishcamp C CXX)
+project(libfishcamp C CXX)
 
 #***********************************************************
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 include(CMakeCommon)
 find_package(INDI REQUIRED)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-option(INDI_INSTALL_FIRMWARE "Install Firmware" on)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-include_directories( ${INDI_INCLUDE_DIR})
+option(INDI_INSTALL_FIRMWARE "Install Firmware" On)
 
-IF(APPLE)
+include_directories(${INDI_INCLUDE_DIR})
+
+if(APPLE)
   set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/fishcamp")
   ##This one is needed for homebrew
-  include_directories( "/usr/local/include")
+  include_directories("/usr/local/include")
   ## This one is needed for Craft
   include_directories("${CMAKE_INSTALL_PREFIX}/include")
-ELSE(APPLE)
-  set(FIRMWARE_INSTALL_DIR "/lib/firmware" CACHE STRING "libfishcamp firmware installation dir")
-  set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-ENDIF(APPLE)
+else(APPLE)
+  set(
+    FIRMWARE_INSTALL_DIR
+    "/usr/lib/firmware"
+    CACHE STRING
+    "libfishcamp firmware installation dir"
+  )
+endif(APPLE)
+
 #***********************************************************
 find_package(USB1 REQUIRED)
-include_directories( ${USB1_INCLUDE_DIR})
-ADD_DEFINITIONS(-Wno-multichar)
+include_directories(${USB1_INCLUDE_DIR})
+add_definitions(-Wno-multichar)
 
 set(LIBFISHCAMP_VERSION "1.1")
 set(LIBFISHCAMP_SOVERSION "1")
@@ -34,19 +50,25 @@ set(LIBFISHCAMP_SOVERSION "1")
 set(fishcamp_LIB_SRCS fishcamp.c)
 
 #build a shared library
-ADD_LIBRARY(fishcamp SHARED ${fishcamp_LIB_SRCS})
+add_library(fishcamp SHARED ${fishcamp_LIB_SRCS})
 
-set_target_properties(fishcamp PROPERTIES VERSION ${LIBFISHCAMP_VERSION} SOVERSION ${LIBFISHCAMP_SOVERSION})
+set_target_properties(
+  fishcamp
+  PROPERTIES VERSION ${LIBFISHCAMP_VERSION} SOVERSION ${LIBFISHCAMP_SOVERSION}
+)
 
 target_link_libraries(fishcamp ${USB1_LIBRARIES})
 
-INSTALL(FILES fishcamp.h fishcamp_common.h DESTINATION include/libfishcamp)
+install(FILES fishcamp.h fishcamp_common.h DESTINATION include/libfishcamp)
 
-INSTALL(TARGETS fishcamp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS fishcamp LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-IF (INDI_INSTALL_FIRMWARE)
-  install( FILES gdr_usb.hex Guider_mono_rev16_intel.srec DESTINATION ${FIRMWARE_INSTALL_DIR})
-  IF(NOT APPLE AND INDI_INSTALL_UDEV_RULES)
+if(INDI_INSTALL_FIRMWARE)
+  install(
+    FILES gdr_usb.hex Guider_mono_rev16_intel.srec
+    DESTINATION ${FIRMWARE_INSTALL_DIR}
+  )
+  if(NOT APPLE AND INDI_INSTALL_UDEV_RULES)
     install(FILES 99-fishcamp.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  ENDIF()
-ENDIF()
+  endif()
+endif()

--- a/libfli/CMakeLists.txt
+++ b/libfli/CMakeLists.txt
@@ -1,98 +1,129 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(libfli CXX C)
+project(libfli CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 include(InstallImported)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-ADD_DEFINITIONS(-Wall -O2 -D__LIBUSB__)
+add_definitions(-Wall -O2 -D__LIBUSB__)
 
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 
 find_package(USB1 REQUIRED)
 find_package(INDI REQUIRED)
 
-include_directories( ${INDI_INCLUDE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${USB1_INCLUDE_DIR})
+include_directories(${USB1_INCLUDE_DIR})
 include_directories(unix)
 
-if (APPLE)
-    ##This one is needed for homebrew
-include_directories( "/usr/local/include")
-    ## This one is needed for Craft
-include_directories("${CMAKE_INSTALL_PREFIX}/include")
+if(APPLE)
+  ##This one is needed for homebrew
+  include_directories("/usr/local/include")
+  ## This one is needed for Craft
+  include_directories("${CMAKE_INSTALL_PREFIX}/include")
 endif(APPLE)
 
 # FLI Standard libusb library
-set(fli_LIB_SRCS
-   libfli.c   
-   libfli-camera.c   
-   libfli-camera-parport.c   
-   libfli-camera-usb.c   
-   libfli-filter-focuser.c   
-   libfli-mem.c
-   libfli-raw.c
-      
-   unix/libfli-usb.c
-   unix/libfli-debug.c
-   unix/libfli-serial.c
-   unix/libfli-sys.c
-   
-   #unix/linux/libfli-usb-sys.c
-   
-   # LIBUSB support
-   unix/libusb/libfli-usb-sys.c
+set(
+  fli_LIB_SRCS
+  libfli.c
+  libfli-camera.c
+  libfli-camera-parport.c
+  libfli-camera-usb.c
+  libfli-filter-focuser.c
+  libfli-mem.c
+  libfli-raw.c
+  unix/libfli-usb.c
+  unix/libfli-debug.c
+  unix/libfli-serial.c
+  unix/libfli-sys.c
+  #unix/linux/libfli-usb-sys.c
+  # LIBUSB support
+  unix/libusb/libfli-usb-sys.c
 )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-list(APPEND fli_LIB_SRCS unix/linux/libfli-parport.c)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  list(APPEND fli_LIB_SRCS unix/linux/libfli-parport.c)
 endif()
 
 #build a shared library
-ADD_LIBRARY(fli SHARED ${fli_LIB_SRCS})
+add_library(fli SHARED ${fli_LIB_SRCS})
 set_target_properties(fli PROPERTIES VERSION 2.0 SOVERSION 2)
 
 #need to link to some other libraries ? just add them here
-TARGET_LINK_LIBRARIES(fli ${USB1_LIBRARIES} -lm -lpthread)
+target_link_libraries(fli ${USB1_LIBRARIES} -lm -lpthread)
 
 # Install header
-INSTALL(FILES libfli.h DESTINATION include)
+install(FILES libfli.h DESTINATION include)
 # Install Libraryh
-INSTALL(TARGETS fli LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS fli LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-fli.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-fli.rules
+    DESTINATION ${UDEVRULES_INSTALL_DIR}
+  )
 endif()
 
 ###
 # FLI Pro Library (Linux only)
 ##
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   add_library(flipro SHARED IMPORTED)
   add_library(flialgo SHARED IMPORTED)
-  set (FLIPRO_VERSION "2.1.4")
-  set (FLIPRO_SOVERSION "2")
+  set(FLIPRO_VERSION "2.1.4")
+  set(FLIPRO_SOVERSION "2")
 
   # x86_64 and arm64 support only
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET flipro PROPERTY IMPORTED_LOCATION "flipro/arm64/libflipro.bin")
-    set_property (TARGET flialgo PROPERTY IMPORTED_LOCATION "flipro/arm64/libflialgo.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
-    set_property (TARGET flipro PROPERTY IMPORTED_LOCATION "flipro/x64/libflipro.bin")
-    set_property (TARGET flialgo PROPERTY IMPORTED_LOCATION "flipro/x64/libflialgo.bin")
-  endif ()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET flipro
+      PROPERTY IMPORTED_LOCATION "flipro/arm64/libflipro.bin"
+    )
+    set_property(
+      TARGET flialgo
+      PROPERTY IMPORTED_LOCATION "flipro/arm64/libflialgo.bin"
+    )
+  elseif(
+    CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"
+    OR CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86"
+  )
+    set_property(
+      TARGET flipro
+      PROPERTY IMPORTED_LOCATION "flipro/x64/libflipro.bin"
+    )
+    set_property(
+      TARGET flialgo
+      PROPERTY IMPORTED_LOCATION "flipro/x64/libflialgo.bin"
+    )
+  endif()
 
-  set_target_properties(flipro PROPERTIES VERSION ${FLIPRO_VERSION} SOVERSION ${FLIPRO_SOVERSION})
-  set_target_properties(flialgo PROPERTIES VERSION ${FLIPRO_VERSION} SOVERSION ${FLIPRO_SOVERSION})
+  set_target_properties(
+    flipro
+    PROPERTIES VERSION ${FLIPRO_VERSION} SOVERSION ${FLIPRO_SOVERSION}
+  )
+  set_target_properties(
+    flialgo
+    PROPERTIES VERSION ${FLIPRO_VERSION} SOVERSION ${FLIPRO_SOVERSION}
+  )
 
-  INSTALL(FILES flipro/libflipro.h DESTINATION include)
+  install(FILES flipro/libflipro.h DESTINATION include)
 
   # Install library
-  install_imported (TARGETS flipro flialgo  DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif ()
+  install_imported(TARGETS flipro flialgo  DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/libinovasdk/CMakeLists.txt
+++ b/libinovasdk/CMakeLists.txt
@@ -1,44 +1,63 @@
 cmake_minimum_required(VERSION 3.16)
-project (libinovasdk)
+project(libinovasdk)
 
-set (INOVASDK_VERSION "1.3.6")
-set (INOVASDK_SOVERSION "1")
+set(INOVASDK_VERSION "1.3.6")
+set(INOVASDK_SOVERSION "1")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (inovasdk SHARED IMPORTED)
+add_library(inovasdk SHARED IMPORTED)
 
-set_target_properties (inovasdk PROPERTIES VERSION 1.3.6 SOVERSION 1)
+set_target_properties(inovasdk PROPERTIES VERSION 1.3.6 SOVERSION 1)
 
-if (UNIX AND NOT WIN32 AND NOT APPLE)
+if(UNIX AND NOT WIN32 AND NOT APPLE)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET inovasdk
+      PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv6"
+    )
+    #elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "armv7l")
+    #   set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv7")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET inovasdk
+      PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv8"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET inovasdk
+      PROPERTY IMPORTED_LOCATION "libinovasdk.so.x64"
+    )
+  else()
+    set_property(
+      TARGET inovasdk
+      PROPERTY IMPORTED_LOCATION "libinovasdk.so.x86"
+    )
+  endif()
 
-   if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-      set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv6")
-   #elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "armv7l")
-   #   set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv7")
-   elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-      set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.armv8")
-   elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-      set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.x64")
-   else ()
-      set_property (TARGET inovasdk PROPERTY IMPORTED_LOCATION "libinovasdk.so.x86")
-   endif ()
-
-   # Install udev rules
-   if (INDI_INSTALL_UDEV_RULES)
-      set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-      install (FILES 99-inovaplx.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-   endif ()
-
-endif ()
+  # Install udev rules
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-inovaplx.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES inovasdk.h DESTINATION include/inovasdk)
+install(FILES inovasdk.h DESTINATION include/inovasdk)
 
 # Install library
-install_imported (TARGETS inovasdk DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS inovasdk DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libmallincam/CMakeLists.txt
+++ b/libmallincam/CMakeLists.txt
@@ -1,49 +1,72 @@
 cmake_minimum_required(VERSION 3.16)
-project (libmallincam)
+project(libmallincam)
 
-set (LIBMALLINCAM_VERSION "59.29176")
-set (LIBMALLINCAM_SOVERSION "59")
+set(LIBMALLINCAM_VERSION "59.29176")
+set(LIBMALLINCAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (mallincam SHARED IMPORTED)
+add_library(mallincam SHARED IMPORTED)
 
-set_target_properties (mallincam PROPERTIES VERSION ${LIBMALLINCAM_VERSION} SOVERSION ${LIBMALLINCAM_SOVERSION})
+set_target_properties(
+  mallincam
+  PROPERTIES VERSION ${LIBMALLINCAM_VERSION} SOVERSION ${LIBMALLINCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET mallincam
+    PROPERTY IMPORTED_LOCATION "mac/libmallincam.bin"
+  )
 
-  set_property (TARGET mallincam PROPERTY IMPORTED_LOCATION "mac/libmallincam.bin")
-
-  FIX_MACOS_LIBRARIES("libmallincam" "mac/libmallincam.bin" "MALLINCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET mallincam PROPERTY IMPORTED_LOCATION "armhf/libmallincam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET mallincam PROPERTY IMPORTED_LOCATION "arm64/libmallincam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET mallincam PROPERTY IMPORTED_LOCATION "x64/libmallincam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+  fix_macos_libraries("libmallincam" "mac/libmallincam.bin" "MALLINCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET mallincam
+      PROPERTY IMPORTED_LOCATION "armhf/libmallincam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET mallincam
+      PROPERTY IMPORTED_LOCATION "arm64/libmallincam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET mallincam
+      PROPERTY IMPORTED_LOCATION "x64/libmallincam.bin"
+    )
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-mallincam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-mallincam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES mallincam.h DESTINATION include/libmallincam)
+install(FILES mallincam.h DESTINATION include/libmallincam)
 
 # Install library
-install_imported (TARGETS mallincam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS mallincam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libmeadecam/CMakeLists.txt
+++ b/libmeadecam/CMakeLists.txt
@@ -1,48 +1,68 @@
 cmake_minimum_required(VERSION 3.16)
-project (libmeadecam)
+project(libmeadecam)
 
-set (LIBMEADECAM_VERSION "59.29176")
-set (LIBMEADECAM_SOVERSION "59")
+set(LIBMEADECAM_VERSION "59.29176")
+set(LIBMEADECAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (meadecam SHARED IMPORTED)
+add_library(meadecam SHARED IMPORTED)
 
-set_target_properties (meadecam PROPERTIES VERSION ${LIBMEADECAM_VERSION} SOVERSION ${LIBMEADECAM_SOVERSION})
+set_target_properties(
+  meadecam
+  PROPERTIES VERSION ${LIBMEADECAM_VERSION} SOVERSION ${LIBMEADECAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(TARGET meadecam PROPERTY IMPORTED_LOCATION "mac/libmeadecam.bin")
 
-  set_property (TARGET meadecam PROPERTY IMPORTED_LOCATION "mac/libmeadecam.bin")
-
-  FIX_MACOS_LIBRARIES("libmeadecam" "mac/libmeadecam.bin" "MEADECAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET meadecam PROPERTY IMPORTED_LOCATION "armhf/libmeadecam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET meadecam PROPERTY IMPORTED_LOCATION "arm64/libmeadecam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET meadecam PROPERTY IMPORTED_LOCATION "x64/libmeadecam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+  fix_macos_libraries("libmeadecam" "mac/libmeadecam.bin" "MEADECAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET meadecam
+      PROPERTY IMPORTED_LOCATION "armhf/libmeadecam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET meadecam
+      PROPERTY IMPORTED_LOCATION "arm64/libmeadecam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET meadecam
+      PROPERTY IMPORTED_LOCATION "x64/libmeadecam.bin"
+    )
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-meadecam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-meadecam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES meadecam.h DESTINATION include/libmeadecam)
+install(FILES meadecam.h DESTINATION include/libmeadecam)
 
 # Install library
-install_imported (TARGETS meadecam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS meadecam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libmicam/CMakeLists.txt
+++ b/libmicam/CMakeLists.txt
@@ -1,52 +1,60 @@
 cmake_minimum_required(VERSION 3.16)
-project (libmicam)
+project(libmicam)
 
-set (MICAM_VERSION "0.12.0")
-set (MICAM_VERSION_MAC "0.11.0")
-set (MICAM_SOVERSION "0")
+set(MICAM_VERSION "0.12.0")
+set(MICAM_VERSION_MAC "0.11.0")
+set(MICAM_SOVERSION "0")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (gxccd SHARED IMPORTED)
+add_library(gxccd SHARED IMPORTED)
 
-set_target_properties (gxccd PROPERTIES VERSION ${MICAM_VERSION} SOVERSION ${MICAM_SOVERSION})
+set_target_properties(
+  gxccd
+  PROPERTIES VERSION ${MICAM_VERSION} SOVERSION ${MICAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_target_properties(gxccd PROPERTIES VERSION ${MICAM_VERSION_MAC})
 
-  set_target_properties (gxccd PROPERTIES VERSION ${MICAM_VERSION_MAC})
+  set_property(TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdmac.bin")
 
-  set_property (TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdmac.bin")
-
-  FIX_MACOS_LIBRARIES("libgxccd" "libgxccdmac.bin" "Moravian/GXCCD")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdarmv7.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdarmv8.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    set_property (TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccd64.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
-    set_property (TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccd32.bin")
-  endif ()
+  fix_macos_libraries("libgxccd" "libgxccdmac.bin" "Moravian/GXCCD")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdarmv7.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccdarmv8.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    set_property(TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccd64.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
+    set_property(TARGET gxccd PROPERTY IMPORTED_LOCATION "libgxccd32.bin")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-miccd.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-miccd.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES gxccd.h DESTINATION include/libmicam)
+install(FILES gxccd.h DESTINATION include/libmicam)
 
 # Install library
-install_imported (TARGETS gxccd DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS gxccd DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libnncam/CMakeLists.txt
+++ b/libnncam/CMakeLists.txt
@@ -1,49 +1,60 @@
 cmake_minimum_required(VERSION 3.16)
-project (libnncam)
+project(libnncam)
 
-set (LIBNNCAM_VERSION "59.29176")
-set (LIBNNCAM_SOVERSION "59")
+set(LIBNNCAM_VERSION "59.29176")
+set(LIBNNCAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (nncam SHARED IMPORTED)
+add_library(nncam SHARED IMPORTED)
 
-set_target_properties (nncam PROPERTIES VERSION ${LIBNNCAM_VERSION} SOVERSION ${LIBNNCAM_SOVERSION})
+set_target_properties(
+  nncam
+  PROPERTIES VERSION ${LIBNNCAM_VERSION} SOVERSION ${LIBNNCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(TARGET nncam PROPERTY IMPORTED_LOCATION "mac/libnncam.bin")
 
-  set_property (TARGET nncam PROPERTY IMPORTED_LOCATION "mac/libnncam.bin")
-
-  FIX_MACOS_LIBRARIES("libnncam" "mac/libnncam.bin" "NNCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET nncam PROPERTY IMPORTED_LOCATION "armhf/libnncam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET nncam PROPERTY IMPORTED_LOCATION "arm64/libnncam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET nncam PROPERTY IMPORTED_LOCATION "x64/libnncam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
-
-  # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-nncam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  fix_macos_libraries("libnncam" "mac/libnncam.bin" "NNCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(TARGET nncam PROPERTY IMPORTED_LOCATION "armhf/libnncam.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET nncam PROPERTY IMPORTED_LOCATION "arm64/libnncam.bin")
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(TARGET nncam PROPERTY IMPORTED_LOCATION "x64/libnncam.bin")
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
   endif()
 
-endif ()
+  # Install udev rules
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-nncam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES nncam.h DESTINATION include/libnncam)
+install(FILES nncam.h DESTINATION include/libnncam)
 
 # Install library
-install_imported (TARGETS nncam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS nncam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libogmacam/CMakeLists.txt
+++ b/libogmacam/CMakeLists.txt
@@ -1,48 +1,65 @@
 cmake_minimum_required(VERSION 3.16)
-project (libogmacam)
+project(libogmacam)
 
-set (LIBOGMACAM_VERSION "59.29176")
-set (LIBOGMACAM_SOVERSION "59")
+set(LIBOGMACAM_VERSION "59.29176")
+set(LIBOGMACAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (ogmacam SHARED IMPORTED)
+add_library(ogmacam SHARED IMPORTED)
 
-set_target_properties (ogmacam PROPERTIES VERSION ${LIBOGMACAM_VERSION} SOVERSION ${LIBOGMACAM_SOVERSION})
+set_target_properties(
+  ogmacam
+  PROPERTIES VERSION ${LIBOGMACAM_VERSION} SOVERSION ${LIBOGMACAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(TARGET ogmacam PROPERTY IMPORTED_LOCATION "mac/libogmacam.bin")
 
-  set_property (TARGET ogmacam PROPERTY IMPORTED_LOCATION "mac/libogmacam.bin")
-
-  FIX_MACOS_LIBRARIES("libogmacam" "mac/libogmacam.bin" "OGMACAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET ogmacam PROPERTY IMPORTED_LOCATION "armhf/libogmacam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET ogmacam PROPERTY IMPORTED_LOCATION "arm64/libogmacam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET ogmacam PROPERTY IMPORTED_LOCATION "x64/libogmacam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
-
-  # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-ogmacam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  fix_macos_libraries("libogmacam" "mac/libogmacam.bin" "OGMACAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET ogmacam
+      PROPERTY IMPORTED_LOCATION "armhf/libogmacam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET ogmacam
+      PROPERTY IMPORTED_LOCATION "arm64/libogmacam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(TARGET ogmacam PROPERTY IMPORTED_LOCATION "x64/libogmacam.bin")
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
   endif()
 
-endif ()
+  # Install udev rules
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-ogmacam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES ogmacam.h DESTINATION include/libogmacam)
+install(FILES ogmacam.h DESTINATION include/libogmacam)
 
 # Install library
-install_imported (TARGETS ogmacam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS ogmacam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libomegonprocam/CMakeLists.txt
+++ b/libomegonprocam/CMakeLists.txt
@@ -1,47 +1,69 @@
 cmake_minimum_required(VERSION 3.16)
-project (libomegonprocam)
+project(libomegonprocam)
 
-set (LIBOMEGONPROCAM_VERSION "59.29176")
-set (LIBOMEGONPROCAM_SOVERSION "59")
+set(LIBOMEGONPROCAM_VERSION "59.29176")
+set(LIBOMEGONPROCAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (omegonprocam SHARED IMPORTED)
+add_library(omegonprocam SHARED IMPORTED)
 
-set_target_properties (omegonprocam PROPERTIES VERSION ${LIBOMEGONPROCAM_VERSION} SOVERSION ${LIBOMEGONPROCAM_SOVERSION})
+set_target_properties(
+  omegonprocam
+  PROPERTIES
+    VERSION ${LIBOMEGONPROCAM_VERSION}
+    SOVERSION ${LIBOMEGONPROCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET omegonprocam
+    PROPERTY IMPORTED_LOCATION "mac/libomegonprocam.bin"
+  )
 
-  set_property (TARGET omegonprocam PROPERTY IMPORTED_LOCATION "mac/libomegonprocam.bin")
-
-  FIX_MACOS_LIBRARIES("libomegonprocam" "mac/libomegonprocam.bin" "OMEGON")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET omegonprocam PROPERTY IMPORTED_LOCATION "armhf/libomegonprocam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET omegonprocam PROPERTY IMPORTED_LOCATION "arm64/libomegonprocam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET omegonprocam PROPERTY IMPORTED_LOCATION "x64/libomegonprocam.bin")
-  endif ()
+  fix_macos_libraries("libomegonprocam" "mac/libomegonprocam.bin" "OMEGON")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET omegonprocam
+      PROPERTY IMPORTED_LOCATION "armhf/libomegonprocam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET omegonprocam
+      PROPERTY IMPORTED_LOCATION "arm64/libomegonprocam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET omegonprocam
+      PROPERTY IMPORTED_LOCATION "x64/libomegonprocam.bin"
+    )
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-omegonprocam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-omegonprocam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES omegonprocam.h DESTINATION include/libomegonprocam)
+install(FILES omegonprocam.h DESTINATION include/libomegonprocam)
 
 # Install library
-install_imported (TARGETS omegonprocam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS omegonprocam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libpktriggercord/CMakeLists.txt
+++ b/libpktriggercord/CMakeLists.txt
@@ -1,75 +1,106 @@
-cmake_minimum_required (VERSION 3.12)
-project (libpktriggercord C)
+cmake_minimum_required(VERSION 3.12)
+project(libpktriggercord C)
 
-set (PK_VERSION 0.85.03)
-set (PK_SOVERSION 0)
-set (PK_DATADIR /usr/share/pktriggercord)
-set (PK_DEBUG true)
-set (PK_WARNINGS true)
+set(PK_VERSION 0.85.03)
+set(PK_SOVERSION 0)
+set(PK_DATADIR /usr/share/pktriggercord)
+set(PK_DEBUG true)
+set(PK_WARNINGS true)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 find_package(INDI REQUIRED)
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
-set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 # Build library
-add_definitions (-DPKTDATADIR="${PK_DATADIR}")
-add_definitions (-DVERSION="${PK_VERSION}")
+add_definitions(-DPKTDATADIR="${PK_DATADIR}")
+add_definitions(-DVERSION="${PK_VERSION}")
 
-include_directories (${CMAKE_CURRENT_BINARY_DIR})
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/src)
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/src/src/external/js0n)
-include_directories (${INDI_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/src/external/js0n)
+include_directories(${INDI_INCLUDE_DIR})
 
 # strip main function from pktriggercord
-file (READ ${CMAKE_CURRENT_SOURCE_DIR}/src/pktriggercord-cli.c PK_CLI)
-string (REGEX REPLACE "int main.*$" "" PK_CLI "${PK_CLI}")
-file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/libpktriggercord.c "${PK_CLI}")
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/src/pktriggercord-cli.c PK_CLI)
+string(REGEX REPLACE "int main.*$" "" PK_CLI "${PK_CLI}")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libpktriggercord.c "${PK_CLI}")
 
-set (libpktriggercord_SRCS
+set(
+  libpktriggercord_SRCS
   ${CMAKE_CURRENT_BINARY_DIR}/libpktriggercord.c # stripped
-
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_model.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_model.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_lens.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_enum.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_utils.c
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_log.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_scsi.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/src/external/js0n/js0n.c
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pktriggercord-servermode.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/pslr_scsi.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/src/external/js0n/js0n.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/pktriggercord-servermode.c
 )
 
-add_library (pktriggercord SHARED ${libpktriggercord_SRCS})
-set_target_properties (pktriggercord PROPERTIES VERSION ${PK_VERSION} SOVERSION ${PK_SOVERSION})
+add_library(pktriggercord SHARED ${libpktriggercord_SRCS})
+set_target_properties(
+  pktriggercord
+  PROPERTIES VERSION ${PK_VERSION} SOVERSION ${PK_SOVERSION}
+)
 
 # Build udev rules
-add_custom_command (
+add_custom_command(
   OUTPUT 95-pentax.rules
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/pentax.rules ${CMAKE_CURRENT_BINARY_DIR}/95-pentax.rules
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/pentax.rules
+    ${CMAKE_CURRENT_BINARY_DIR}/95-pentax.rules
 )
 
-add_custom_command (
+add_custom_command(
   OUTPUT 95-samsung.rules
-  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/samsung.rules ${CMAKE_CURRENT_BINARY_DIR}/95-samsung.rules
+  COMMAND
+    ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/src/samsung.rules
+    ${CMAKE_CURRENT_BINARY_DIR}/95-samsung.rules
 )
 
-add_custom_target (udev_rules ALL DEPENDS 95-pentax.rules 95-samsung.rules)
+add_custom_target(udev_rules ALL DEPENDS 95-pentax.rules 95-samsung.rules)
 
 # Install udev rules
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/95-pentax.rules ${CMAKE_CURRENT_BINARY_DIR}/95-samsung.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/pentax_settings.json DESTINATION ${PK_DATADIR})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INDI_INSTALL_UDEV_RULES)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/95-pentax.rules
+      ${CMAKE_CURRENT_BINARY_DIR}/95-samsung.rules
+    DESTINATION ${UDEVRULES_INSTALL_DIR}
+  )
+  install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/pentax_settings.json
+    DESTINATION ${PK_DATADIR}
+  )
 endif()
 
 # Install header files
-install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/ DESTINATION include/libpktriggercord FILES_MATCHING PATTERN "*.h")
-install (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION include/libpktriggercord)
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/
+  DESTINATION include/libpktriggercord
+  FILES_MATCHING
+  PATTERN "*.h"
+)
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION include/libpktriggercord
+)
 
 # Install library
-install (TARGETS pktriggercord DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
+install(TARGETS pktriggercord DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libplayerone/CMakeLists.txt
+++ b/libplayerone/CMakeLists.txt
@@ -1,69 +1,107 @@
 cmake_minimum_required(VERSION 3.16)
-project (libplayerone)
+project(libplayerone)
 
 # Using PlayerOne Camera SDK Version 3.8.1 updated on 2025-3-28
 # Using PlayerOne EFW    SDK Version 1.2.2 updated on 2025-3-12
 
-set (POACAM_VERSION "3.8.1")
-set (POACAM_SOVERSION "3")
+set(POACAM_VERSION "3.8.1")
+set(POACAM_SOVERSION "3")
 
-set (POAEFW_VERSION "1.2.2")
-set (POAEFW_SOVERSION "1")
+set(POAEFW_VERSION "1.2.2")
+set(POAEFW_SOVERSION "1")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (PlayerOneCamera  SHARED IMPORTED)
-add_library (PlayerOnePW      SHARED IMPORTED)
+add_library(PlayerOneCamera SHARED IMPORTED)
+add_library(PlayerOnePW SHARED IMPORTED)
 
-set_target_properties (PlayerOneCamera  PROPERTIES VERSION ${POACAM_VERSION} SOVERSION ${POACAM_SOVERSION})
-set_target_properties (PlayerOnePW      PROPERTIES VERSION ${POAEFW_VERSION} SOVERSION ${POAEFW_SOVERSION})
+set_target_properties(
+  PlayerOneCamera
+  PROPERTIES VERSION ${POACAM_VERSION} SOVERSION ${POACAM_SOVERSION}
+)
+set_target_properties(
+  PlayerOnePW
+  PROPERTIES VERSION ${POAEFW_VERSION} SOVERSION ${POAEFW_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET PlayerOneCamera
+    PROPERTY IMPORTED_LOCATION "mac/libPlayerOneCamera.bin"
+  )
+  set_property(
+    TARGET PlayerOnePW
+    PROPERTY IMPORTED_LOCATION "mac/libPlayerOnePW.bin"
+  )
 
-  set_property (TARGET PlayerOneCamera  PROPERTY IMPORTED_LOCATION "mac/libPlayerOneCamera.bin")
-  set_property (TARGET PlayerOnePW      PROPERTY IMPORTED_LOCATION "mac/libPlayerOnePW.bin")
-    
-  FIX_MACOS_LIBRARIES("libPlayerOneCamera" "mac/libPlayerOneCamera.bin" "PLAYER ONE")
-  FIX_MACOS_LIBRARIES("libPlayerOnePW"     "mac/libPlayerOnePW.bin" "PLAYER ONE")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET PlayerOneCamera  PROPERTY IMPORTED_LOCATION "armv6/libPlayerOneCamera.bin")
-    set_property (TARGET PlayerOnePW      PROPERTY IMPORTED_LOCATION "armv6/libPlayerOnePW.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET PlayerOneCamera  PROPERTY IMPORTED_LOCATION "armv8/libPlayerOneCamera.bin")
-    set_property (TARGET PlayerOnePW      PROPERTY IMPORTED_LOCATION "armv8/libPlayerOnePW.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-    set_property (TARGET PlayerOneCamera  PROPERTY IMPORTED_LOCATION "x64/libPlayerOneCamera.bin")
-    set_property (TARGET PlayerOnePW      PROPERTY IMPORTED_LOCATION "x64/libPlayerOnePW.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
+  fix_macos_libraries("libPlayerOneCamera" "mac/libPlayerOneCamera.bin" "PLAYER ONE")
+  fix_macos_libraries("libPlayerOnePW"     "mac/libPlayerOnePW.bin" "PLAYER ONE")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET PlayerOneCamera
+      PROPERTY IMPORTED_LOCATION "armv6/libPlayerOneCamera.bin"
+    )
+    set_property(
+      TARGET PlayerOnePW
+      PROPERTY IMPORTED_LOCATION "armv6/libPlayerOnePW.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET PlayerOneCamera
+      PROPERTY IMPORTED_LOCATION "armv8/libPlayerOneCamera.bin"
+    )
+    set_property(
+      TARGET PlayerOnePW
+      PROPERTY IMPORTED_LOCATION "armv8/libPlayerOnePW.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    set_property(
+      TARGET PlayerOneCamera
+      PROPERTY IMPORTED_LOCATION "x64/libPlayerOneCamera.bin"
+    )
+    set_property(
+      TARGET PlayerOnePW
+      PROPERTY IMPORTED_LOCATION "x64/libPlayerOnePW.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
     #x86 library is not provided from manufacturer
-    set_property (TARGET PlayerOneCamera  PROPERTY IMPORTED_LOCATION "")
-    set_property (TARGET PlayerOnePW      PROPERTY IMPORTED_LOCATION "")
-  endif ()
+    set_property(TARGET PlayerOneCamera PROPERTY IMPORTED_LOCATION "")
+    set_property(TARGET PlayerOnePW PROPERTY IMPORTED_LOCATION "")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-player_one_astronomy.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-player_one_astronomy.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (
+install(
   FILES PlayerOneCamera.h PlayerOnePW.h ConvFuncs.h
   DESTINATION include/libplayerone
 )
 
 # Install library
-install_imported (
+install_imported(
   TARGETS PlayerOneCamera PlayerOnePW
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/libqhy/CMakeLists.txt
+++ b/libqhy/CMakeLists.txt
@@ -1,63 +1,89 @@
 cmake_minimum_required(VERSION 3.16)
-project (libqhy)
+project(libqhy)
 
 # QHY SDK 25.06.03
-set (LIBQHY_VERSION "25.06.03")
-set (LIBQHY_SOVERSION "20")
+set(LIBQHY_VERSION "25.06.03")
+set(LIBQHY_SOVERSION "20")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
+
 option(INDI_INSTALL_FIRMWARE "Install Firmware" On)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (qhyccd SHARED IMPORTED)
+add_library(qhyccd SHARED IMPORTED)
 
-set_target_properties (qhyccd PROPERTIES VERSION ${LIBQHY_VERSION} SOVERSION ${LIBQHY_SOVERSION})
+set_target_properties(
+  qhyccd
+  PROPERTIES VERSION ${LIBQHY_VERSION} SOVERSION ${LIBQHY_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set(
+    QHY_FIRMWARE_INSTALL_DIR
+    "/usr/local/lib/indi/DriverSupport/qhy/firmware"
+    CACHE STRING
+    "QHY firmware installation directory"
+  )
 
-  set (QHY_FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy/firmware" CACHE STRING "QHY firmware installation directory")
+  set_property(TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd.dylib")
 
-  set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd.dylib")
+  fix_macos_libraries("libqhyccd" "libqhyccd.dylib" "QHY")
+elseif(UNIX AND NOT WIN32)
+  set(
+    QHY_FIRMWARE_INSTALL_DIR
+    "/usr/lib/firmware/qhy"
+    CACHE STRING
+    "QHY firmware installation directory"
+  )
 
-  FIX_MACOS_LIBRARIES("libqhyccd" "libqhyccd.dylib" "QHY")
-
-elseif (UNIX AND NOT WIN32)
-
-  set (QHY_FIRMWARE_INSTALL_DIR "/lib/firmware/qhy" CACHE STRING "QHY firmware installation directory")
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv6.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv8.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_x86_64.bin")
-  else ()
-    message (FATAL_ERROR "x86-32 architecture is not supported.")
-  endif ()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv6.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET qhyccd PROPERTY IMPORTED_LOCATION "libqhyccd_armv8.bin")
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET qhyccd
+      PROPERTY IMPORTED_LOCATION "libqhyccd_x86_64.bin"
+    )
+  else()
+    message(FATAL_ERROR "x86-32 architecture is not supported.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 85-qhyccd.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 85-qhyccd.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES qhyccd.h qhyccderr.h qhyccdcamdef.h qhyccdstruct.h DESTINATION include/libqhy)
+install(
+  FILES qhyccd.h qhyccderr.h qhyccdcamdef.h qhyccdstruct.h
+  DESTINATION include/libqhy
+)
 
 # Install firmware
-IF (INDI_INSTALL_FIRMWARE)
-  install (
-    CODE "
+if(INDI_INSTALL_FIRMWARE)
+  install(
+    CODE
+      "
     file(GLOB QHY_FIRMWARE ${CMAKE_CURRENT_SOURCE_DIR}/firmware/*) \n
     file(INSTALL DESTINATION ${QHY_FIRMWARE_INSTALL_DIR} TYPE FILE FILES \${QHY_FIRMWARE})"
   )
 endif()
 
 # Install library
-install_imported (TARGETS qhyccd DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS qhyccd DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libricohcamerasdk/CMakeLists.txt
+++ b/libricohcamerasdk/CMakeLists.txt
@@ -1,51 +1,88 @@
 cmake_minimum_required(VERSION 3.16)
-project (libricohcamerasdk)
+project(libricohcamerasdk)
 
-set (LIBPENTAX_VERSION "1.1.0")
-set (LIBPENTAX_SOVERSION "1")
-set (LIBMTP_VERSION "9.3.0")
-set (LIBMTP_SOVERSION "9")
+set(LIBPENTAX_VERSION "1.1.0")
+set(LIBPENTAX_SOVERSION "1")
+set(LIBMTP_VERSION "9.3.0")
+set(LIBMTP_SOVERSION "9")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (RicohCameraSDKCpp SHARED IMPORTED)
-add_library (mtpricoh          SHARED IMPORTED)
+add_library(RicohCameraSDKCpp SHARED IMPORTED)
+add_library(mtpricoh SHARED IMPORTED)
 
-set_target_properties (RicohCameraSDKCpp PROPERTIES VERSION ${LIBPENTAX_VERSION} SOVERSION ${LIBPENTAX_SOVERSION})
-set_target_properties (mtpricoh          PROPERTIES VERSION ${LIBMTP_VERSION} SOVERSION ${LIBMTP_SOVERSION})
+set_target_properties(
+  RicohCameraSDKCpp
+  PROPERTIES VERSION ${LIBPENTAX_VERSION} SOVERSION ${LIBPENTAX_SOVERSION}
+)
+set_target_properties(
+  mtpricoh
+  PROPERTIES VERSION ${LIBMTP_VERSION} SOVERSION ${LIBMTP_SOVERSION}
+)
 
-if (UNIX AND NOT WIN32 AND NOT APPLE)
-
-  if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86_64|amd64)")
-    set_property (TARGET RicohCameraSDKCpp PROPERTY IMPORTED_LOCATION "lib/x64/libRicohCameraSDKCpp.bin")
-    set_property (TARGET mtpricoh          PROPERTY IMPORTED_LOCATION "lib/x64/libmtpricoh.bin")
+if(UNIX AND NOT WIN32 AND NOT APPLE)
+  if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86_64|amd64)")
+    set_property(
+      TARGET RicohCameraSDKCpp
+      PROPERTY IMPORTED_LOCATION "lib/x64/libRicohCameraSDKCpp.bin"
+    )
+    set_property(
+      TARGET mtpricoh
+      PROPERTY IMPORTED_LOCATION "lib/x64/libmtpricoh.bin"
+    )
   elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^i[3-6]86")
-    set_property (TARGET RicohCameraSDKCpp PROPERTY IMPORTED_LOCATION "lib/x86/libRicohCameraSDKCpp.bin")
-    set_property (TARGET mtpricoh          PROPERTY IMPORTED_LOCATION "lib/x86/libmtpricoh.bin")
+    set_property(
+      TARGET RicohCameraSDKCpp
+      PROPERTY IMPORTED_LOCATION "lib/x86/libRicohCameraSDKCpp.bin"
+    )
+    set_property(
+      TARGET mtpricoh
+      PROPERTY IMPORTED_LOCATION "lib/x86/libmtpricoh.bin"
+    )
   elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
-    set_property (TARGET RicohCameraSDKCpp PROPERTY IMPORTED_LOCATION "lib/armv7l/libRicohCameraSDKCpp.bin")
-    set_property (TARGET mtpricoh          PROPERTY IMPORTED_LOCATION "lib/armv7l/libmtpricoh.bin")
-  else ()
+    set_property(
+      TARGET RicohCameraSDKCpp
+      PROPERTY IMPORTED_LOCATION "lib/armv7l/libRicohCameraSDKCpp.bin"
+    )
+    set_property(
+      TARGET mtpricoh
+      PROPERTY IMPORTED_LOCATION "lib/armv7l/libmtpricoh.bin"
+    )
+  else()
     message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
   endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-pentax.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-pentax.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES include/ricoh_camera_sdk.hpp DESTINATION include/libricohcamerasdk)
-install (DIRECTORY include/ricoh_camera_sdk DESTINATION include/libricohcamerasdk)
+install(
+  FILES include/ricoh_camera_sdk.hpp
+  DESTINATION include/libricohcamerasdk
+)
+install(
+  DIRECTORY include/ricoh_camera_sdk
+  DESTINATION include/libricohcamerasdk
+)
 
 # Install library
-install_imported (TARGETS RicohCameraSDKCpp mtpricoh DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS RicohCameraSDKCpp mtpricoh DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libsbig/CMakeLists.txt
+++ b/libsbig/CMakeLists.txt
@@ -1,57 +1,73 @@
 cmake_minimum_required(VERSION 3.16)
-project (libsbig)
+project(libsbig)
 
-set (SBIG_VERSION "4.9.9")
-set (SBIG_SOVERSION "4")
+set(SBIG_VERSION "4.9.9")
+set(SBIG_SOVERSION "4")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 option(INDI_INSTALL_FIRMWARE "Install Firmware" On)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (sbig SHARED IMPORTED)
+add_library(sbig SHARED IMPORTED)
 
-set_target_properties (sbig PROPERTIES VERSION ${SBIG_VERSION} SOVERSION ${SBIG_SOVERSION})
+set_target_properties(
+  sbig
+  PROPERTIES VERSION ${SBIG_VERSION} SOVERSION ${SBIG_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/sbig")
 
-  set (FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/sbig")
+  set_property(TARGET sbig PROPERTY IMPORTED_LOCATION "SBIGUDrvOSX.bin")
 
-  set_property (TARGET sbig PROPERTY IMPORTED_LOCATION "SBIGUDrvOSX.bin")
+  fix_macos_libraries("libsbig" "SBIGUDrvOSX.bin" "SBIG")
+elseif(UNIX AND NOT WIN32)
+  set(
+    FIRMWARE_INSTALL_DIR
+    "/usr/lib/firmware"
+    CACHE STRING
+    "sbig firmware installation directory"
+  )
 
-  FIX_MACOS_LIBRARIES("libsbig" "SBIGUDrvOSX.bin" "SBIG")
-
-elseif (UNIX AND NOT WIN32)
-
-  set (FIRMWARE_INSTALL_DIR "/lib/firmware" CACHE STRING "sbig firmware installation directory")
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_armhf.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_arm64.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_x64.bin")
-  endif ()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_armhf.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_arm64.bin")
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(TARGET sbig PROPERTY IMPORTED_LOCATION "libsbig_x64.bin")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 51-sbig-debian.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 51-sbig-debian.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES sbigudrv.h DESTINATION include/libsbig)
+install(FILES sbigudrv.h DESTINATION include/libsbig)
 
 # Install firmware
-IF (INDI_INSTALL_FIRMWARE)
-  install (FILES sbigucam.hex sbiglcam.hex sbigfcam.hex sbigpcam.hex stfga.bin DESTINATION ${FIRMWARE_INSTALL_DIR})
-ENDIF()
+if(INDI_INSTALL_FIRMWARE)
+  install(
+    FILES sbigucam.hex sbiglcam.hex sbigfcam.hex sbigpcam.hex stfga.bin
+    DESTINATION ${FIRMWARE_INSTALL_DIR}
+  )
+endif()
 
 # Install library
-install_imported (TARGETS sbig DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS sbig DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libstarshootg/CMakeLists.txt
+++ b/libstarshootg/CMakeLists.txt
@@ -1,47 +1,69 @@
 cmake_minimum_required(VERSION 3.16)
-project (libstarshootg)
+project(libstarshootg)
 
-set (LIBSTARSHOOTG_VERSION "59.29176")
-set (LIBSTARSHOOTG_SOVERSION "59")
+set(LIBSTARSHOOTG_VERSION "59.29176")
+set(LIBSTARSHOOTG_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (starshootg SHARED IMPORTED)
+add_library(starshootg SHARED IMPORTED)
 
-set_target_properties (starshootg PROPERTIES VERSION ${LIBSTARSHOOTG_VERSION} SOVERSION ${LIBSTARSHOOTG_SOVERSION})
+set_target_properties(
+  starshootg
+  PROPERTIES
+    VERSION ${LIBSTARSHOOTG_VERSION}
+    SOVERSION ${LIBSTARSHOOTG_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET starshootg
+    PROPERTY IMPORTED_LOCATION "mac/libstarshootg.bin"
+  )
 
-  set_property (TARGET starshootg PROPERTY IMPORTED_LOCATION "mac/libstarshootg.bin")
-
-  FIX_MACOS_LIBRARIES("libstarshootg" "mac/libstarshootg.bin" "StarShoot")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET starshootg PROPERTY IMPORTED_LOCATION "armhf/libstarshootg.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET starshootg PROPERTY IMPORTED_LOCATION "arm64/libstarshootg.bin")
+  fix_macos_libraries("libstarshootg" "mac/libstarshootg.bin" "StarShoot")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET starshootg
+      PROPERTY IMPORTED_LOCATION "armhf/libstarshootg.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET starshootg
+      PROPERTY IMPORTED_LOCATION "arm64/libstarshootg.bin"
+    )
   elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET starshootg PROPERTY IMPORTED_LOCATION "x64/libstarshootg.bin")
-  endif ()
+    set_property(
+      TARGET starshootg
+      PROPERTY IMPORTED_LOCATION "x64/libstarshootg.bin"
+    )
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-starshootg.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-starshootg.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES starshootg.h DESTINATION include/libstarshootg)
+install(FILES starshootg.h DESTINATION include/libstarshootg)
 
 # Install library
-install_imported (TARGETS starshootg DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS starshootg DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libsvbony/CMakeLists.txt
+++ b/libsvbony/CMakeLists.txt
@@ -1,53 +1,74 @@
 cmake_minimum_required(VERSION 3.16)
-project (libsvbony)
+project(libsvbony)
 
-set (SVBCAMERASDK_VERSION "1.13.4")
-set (SVBCAMERASDK_SOVERSION "1")
+set(SVBCAMERASDK_VERSION "1.13.4")
+set(SVBCAMERASDK_SOVERSION "1")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (SVBCameraSDK SHARED IMPORTED)
+add_library(SVBCameraSDK SHARED IMPORTED)
 
-set_target_properties (SVBCameraSDK PROPERTIES VERSION ${SVBCAMERASDK_VERSION} SOVERSION ${SVBCAMERASDK_SOVERSION})
+set_target_properties(
+  SVBCameraSDK
+  PROPERTIES VERSION ${SVBCAMERASDK_VERSION} SOVERSION ${SVBCAMERASDK_SOVERSION}
+)
 
 if(WIN32)
+  message(FATAL_ERROR "MS Windows not supported.")
+elseif(APPLE)
+  set_property(
+    TARGET SVBCameraSDK
+    PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_mac64.bin"
+  )
 
-    message(FATAL_ERROR "MS Windows not supported.")
+  fix_macos_libraries("libSVBCameraSDK" "libSVBCameraSDK_mac64.bin" "SVBONY")
+elseif(UNIX)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET SVBCameraSDK
+      PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_armv6.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET SVBCameraSDK
+      PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_armv8.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    set_property(
+      TARGET SVBCameraSDK
+      PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_amd64.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
+    set_property(
+      TARGET SVBCameraSDK
+      PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_x86.bin"
+    )
+  endif()
 
-elseif (APPLE)
-
-    set_property (TARGET SVBCameraSDK PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_mac64.bin")
-
-    FIX_MACOS_LIBRARIES("libSVBCameraSDK" "libSVBCameraSDK_mac64.bin" "SVBONY")
-
-elseif (UNIX)
-
-    if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-        set_property (TARGET SVBCameraSDK PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_armv6.bin")
-    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-        set_property (TARGET SVBCameraSDK PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_armv8.bin")
-    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-        set_property (TARGET SVBCameraSDK PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_amd64.bin")
-    elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "i[3-6]86")
-        set_property (TARGET SVBCameraSDK PROPERTY IMPORTED_LOCATION "libSVBCameraSDK_x86.bin")
-    endif ()
-
-    # Install udev rules
-    if (INDI_INSTALL_UDEV_RULES)
-        set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-        install (FILES 90-svbonyusb.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-    endif()
-
-endif ()
+  # Install udev rules
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 90-svbonyusb.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # install header files
-install (FILES SVBCameraSDK.h DESTINATION include/libsvbony)
+install(FILES SVBCameraSDK.h DESTINATION include/libsvbony)
 
 # Install library
-install_imported (TARGETS SVBCameraSDK DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS SVBCameraSDK DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libsvbonycam/CMakeLists.txt
+++ b/libsvbonycam/CMakeLists.txt
@@ -1,48 +1,71 @@
 cmake_minimum_required(VERSION 3.16)
-project (libsvbonycam)
+project(libsvbonycam)
 
-set (LIBSVBONYCAM_VERSION "57.27348")
-set (LIBSVBONYCAM_SOVERSION "57")
+set(LIBSVBONYCAM_VERSION "57.27348")
+set(LIBSVBONYCAM_SOVERSION "57")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (svbonycam SHARED IMPORTED)
+add_library(svbonycam SHARED IMPORTED)
 
-set_target_properties (svbonycam PROPERTIES VERSION ${LIBSVBONYCAM_VERSION} SOVERSION ${LIBSVBONYCAM_SOVERSION})
+set_target_properties(
+  svbonycam
+  PROPERTIES VERSION ${LIBSVBONYCAM_VERSION} SOVERSION ${LIBSVBONYCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(
+    TARGET svbonycam
+    PROPERTY IMPORTED_LOCATION "mac/libsvbonycam.bin"
+  )
 
-  set_property (TARGET svbonycam PROPERTY IMPORTED_LOCATION "mac/libsvbonycam.bin")
-
-  FIX_MACOS_LIBRARIES("libsvbonycam" "mac/libsvbonycam.bin" "SVBONYCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET svbonycam PROPERTY IMPORTED_LOCATION "armhf/libsvbonycam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET svbonycam PROPERTY IMPORTED_LOCATION "arm64/libsvbonycam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET svbonycam PROPERTY IMPORTED_LOCATION "x64/libsvbonycam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+  fix_macos_libraries("libsvbonycam" "mac/libsvbonycam.bin" "SVBONYCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET svbonycam
+      PROPERTY IMPORTED_LOCATION "armhf/libsvbonycam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET svbonycam
+      PROPERTY IMPORTED_LOCATION "arm64/libsvbonycam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(
+      TARGET svbonycam
+      PROPERTY IMPORTED_LOCATION "x64/libsvbonycam.bin"
+    )
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-svbonycam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-svbonycam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES svbonycam.h DESTINATION include/libsvbonycam)
+install(FILES svbonycam.h DESTINATION include/libsvbonycam)
 
 # Install library
-install_imported (TARGETS svbonycam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS svbonycam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libtoupcam/CMakeLists.txt
+++ b/libtoupcam/CMakeLists.txt
@@ -1,48 +1,62 @@
 cmake_minimum_required(VERSION 3.16)
-project (libtoupcam)
+project(libtoupcam)
 
-set (LIBTOUPCAM_VERSION "59.29176")
-set (LIBTOUPCAM_SOVERSION "59")
+set(LIBTOUPCAM_VERSION "59.29176")
+set(LIBTOUPCAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
-include (InstallImported)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
+include(InstallImported)
 
-add_library (toupcam SHARED IMPORTED)
+add_library(toupcam SHARED IMPORTED)
 
-set_target_properties (toupcam PROPERTIES VERSION ${LIBTOUPCAM_VERSION} SOVERSION ${LIBTOUPCAM_SOVERSION})
+set_target_properties(
+  toupcam
+  PROPERTIES VERSION ${LIBTOUPCAM_VERSION} SOVERSION ${LIBTOUPCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(TARGET toupcam PROPERTY IMPORTED_LOCATION "mac/libtoupcam.bin")
 
-  set_property (TARGET toupcam PROPERTY IMPORTED_LOCATION "mac/libtoupcam.bin")
-
-  FIX_MACOS_LIBRARIES("libtoupcam" "mac/libtoupcam.bin" "TOUPCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET toupcam PROPERTY IMPORTED_LOCATION "armhf/libtoupcam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET toupcam PROPERTY IMPORTED_LOCATION "arm64/libtoupcam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET toupcam PROPERTY IMPORTED_LOCATION "x64/libtoupcam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+  fix_macos_libraries("libtoupcam" "mac/libtoupcam.bin" "TOUPCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(
+      TARGET toupcam
+      PROPERTY IMPORTED_LOCATION "armhf/libtoupcam.bin"
+    )
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(
+      TARGET toupcam
+      PROPERTY IMPORTED_LOCATION "arm64/libtoupcam.bin"
+    )
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(TARGET toupcam PROPERTY IMPORTED_LOCATION "x64/libtoupcam.bin")
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES 99-toupcam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(FILES 99-toupcam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+  endif()
+endif()
 
 # Install header files
-install (FILES toupcam.h DESTINATION include/libtoupcam)
+install(FILES toupcam.h DESTINATION include/libtoupcam)
 
 # Install library
-install_imported (TARGETS toupcam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS toupcam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/libtscam/CMakeLists.txt
+++ b/libtscam/CMakeLists.txt
@@ -1,49 +1,60 @@
 cmake_minimum_required(VERSION 3.16)
-project (libtscam)
+project(libtscam)
 
-set (LIBTSCAM_VERSION "59.29176")
-set (LIBTSCAM_SOVERSION "59")
+set(LIBTSCAM_VERSION "59.29176")
+set(LIBTSCAM_SOVERSION "59")
 
-option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
-include (GNUInstallDirs)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+include(GNUInstallDirs)
 include(CMakeCommon)
-include (InstallImported)
+include(InstallImported)
 
-add_library (tscam SHARED IMPORTED)
+add_library(tscam SHARED IMPORTED)
 
-set_target_properties (tscam PROPERTIES VERSION ${LIBTSCAM_VERSION} SOVERSION ${LIBTSCAM_SOVERSION})
+set_target_properties(
+  tscam
+  PROPERTIES VERSION ${LIBTSCAM_VERSION} SOVERSION ${LIBTSCAM_SOVERSION}
+)
 
-if (APPLE)
+if(APPLE)
+  set_property(TARGET tscam PROPERTY IMPORTED_LOCATION "mac/libtscam.bin")
 
-  set_property (TARGET tscam PROPERTY IMPORTED_LOCATION "mac/libtscam.bin")
-
-  FIX_MACOS_LIBRARIES("libtscam" "mac/libtscam.bin" "TSCAM")
-
-elseif (UNIX AND NOT WIN32)
-
-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
-    set_property (TARGET tscam PROPERTY IMPORTED_LOCATION "armhf/libtscam.bin")
-  elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set_property (TARGET tscam PROPERTY IMPORTED_LOCATION "arm64/libtscam.bin")
-  elseif (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    set_property (TARGET tscam PROPERTY IMPORTED_LOCATION "x64/libtscam.bin")
-  else ()
-    message (FATAL_ERROR "unsupported architecture.")
-  endif ()
+  fix_macos_libraries("libtscam" "mac/libtscam.bin" "TSCAM")
+elseif(UNIX AND NOT WIN32)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "armv+")
+    set_property(TARGET tscam PROPERTY IMPORTED_LOCATION "armhf/libtscam.bin")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set_property(TARGET tscam PROPERTY IMPORTED_LOCATION "arm64/libtscam.bin")
+  elseif(CMAKE_SIZEOF_VOID_P MATCHES "8")
+    set_property(TARGET tscam PROPERTY IMPORTED_LOCATION "x64/libtscam.bin")
+  else()
+    message(FATAL_ERROR "unsupported architecture.")
+  endif()
 
   # Install udev rules
-  if (INDI_INSTALL_UDEV_RULES)
-    set (UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
-    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-tscam.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
-  endif ()
-
-endif ()
+  if(INDI_INSTALL_UDEV_RULES)
+    install(
+      FILES ${CMAKE_CURRENT_SOURCE_DIR}/99-tscam.rules
+      DESTINATION ${UDEVRULES_INSTALL_DIR}
+    )
+  endif()
+endif()
 
 # Install header files
-install (FILES tscam.h DESTINATION include/libtscam)
+install(FILES tscam.h DESTINATION include/libtscam)
 
 # Install library
-install_imported (TARGETS tscam DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install_imported(TARGETS tscam DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/obsolete/indi-ssag/CMakeLists.txt
+++ b/obsolete/indi-ssag/CMakeLists.txt
@@ -1,48 +1,78 @@
 cmake_minimum_required(VERSION 3.16)
-PROJECT(indi_ssag CXX C)
+project(indi_ssag CXX C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 find_package(INDI REQUIRED)
 find_package(USB1 REQUIRED)
 
-set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(INDI_INSTALL_UDEV_RULES "Install UDEV rules" On)
+  if(NOT UDEVRULES_INSTALL_DIR)
+    set(
+      UDEVRULES_INSTALL_DIR
+      "/usr/lib/udev/rules.d"
+      CACHE STRING
+      "Base directory for udev rules"
+    )
+  endif()
+endif()
 
 set(INDI_SSAG_VERSION_MAJOR 1)
 set(INDI_SSAG_VERSION_MINOR 0)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_ssag.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml )
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/indi_ssag.xml.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml
+)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+)
 
-include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-include_directories( ${INDI_INCLUDE_DIR})
-include_directories( ${CFITSIO_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${INDI_INCLUDE_DIR})
+include_directories(${CFITSIO_INCLUDE_DIR})
 
 include(CMakeCommon)
 
-set(indissag_SRCS
-${CMAKE_CURRENT_SOURCE_DIR}/ssagccd.cpp
-${CMAKE_CURRENT_SOURCE_DIR}/openssag_loader.cpp
-${CMAKE_CURRENT_SOURCE_DIR}/openssag.cpp )
+set(
+  indissag_SRCS
+  ${CMAKE_CURRENT_SOURCE_DIR}/ssagccd.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/openssag_loader.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/openssag.cpp
+)
 
-IF (UNITY_BUILD)
-    ENABLE_UNITY_BUILD(indissag indissag_SRCS 10 cpp)
-ENDIF ()
+if(UNITY_BUILD)
+  enable_unity_build(indissag indissag_SRCS 10 cpp)
+endif()
 
 add_executable(indi_ssag_ccd ${indissag_SRCS})
 
-target_link_libraries(indi_ssag_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  indi_ssag_ccd
+  ${INDI_LIBRARIES}
+  ${CFITSIO_LIBRARIES}
+  ${USB1_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-target_link_libraries(indi_ssag_ccd rt)
-endif (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+  target_link_libraries(indi_ssag_ccd rt)
+endif(
+  CMAKE_SYSTEM_NAME MATCHES "Linux"
+  AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm*"
+)
 
-install(TARGETS indi_ssag_ccd RUNTIME DESTINATION bin )
+install(TARGETS indi_ssag_ccd RUNTIME DESTINATION bin)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml DESTINATION ${INDI_DATA_DIR})
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-install(FILES 95-ssag.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml
+  DESTINATION ${INDI_DATA_DIR}
+)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  install(FILES 95-ssag.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 endif()


### PR DESCRIPTION
All our makefiles wanted to install udev rules into /lib on linux, which is not correct, as those files should go into /usr/lib

These issues were found while building the individual packets for arch linux AUR packages, that separate them into different AUR repositories.

Also fixed all cmakelint flags.