### PR TITLE
Fixes installation dependency error for indi-gpio

### DIFF
--- a/debian/indi-gpio/control
+++ b/debian/indi-gpio/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.1
 
 Package: indi-gpio
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libgpiod2
+Depends: ${shlibs:Depends}, ${misc:Depends}, libgpiod2 | libgpiod3
 Description: INDI Driver for GPIOD
  INDI Driver for Boards with GPIOs to read digital inputs and toggle digital outputs.
  This driver is compatible with any INDI client.


### PR DESCRIPTION
indi-gpio requires libgpiod2 at installation, while newer distributions provide libgpiod3 instead.
This fixes dependency issue on newer distributions i.e. debian trixie.