### PR TITLE
Fixed case typo in inactive weather check

### DIFF
--- a/debian/indi-ocs/changelog
+++ b/debian/indi-ocs/changelog
@@ -1,3 +1,7 @@
+indi-ocs (1.4) nobel; urgency=medium
+
+  * New release - Corrected inactive weather measurement check added incorrectly in V1.1
+
 indi-ocs (1.3) nobel; urgency=medium
 
   * New release - fix for park state and typo

--- a/debian/indi-ocs/copyright
+++ b/debian/indi-ocs/copyright
@@ -1,6 +1,6 @@
 Copyright: 
 
-    Copyright 2024 Ed Lee <ed@thefamilee.co.uk>
+    Copyright 2025 Ed Lee <ed@thefamilee.co.uk>
     
 
 License:

--- a/indi-ocs/CMakeLists.txt
+++ b/indi-ocs/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules/")
 include(GNUInstallDirs)
 
 set(INDI_OCS_VERSION_MAJOR 1)
-set(INDI_OCS_VERSION_MINOR 3)
+set(INDI_OCS_VERSION_MINOR 4)
 
 find_package(INDI REQUIRED)
 find_package(Nova REQUIRED)

--- a/indi-ocs/README.txt
+++ b/indi-ocs/README.txt
@@ -1,24 +1,30 @@
-Observatory Control System (OCS) Indi Driver V1.1
+Observatory Control System (OCS) Indi Driver V1.4
 -------------------------------------------------
 
 An Indi driver for the OCS (https://onstep.groups.io/g/onstep-ocs/wiki)
-
   Copyright (C) 2023-2025 Ed Lee
 
-Version 1.1
+Version 1.4
+    Corrected inactive weather measurement check added incorrectly in V1.1
 
-Added OCS command protocol change on inactive weather measurements - OCS v3.08a
-Fixed weather measurement polling
-Fixed typo in network connection timeout value
-Fixed arbitary command debug blocks
-Added command/response blocking to prevent out-of-order value updates
-Refactored some if-else ladders to switch cases
-Added debug option for pausing to allow remote debugger to attach
-Tested with OCS v3.09f
+Version 1.3
+    Fix for park state and typo
+
+Version 1.2
+    Added shutter control on park / unpark options and fixed Dome Az slaving.
+
+Version 1.1
+    Added OCS command protocol change on inactive weather measurements - OCS v3.08a
+    Fixed weather measurement polling
+    Fixed typo in network connection timeout value
+    Fixed arbitary command debug blocks
+    Added command/response blocking to prevent out-of-order value updates
+    Refactored some if-else ladders to switch cases
+    Added debug option for pausing to allow remote debugger to attach
+    Tested with OCS v3.09f
 
 Version 1.0
     First release
 
 Version 0.1
-
     Initial test release

--- a/indi-ocs/indi_ocs.xml.cmake
+++ b/indi-ocs/indi_ocs.xml.cmake
@@ -3,7 +3,7 @@
 <devGroup group="Domes">
     <device label="OCS" manufacturer="Other">
         <driver name="OCS">indi_ocs</driver>
-        <version>1.3</version>
+        <version>1.4</version>
     </device>
 </devGroup>
 </driversList>

--- a/indi-ocs/ocs.cpp
+++ b/indi-ocs/ocs.cpp
@@ -65,7 +65,7 @@ OCS::OCS() : INDI::Dome(), WI(this)
     // kill(getpid(), SIGSTOP);
     // Debug only end
 
-    setVersion(1, 3);
+    setVersion(1, 4);
     SetDomeCapability(DOME_CAN_ABORT | DOME_HAS_SHUTTER);
     SlowTimer.callOnTimeout(std::bind(&OCS::SlowTimerHit, this));
 }
@@ -346,7 +346,7 @@ void OCS::GetCapabilites()
         int measurement_error_or_fail = getCommandSingleCharErrorOrLongResponse(PortFD, measurement_reponse,
                                                                                 measurement_command);
         if (measurement_error_or_fail > 1 && strcmp(measurement_reponse, "N/A") != 0 &&
-            strcmp(measurement_reponse, "NAN") != 0 && strcmp(measurement_reponse, "0") != 0) {
+            strcmp(measurement_reponse, "nan") != 0 && strcmp(measurement_reponse, "0") != 0) {
             weather_enabled[measurement] = 1;
         } else {
             weather_enabled[measurement] = 0;


### PR DESCRIPTION
A minor update to correct a case typo ("NAN" instead of "nan") in the checks for inactive weather devices.
Bumps driver to V1.4