### PR TITLE
link ASI drivers against system libhidapi instead of hidapi statically linked into the precompiled SDK

### DIFF
--- a/indi-asi/CMakeLists.txt
+++ b/indi-asi/CMakeLists.txt
@@ -12,6 +12,20 @@ find_package(ZLIB REQUIRED)
 find_package(USB1 REQUIRED)
 find_package(Threads REQUIRED)
 
+if(INDI_HIDAPILIB)
+    set(HIDAPILIB "")
+    message(STATUS "Using indi bundled hid library")
+else(INDI_HIDAPILIB)
+    # We need to explicitly link against libhidapi-libusb, as the ASI driver
+    # libraries are linked statically against libhidapi-hidraw, which is the
+    # wrong backend in our case. The hidapi library must be linked prior to
+    # the ASI libraries to get priority during symbol resolution.
+    find_package(hidapi REQUIRED)
+    add_definitions(-D_USE_SYSTEM_HIDAPILIB)
+    set(HIDAPILIB -Wl,--push-state,--no-as-needed hidapi::libusb -Wl,--pop-state)
+    message(STATUS "Using system provided hid library")
+endif(INDI_HIDAPILIB)
+
 set(ASI_VERSION_MAJOR 2)
 set(ASI_VERSION_MINOR 6)
 
@@ -35,7 +49,7 @@ set(indi_asi_SRCS
    )
 
 add_executable(indi_asi_ccd ${indi_asi_SRCS})
-target_link_libraries(indi_asi_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_ccd ${INDI_LIBRARIES} ${HIDAPILIB} ${CFITSIO_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
 ########### indi_asi_single_ccd ###########
 set(indi_asi_single_SRCS
@@ -45,60 +59,60 @@ set(indi_asi_single_SRCS
    )
 
 add_executable(indi_asi_single_ccd ${indi_asi_single_SRCS})
-target_link_libraries(indi_asi_single_ccd ${INDI_LIBRARIES} ${CFITSIO_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_single_ccd ${INDI_LIBRARIES} ${HIDAPILIB} ${CFITSIO_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
 ########### indi_asi_wheel ###########
 add_executable(indi_asi_wheel ${CMAKE_CURRENT_SOURCE_DIR}/asi_wheel.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(indi_asi_wheel ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
+target_link_libraries(indi_asi_wheel ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
 ELSE()
-target_link_libraries(indi_asi_wheel ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_wheel ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 ########### indi_asi_st4 ###########
 add_executable(indi_asi_st4 ${CMAKE_CURRENT_SOURCE_DIR}/asi_st4.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(indi_asi_st4 ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
+target_link_libraries(indi_asi_st4 ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
 ELSE()
-target_link_libraries(indi_asi_st4 ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_st4 ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 ########### indi_asi_focuser ###########
 add_executable(indi_asi_focuser ${CMAKE_CURRENT_SOURCE_DIR}/asi_focuser.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(indi_asi_focuser ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
+target_link_libraries(indi_asi_focuser ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
 ELSE()
-target_link_libraries(indi_asi_focuser ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_focuser ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 ########### indi_asi_rotator ###########
 add_executable(indi_asi_rotator ${CMAKE_CURRENT_SOURCE_DIR}/asi_rotator.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(indi_asi_rotator ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
+target_link_libraries(indi_asi_rotator ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})
 ELSE()
-target_link_libraries(indi_asi_rotator ${INDI_LIBRARIES} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(indi_asi_rotator ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 ########### asi_camera_test ###########
 add_executable(asi_camera_test ${CMAKE_CURRENT_SOURCE_DIR}/asi_camera_test.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(asi_camera_test ${ASI_LIBRARIES} ${USB1_LIBRARIES})
+target_link_libraries(asi_camera_test ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES})
 ELSE()
-target_link_libraries(asi_camera_test ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(asi_camera_test ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 ########### asi_multi_camera_test ###########
 add_executable(asi_multi_camera_test ${CMAKE_CURRENT_SOURCE_DIR}/asi_multi_camera_test.cpp)
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
-target_link_libraries(asi_multi_camera_test ${ASI_LIBRARIES} ${USB1_LIBRARIES})
+target_link_libraries(asi_multi_camera_test ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES})
 ELSE()
-target_link_libraries(asi_multi_camera_test ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(asi_multi_camera_test ${HIDAPILIB} ${ASI_LIBRARIES} ${USB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 ENDIF()
 
 #####################################


### PR DESCRIPTION
`libasi` ships precompiled libraries which contains a statically linked `libhidapi-hidraw`. When linking INDI against the system provided `libhidapi` the `hidapi`-library of the ASI SDK instead of the system libraries. Unfortunately the ASI SDK tries to access the devices via `hidraw`-devices, whereas INDI requires access via direct USB access with `libusb`.

For a detailed explanation see https://github.com/hamarituc/gentoo-overlay/issues/17#issuecomment-3536129335