### PR TITLE
Fixing Leak in INDI Webcam

### DIFF
--- a/indi-webcam/indi_webcam.cpp
+++ b/indi-webcam/indi_webcam.cpp
@@ -1386,7 +1386,6 @@ bool indi_webcam::grabImage()
         if(webcamStacking)
             addToStack();
         gotAnImageAlready = true;
-        freeMemory();
     }
     else
     {


### PR DESCRIPTION
Using av_frame_free instead of av_free to release FFMpeg frames in INDI Webcam so that FFMpeg releases the memory correctly.  Also adding some additional memory free commands to make the code more robust against leaks.