### PR TITLE
Restore conversion gain and tail light setting for touptek manufactured cameras

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -21,6 +21,7 @@
 
 #include "indi_toupbase.h"
 #include "config.h"
+#include "indiapi.h"
 #include <stream/streammanager.h>
 #include <unordered_map>
 #include <unistd.h>
@@ -253,15 +254,15 @@ bool ToupBase::initProperties()
         /// Conversion Gain
         ///////////////////////////////////////////////////////////////////////////////////
         int nsp = 2;
-        m_GainConversionSP[GAIN_LOW].fill("GAIN_LOW", "Low", ISS_OFF);
-        m_GainConversionSP[GAIN_HIGH].fill("GAIN_HIGH", "High", ISS_OFF);
+        m_ConversionGainSP[GAIN_LOW].fill("GAIN_LOW", "Low", ISS_OFF);
+        m_ConversionGainSP[GAIN_HIGH].fill("GAIN_HIGH", "High", ISS_OFF);
         if (m_Instance->model->flag & CP(FLAG_CGHDR))
         {
-            m_GainConversionSP[GAIN_HDR].fill("GAIN_HDR", "HDR", ISS_OFF);
+            m_ConversionGainSP[GAIN_HDR].fill("GAIN_HDR", "HDR", ISS_OFF);
             ++nsp;
         }
-        m_GainConversionSP.resize(nsp);
-        m_GainConversionSP.fill(getDeviceName(), "TC_CONVERSION_GAIN", "Conversion Gain", CONTROL_TAB, IP_RW,
+        m_ConversionGainSP.resize(nsp);
+        m_ConversionGainSP.fill(getDeviceName(), "TC_CONVERSION_GAIN", "Conversion Gain", CONTROL_TAB, IP_RW,
                                 ISR_1OFMANY, 60, IPS_IDLE);
     }
 
@@ -390,7 +391,7 @@ bool ToupBase::updateProperties()
             defineProperty(m_HeatSP);
 
         if (m_Instance->model->flag & (CP(FLAG_CG) | CP(FLAG_CGHDR)))
-            defineProperty(m_GainConversionSP);
+            defineProperty(m_ConversionGainSP);
 
         if (m_SupportTailLight)
             defineProperty(m_TailLightSP);
@@ -443,7 +444,7 @@ bool ToupBase::updateProperties()
             deleteProperty(m_HeatSP);
 
         if (m_Instance->model->flag & (CP(FLAG_CG) | CP(FLAG_CGHDR)))
-            deleteProperty(m_GainConversionSP);
+            deleteProperty(m_ConversionGainSP);
 
         if (m_SupportTailLight)
             deleteProperty(m_TailLightSP);
@@ -506,7 +507,7 @@ bool ToupBase::Connect()
     {
         int taillight      = 0;
         HRESULT rc         = FP(get_Option(m_Handle, CP(OPTION_TAILLIGHT), &taillight));
-        m_SupportTailLight = SUCCEEDED(rc) ? true : false;
+        m_SupportTailLight = SUCCEEDED(rc);
     }
 
     // Get min/max exposures
@@ -681,12 +682,52 @@ void ToupBase::setupParams()
     // Set trigger mode to software
     rc = FP(put_Option(m_Handle, CP(OPTION_TRIGGER), m_CurrentTriggerMode));
     if (FAILED(rc))
+    {
         LOGF_ERROR("Failed to set software trigger mode. %s", errorCodes(rc).c_str());
+    }
+
+    // Set tail light status
+    int currentTailLightValue, configuredTailLightValue = 0;
+
+    if (m_SupportTailLight)
+    {
+        rc = FP(get_Option(m_Handle, CP(OPTION_TAILLIGHT), &currentTailLightValue));
+        if (FAILED(rc))
+        {
+            LOGF_ERROR("Failed to get camera tail light status. %s", errorCodes(rc).c_str());
+        }
+        configuredTailLightValue = m_TailLightSP.findOnSwitchIndex();
+        if (currentTailLightValue != configuredTailLightValue)
+        {
+            rc = FP(put_Option(m_Handle, CP(OPTION_TAILLIGHT), configuredTailLightValue));
+            if (FAILED(rc))
+            {
+                m_TailLightSP.setState(IPS_ALERT);
+                LOGF_ERROR("Failed to set camera tail light status. %s", errorCodes(rc).c_str());
+                m_TailLightSP.apply();
+            }
+        }
+    }
 
     // Get CCD Controls values
-    int conversionGain = 0;
-    FP(get_Option(m_Handle, CP(OPTION_CG), &conversionGain));
-    m_GainConversionSP[conversionGain].setState(ISS_ON);
+    int currentConversionGain, configuredConversionGain = 0;
+
+    rc = FP(get_Option(m_Handle, CP(OPTION_CG), &currentConversionGain));
+    if (FAILED(rc))
+    {
+        LOGF_ERROR("Failed to get camera gain conversion setting. %s", errorCodes(rc).c_str());
+    }
+    configuredConversionGain = m_ConversionGainSP.findOnSwitchIndex();
+    if (currentConversionGain != configuredConversionGain)
+    {
+        rc = FP(put_Option(m_Handle, CP(OPTION_CG), configuredConversionGain));
+        if (FAILED(rc))
+        {
+            m_ConversionGainSP.setState(IPS_ALERT);
+            LOGF_ERROR("Failed to set camera gain conversion setting. %s", errorCodes(rc).c_str());
+            m_ConversionGainSP.apply();
+        }
+    }
 
     uint16_t nMax = 0, nDef = 0;
     // Gain
@@ -1293,20 +1334,20 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         //////////////////////////////////////////////////////////////////////
         /// Conversion Gain
         //////////////////////////////////////////////////////////////////////
-        if (m_GainConversionSP.isNameMatch(name))
+        if (m_ConversionGainSP.isNameMatch(name))
         {
-            if (m_GainConversionSP.isUpdated(states, names, n))
+            if (m_ConversionGainSP.isUpdated(states, names, n))
             {
-                m_GainConversionSP.update(states, names, n);
-                m_GainConversionSP.setState(IPS_OK);
-                FP(put_Option(m_Handle, CP(OPTION_CG), m_GainConversionSP.findOnSwitchIndex()));
-                m_GainConversionSP.apply();
-                saveConfig(m_GainConversionSP);
+                m_ConversionGainSP.update(states, names, n);
+                m_ConversionGainSP.setState(IPS_OK);
+                FP(put_Option(m_Handle, CP(OPTION_CG), m_ConversionGainSP.findOnSwitchIndex()));
+                m_ConversionGainSP.apply();
+                saveConfig(m_ConversionGainSP);
             }
             else
             {
-                m_GainConversionSP.setState(IPS_OK);
-                m_GainConversionSP.apply();
+                m_ConversionGainSP.setState(IPS_OK);
+                m_ConversionGainSP.apply();
                 return true;
             }
             return true;
@@ -2053,7 +2094,7 @@ bool ToupBase::saveConfigItems(FILE *fp)
         m_TailLightSP.save(fp);
     m_AutoExposureSP.save(fp);
     if (m_Instance->model->flag & (CP(FLAG_CG) | CP(FLAG_CGHDR)))
-        m_GainConversionSP.save(fp);
+        m_ConversionGainSP.save(fp);
     m_BBAutoSP.save(fp);
     if (m_Instance->model->flag & CP(FLAG_HEAT))
         m_HeatSP.save(fp);

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -31,261 +31,261 @@
 
 class ToupBase : public INDI::CCD
 {
-    public:
-        explicit ToupBase(const XP(DeviceV2) *instance, const std::string &name);
-        virtual ~ToupBase() override;
+  public:
+    explicit ToupBase(const XP(DeviceV2) * instance, const std::string &name);
+    virtual ~ToupBase() override;
 
-        virtual const char *getDefaultName() override;
+    virtual const char *getDefaultName() override;
 
-        virtual bool initProperties() override;
-        virtual bool updateProperties() override;
+    virtual bool initProperties() override;
+    virtual bool updateProperties() override;
 
-        virtual bool Connect() override;
-        virtual bool Disconnect() override;
+    virtual bool Connect() override;
+    virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
-        virtual bool StartExposure(float duration) override;
-        virtual bool AbortExposure() override;
+    virtual int SetTemperature(double temperature) override;
+    virtual bool StartExposure(float duration) override;
+    virtual bool AbortExposure() override;
 
-    protected:
-        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+  protected:
+    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
-        // Streaming
-        virtual bool StartStreaming() override;
-        virtual bool StopStreaming() override;
+    // Streaming
+    virtual bool StartStreaming() override;
+    virtual bool StopStreaming() override;
 
-        virtual void TimerHit() override;
-        virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
-        virtual bool UpdateCCDBin(int binx, int biny) override;
+    virtual void TimerHit() override;
+    virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
+    virtual bool UpdateCCDBin(int binx, int biny) override;
 
-        virtual bool SetCaptureFormat(uint8_t index) override;
+    virtual bool SetCaptureFormat(uint8_t index) override;
 
-        // Guide Port
-        virtual IPState GuideNorth(uint32_t ms) override;
-        virtual IPState GuideSouth(uint32_t ms) override;
-        virtual IPState GuideEast(uint32_t ms) override;
-        virtual IPState GuideWest(uint32_t ms) override;
+    // Guide Port
+    virtual IPState GuideNorth(uint32_t ms) override;
+    virtual IPState GuideSouth(uint32_t ms) override;
+    virtual IPState GuideEast(uint32_t ms) override;
+    virtual IPState GuideWest(uint32_t ms) override;
 
-        // ASI specific keywords
-        virtual void addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeywords) override;
+    // ASI specific keywords
+    virtual void addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeywords) override;
 
-        // Save config
-        virtual bool saveConfigItems(FILE *fp) override;
+    // Save config
+    virtual bool saveConfigItems(FILE *fp) override;
 
-    private:
-        enum eGUIDEDIRECTION
-        {
-            TOUPBASE_NORTH,
-            TOUPBASE_SOUTH,
-            TOUPBASE_EAST,
-            TOUPBASE_WEST,
-            TOUPBASE_STOP,
-        };
+  private:
+    enum eGUIDEDIRECTION
+    {
+        TOUPBASE_NORTH,
+        TOUPBASE_SOUTH,
+        TOUPBASE_EAST,
+        TOUPBASE_WEST,
+        TOUPBASE_STOP,
+    };
 
-        enum eTriggerMode
-        {
-            TRIGGER_VIDEO,
-            TRIGGER_SOFTWARE
-        };
+    enum eTriggerMode
+    {
+        TRIGGER_VIDEO,
+        TRIGGER_SOFTWARE
+    };
 
-        //#############################################################################
-        // Capture
-        //#############################################################################
-        void allocateFrameBuffer();
-        timeval m_ExposureEnd;
-        double m_ExposureRequest;
+    //#############################################################################
+    // Capture
+    //#############################################################################
+    void allocateFrameBuffer();
+    timeval m_ExposureEnd;
+    double m_ExposureRequest;
 
-        //#############################################################################
-        // Video Format & Streaming
-        //#############################################################################
-        void getVideoImage();
+    //#############################################################################
+    // Video Format & Streaming
+    //#############################################################################
+    void getVideoImage();
 
-        //#############################################################################
-        // Guiding
-        //#############################################################################
-        IPState guidePulse(INDI::Timer &timer, float ms, eGUIDEDIRECTION dir);
-        const char *toString(eGUIDEDIRECTION dir);
-        void stopGuidePulse(INDI::Timer &timer);
-        // Timers
-        INDI::Timer mTimerNS;
-        INDI::Timer mTimerWE;
+    //#############################################################################
+    // Guiding
+    //#############################################################################
+    IPState guidePulse(INDI::Timer &timer, float ms, eGUIDEDIRECTION dir);
+    const char *toString(eGUIDEDIRECTION dir);
+    void stopGuidePulse(INDI::Timer &timer);
+    // Timers
+    INDI::Timer mTimerNS;
+    INDI::Timer mTimerWE;
 
-        //#############################################################################
-        // Setup & Controls
-        //#############################################################################
-        // Get initial parameters from camera
-        void setupParams();
-        // Create number and switch controls for camera by querying the API
-        void createControls(int piNumberOfControls);
-        // Update control values from camera
-        void refreshControls();
+    //#############################################################################
+    // Setup & Controls
+    //#############################################################################
+    // Get initial parameters from camera
+    void setupParams();
+    // Create number and switch controls for camera by querying the API
+    void createControls(int piNumberOfControls);
+    // Update control values from camera
+    void refreshControls();
 
-        //#############################################################################
-        // Resolution
-        //#############################################################################
-        INDI::PropertySwitch m_ResolutionSP {0};
+    //#############################################################################
+    // Resolution
+    //#############################################################################
+    INDI::PropertySwitch m_ResolutionSP{ 0 };
 
-        //#############################################################################
-        // Misc
-        //#############################################################################
-        // Get the current Bayer string used
-        const char *getBayerString();
+    //#############################################################################
+    // Misc
+    //#############################################################################
+    // Get the current Bayer string used
+    const char *getBayerString();
 
-        bool updateBinningMode(int binx, int mode);
+    bool updateBinningMode(int binx, int mode);
 
-        //#############################################################################
-        // Callbacks
-        //#############################################################################
-        static void eventCB(unsigned event, void* pCtx);
-        void eventCallBack(unsigned event);
+    //#############################################################################
+    // Callbacks
+    //#############################################################################
+    static void eventCB(unsigned event, void *pCtx);
+    void eventCallBack(unsigned event);
 
-        //#############################################################################
-        // Camera Handle & Instance
-        //#############################################################################
-        THAND m_Handle { nullptr };
-        const XP(DeviceV2) *m_Instance;
+    //#############################################################################
+    // Camera Handle & Instance
+    //#############################################################################
+    THAND m_Handle{ nullptr };
+    const XP(DeviceV2) * m_Instance;
 
-        //#############################################################################
-        // Properties
-        //#############################################################################
-        INDI::PropertySwitch m_BinningModeSP {2};
-        typedef enum
-        {
-            TC_BINNING_AVG,
-            TC_BINNING_ADD,
-        } BINNING_MODE;
+    //#############################################################################
+    // Properties
+    //#############################################################################
+    INDI::PropertySwitch m_BinningModeSP{ 2 };
+    typedef enum
+    {
+        TC_BINNING_AVG,
+        TC_BINNING_ADD,
+    } BINNING_MODE;
 
-        INDI::PropertySwitch m_HighFullwellSP {2};
+    INDI::PropertySwitch m_HighFullwellSP{ 2 };
 
-        bool activateCooler(bool enable);
+    bool activateCooler(bool enable);
 
-        INDI::PropertySwitch m_CoolerSP {2};
+    INDI::PropertySwitch m_CoolerSP{ 2 };
 
-        INDI::PropertyNumber m_CoolerNP {1};
+    INDI::PropertyNumber m_CoolerNP{ 1 };
 
-        int32_t m_maxTecVoltage { -1 };
+    int32_t m_maxTecVoltage{ -1 };
 
-        INDI::PropertyNumber m_ControlNP {8};
-        enum
-        {
-            TC_GAIN,
-            TC_CONTRAST,
-            TC_BRIGHTNESS,
-            TC_GAMMA,
-            TC_SPEED,
-            TC_FRAMERATE_LIMIT,
-            TC_HUE,
-            TC_SATURATION
-        };
+    INDI::PropertyNumber m_ControlNP{ 8 };
+    enum
+    {
+        TC_GAIN,
+        TC_CONTRAST,
+        TC_BRIGHTNESS,
+        TC_GAMMA,
+        TC_SPEED,
+        TC_FRAMERATE_LIMIT,
+        TC_HUE,
+        TC_SATURATION
+    };
 
-        // Auto Black Balance
-        INDI::PropertySwitch m_BBAutoSP {1};
+    // Auto Black Balance
+    INDI::PropertySwitch m_BBAutoSP{ 1 };
 
-        INDI::PropertySwitch m_AutoExposureSP {2};
+    INDI::PropertySwitch m_AutoExposureSP{ 2 };
 
-        INDI::PropertyNumber m_BlackBalanceNP {3};
-        enum
-        {
-            TC_BLACK_R,
-            TC_BLACK_G,
-            TC_BLACK_B,
-        };
+    INDI::PropertyNumber m_BlackBalanceNP{ 3 };
+    enum
+    {
+        TC_BLACK_R,
+        TC_BLACK_G,
+        TC_BLACK_B,
+    };
 
-        // Offset (Black Level)
-        INDI::PropertyNumber m_OffsetNP {1};
+    // Offset (Black Level)
+    INDI::PropertyNumber m_OffsetNP{ 1 };
 
-        // R/G/B/Gray low/high levels
-        INDI::PropertyNumber m_LevelRangeNP {8};
-        enum
-        {
-            TC_LO_R,
-            TC_HI_R,
-            TC_LO_G,
-            TC_HI_G,
-            TC_LO_B,
-            TC_HI_B,
-            TC_LO_Y,
-            TC_HI_Y,
-        };
+    // R/G/B/Gray low/high levels
+    INDI::PropertyNumber m_LevelRangeNP{ 8 };
+    enum
+    {
+        TC_LO_R,
+        TC_HI_R,
+        TC_LO_G,
+        TC_HI_G,
+        TC_LO_B,
+        TC_HI_B,
+        TC_LO_Y,
+        TC_HI_Y,
+    };
 
-        // White Balance
-        INDI::PropertyNumber m_WBNP {3};
-        enum
-        {
-            TC_WB_R,
-            TC_WB_G,
-            TC_WB_B,
-        };
+    // White Balance
+    INDI::PropertyNumber m_WBNP{ 3 };
+    enum
+    {
+        TC_WB_R,
+        TC_WB_G,
+        TC_WB_B,
+    };
 
-        // Auto White Balance
-        INDI::PropertySwitch m_WBAutoSP {1};
+    // Auto White Balance
+    INDI::PropertySwitch m_WBAutoSP{ 1 };
 
-        // Fan
-        INDI::PropertySwitch m_FanSP {0};
+    // Fan
+    INDI::PropertySwitch m_FanSP{ 0 };
 
-        // Low Noise
-        INDI::PropertySwitch m_LowNoiseSP {2};
+    // Low Noise
+    INDI::PropertySwitch m_LowNoiseSP{ 2 };
 
-        // Heat
-        INDI::PropertySwitch m_HeatSP {0};
+    // Heat
+    INDI::PropertySwitch m_HeatSP{ 0 };
 
-        // Tail Light
-        INDI::PropertySwitch m_TailLightSP {2};
+    // Tail Light
+    INDI::PropertySwitch m_TailLightSP{ 2 };
 
-        // Camera Info
-        INDI::PropertyText m_CameraTP {7};
-        enum
-        {
-            TC_CAMERA_MODEL,
-            TC_CAMERA_DATE,
-            TC_CAMERA_SN,
-            TC_CAMERA_FW_VERSION,
-            TC_CAMERA_HW_VERSION,
-			TC_CAMERA_FPGA_VERSION,
-            TC_CAMERA_REV
-        };
+    // Camera Info
+    INDI::PropertyText m_CameraTP{ 7 };
+    enum
+    {
+        TC_CAMERA_MODEL,
+        TC_CAMERA_DATE,
+        TC_CAMERA_SN,
+        TC_CAMERA_FW_VERSION,
+        TC_CAMERA_HW_VERSION,
+        TC_CAMERA_FPGA_VERSION,
+        TC_CAMERA_REV
+    };
 
-        // SDK Version
-        INDI::PropertyText m_SDKVersionTP {1};
+    // SDK Version
+    INDI::PropertyText m_SDKVersionTP{ 1 };
 
-        INDI::PropertyNumber  m_ADCDepthNP{1};
+    INDI::PropertyNumber m_ADCDepthNP{ 1 };
 
-        // Timeout factor
-        INDI::PropertyNumber m_TimeoutFactorNP {2};
-        enum
-        {
-            MINIMAL_TIMEOUT,
-            TIMEOUT_FACTOR
-        };
+    // Timeout factor
+    INDI::PropertyNumber m_TimeoutFactorNP{ 2 };
+    enum
+    {
+        MINIMAL_TIMEOUT,
+        TIMEOUT_FACTOR
+    };
 
-        INDI::PropertySwitch m_GainConversionSP {3};
-        enum
-        {
-            GAIN_LOW,
-            GAIN_HIGH,
-            GAIN_HDR
-        };
+    INDI::PropertySwitch m_ConversionGainSP{ 3 };
+    enum
+    {
+        GAIN_LOW,
+        GAIN_HIGH,
+        GAIN_HDR
+    };
 
-        BINNING_MODE m_BinningMode = TC_BINNING_ADD;
-        uint8_t m_CurrentVideoFormat = 0;
-        INDI_PIXEL_FORMAT m_CameraPixelFormat = INDI_RGB;
-        eTriggerMode m_CurrentTriggerMode =
-            TRIGGER_SOFTWARE; /* By default, we start the camera with software trigger mode, make it standby */
+    BINNING_MODE m_BinningMode            = TC_BINNING_ADD;
+    uint8_t m_CurrentVideoFormat          = 0;
+    INDI_PIXEL_FORMAT m_CameraPixelFormat = INDI_RGB;
+    eTriggerMode m_CurrentTriggerMode =
+        TRIGGER_SOFTWARE; /* By default, we start the camera with software trigger mode, make it standby */
 
-        bool m_MonoCamera { false };
-        bool m_SupportTailLight { false };
-        double m_LastTemperature {-100};
-        double m_LastCoolerPower {-1};
-        uint8_t m_BitsPerPixel { 8 };
-        uint8_t m_maxBitDepth { 8 };
-        uint8_t m_Channels { 1 };
+    bool m_MonoCamera{ false };
+    bool m_SupportTailLight{ false };
+    double m_LastTemperature{ -100 };
+    double m_LastCoolerPower{ -1 };
+    uint8_t m_BitsPerPixel{ 8 };
+    uint8_t m_maxBitDepth{ 8 };
+    uint8_t m_Channels{ 1 };
 
-        uint8_t *getRgbBuffer();
-        uint8_t *m_rgbBuffer { nullptr };
-        int32_t m_rgbBufferSize { 0 };
+    uint8_t *getRgbBuffer();
+    uint8_t *m_rgbBuffer{ nullptr };
+    int32_t m_rgbBufferSize{ 0 };
 
-        int m_ConfigResolutionIndex {-1};
+    int m_ConfigResolutionIndex{ -1 };
 
-        INDI::ElapsedTimer m_ExposureTimer;
+    INDI::ElapsedTimer m_ExposureTimer;
 };


### PR DESCRIPTION
Saving of tail light status and conversion gain was implemented previously, but the saved configuration was not applied to the camera on start up.

This commit compares the current camera setting with the one saved by indi, and will apply the configured values as needed.

This removed the necessity, that the user has to apply the setting manually o each startup.

The commit also applies clang-tidy formatting conform to the settings found in the .clang-format file in the repo root.