### PR TITLE
fix typo in function identifiers

### DIFF
--- a/indi-eqmod/ahp-gt/ahpgtbase.cpp
+++ b/indi-eqmod/ahp-gt/ahpgtbase.cpp
@@ -195,12 +195,12 @@ bool AHPGTBase::updateProperties()
         GTDEConfigurationNP[GT_MOTOR_TEETH].setValue(ahp_gt_get_motor_teeth(1));
         GTDEConfigurationNP[GT_WORM_TEETH].setValue(ahp_gt_get_worm_teeth(1));
         GTDEConfigurationNP[GT_CROWN_TEETH].setValue(ahp_gt_get_crown_teeth(1));
-        GTDEConfigurationNP[GT_MAX_SPEED].setValue(get_max_speed(1));
-        GTDEConfigurationNP[GT_ACCELERATION].setValue(get_acceleration_angle(1) * 180.0 / M_PI);
+        GTDEConfigurationNP[GT_MAX_SPEED].setValue(ahp_gt_get_max_speed(1));
+        GTDEConfigurationNP[GT_ACCELERATION].setValue(ahp_gt_get_acceleration_angle(1) * 180.0 / M_PI);
         GTDEConfigurationNP.apply();
         for(int x = 0; x < GT_N_MOUNT_CONFIG; x++)
             GTMountConfigSP[x].setState(ISS_OFF);
-        int fork = (get_mount_flags() & isForkMount) ? 1 : 0;
+        int fork = (ahp_gt_get_mount_flags() & isForkMount) ? 1 : 0;
         int azeq = 0;
         azeq |= ((ahp_gt_get_features(0) & isAZEQ) != 0) ? 1 : 0;
         azeq |= ((ahp_gt_get_features(1) & isAZEQ) != 0) ? 1 : 0;


### PR DESCRIPTION
I encountered the same error as in https://github.com/indilib/indi-3rdparty/issues/1058#issuecomment-2833586854 when building packages for Gentoo Linux. From my point of view the prefix `ahp_gt_` is missing for the identifiers `get_max_speed`, `get_acceleration_angle` and `get_mount_flags`. At least for `get_max_speed` I couldn't find any reference to such an identifier before the introducing commit d66bc05c26d3bd571db402495ef3611d36c454f1.

Please check this patch carefully is I cannot judge whether the prefix was dropped in d66bc05c26d3bd571db402495ef3611d36c454f1. At least with the patch, the code builds again.