### PR TITLE
Fix -Werror=unused-parameter

### DIFF
--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -73,7 +73,7 @@ class min_max_property
 class ArvCamera
 {
   public:
-    ArvCamera(void *camera_device) {}
+    ArvCamera([[maybe_unused]] void *camera_device) {}
     virtual bool connect()      = 0;
     virtual bool disconnect()   = 0;
     virtual bool is_connected() = 0;


### PR DESCRIPTION
I tried to compile the latest master and indi-gige fails with this error:
```
In file included from /build/indi-3rdparty/indi-gige/src/indi_gige.h:26,
                 from /build/indi-3rdparty/indi-gige/src/indi_gige.cpp:29:
/build/indi-3rdparty/indi-gige/src/ArvInterface.h: In constructor 'arv::ArvCamera::ArvCamera(void*)':
/build/indi-3rdparty/indi-gige/src/ArvInterface.h:76:21: error: unused parameter 'camera_device' [-Werror=unused-parameter]
```
So I marked it as maybe_unused. Not sure if this is how you'd fix it but at least with this it compiles again.