### PR TITLE
indi-libcamera: set correct exposure time in FITs header

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -872,6 +872,7 @@ bool INDILibCamera::ISNewSwitch(const char *dev, const char *name, ISState * sta
 bool INDILibCamera::StartExposure(float duration)
 {
     Streamer->setPixelFormat(CaptureFormatSP.findOnSwitchIndex() == CAPTURE_JPG ? INDI_JPG : INDI_RGB);
+    PrimaryCCD.setExposureDuration(duration);
     m_Worker.start(std::bind(&INDILibCamera::workerExposure, this, std::placeholders::_1, duration));
     return true;
 }


### PR DESCRIPTION
Fixes the incorrect exposure time in the FITs, as I mentioned [here](https://github.com/indilib/indi-3rdparty/issues/1105#issuecomment-3734333546). Fixes that the exposure time is always reported as 0s.

<img width="745" height="494" alt="image" src="https://github.com/user-attachments/assets/60e61386-8ea1-4916-817d-6f999510566f" />
