### PR TITLE
fix indi-libcamera for rpicam-apps 1.10.1

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -90,7 +90,11 @@ INDILibCamera::INDILibCamera(uint8_t index, const libcamera::ControlList &list) 
 {
     setVersion(LIBCAMERA_VERSION_MAJOR, LIBCAMERA_VERSION_MINOR);
     signal(SIGBUS, default_signal_handler);
-    auto fullName = std::string("LibCamera ") + list.get(properties::Model).value() + "-" + std::to_string(index);
+    auto model = list.get(properties::Model).value();
+    auto fullName = std::string("LibCamera ")
+              + std::string(model)
+              + "-"
+              + std::to_string(index);
     setDeviceName(fullName.c_str());
 }
 


### PR DESCRIPTION
list.get(properties::Model).value() returns a std::string_view, not a std::string.

Fixes https://github.com/indilib/indi-3rdparty/issues/1220