### PR TITLE
Add verbose indi libcamera logs

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -635,7 +635,6 @@ bool INDILibCamera::updateProperties()
 /////////////////////////////////////////////////////////////////////////////
 void INDILibCamera::configureStillOptions(StillOptions *options, double duration)
 {
-    auto us = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::duration<double>(duration * 1000000));
     TimeVal<std::chrono::microseconds> tv;
     tv.set(std::to_string(duration) + "s");
 


### PR DESCRIPTION
It gives us some additional logs to use, such as:

```
2026-01-02T17:18:33: Driver indi_libcamera_ccd: Available controls:
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     Contrast : [0.000000..32.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeEnable : [false..true]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     Sharpness : [0.000000..16.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeFlickerPeriod : [100..1000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AnalogueGain : [1.000000..29.512093]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ColourTemperature : [100..100000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeFlickerMode : [0..1]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ExposureTimeMode : [0..1]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     CnnEnableInputTensor : [false..true]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ColourGains : [0.000000..32.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeExposureMode : [0..3]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     NoiseReductionMode : [0..4]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ExposureValue : [-8.000000..8.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeConstraintMode : [0..3]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     Brightness : [-1.000000..1.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AwbMode : [0..7]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     Saturation : [0.000000..32.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     StatsOutputEnable : [false..true]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     SyncFrames : [1..1000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     SyncMode : [0..2]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     FrameDurationLimits : [16666..115687148]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ExposureTime : [14..115686258]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AeMeteringMode : [0..3]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ScalerCrop : [(0, 0)/64x64..(0, 0)/1920x1080]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     HdrMode : [0..4]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AwbEnable : [false..true]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     ColourCorrectionMatrix : [0.000000..8.000000]
2026-01-02T17:18:33: Driver indi_libcamera_ccd:     AnalogueGainMode : [0..1]
```