### PR TITLE
indi-libcamera: add gain to fits header

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -956,7 +956,7 @@ bool INDILibCamera::UpdateCCDBin(int binx, int biny)
 void INDILibCamera::addFITSKeywords(INDI::CCDChip * targetChip, std::vector<INDI::FITSRecord> &fitsKeywords)
 {
     INDI::CCD::addFITSKeywords(targetChip, fitsKeywords);
-    // TODO Add Gain
+    fitsKeywords.push_back({"GAIN", GainNP[0].getValue(), 3, "Gain"});
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is still pretty much the raw value that we send to libcamera, and doesn't fully represent the actual gain in dB

<img width="745" height="494" alt="image" src="https://github.com/user-attachments/assets/7a62ebd6-2126-4d3a-981c-717f2da997d1" />
