### PR TITLE
Tweak GAIN_STEPS calculation in celestronaux.h

### DIFF
--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -482,8 +482,17 @@ class CelestronAUX :
         static constexpr double STEPS_PER_HOUR {STEPS_PER_REVOLUTION / 24.0};
         static constexpr double HOURS_PER_STEP {24.0 / STEPS_PER_REVOLUTION};
 
-        // Measured rate that would result in 1 step/sec
-        static constexpr uint32_t GAIN_STEPS {80};
+        // Measured rate that would result in 1 step/sec - only approximate
+        // static constexpr uint32_t GAIN_STEPS {80};
+        
+        // Rate based on geometric analysis and testing against SkySafari 7, simulator and real mount:
+        // Logical unit for guiding commands is 1/1024 arcsec/sec.
+        // Steps per arcsecond = 16777216 / (360 * 3600) = 16777216 / 1296000
+        // Scaling Factor (Units -> Steps/sec) = (1/1024) * (16777216 / 1296000)
+        // Factor = 16777216 / (1024 * 1296000) = 16777216 / 1327104000
+        // Simplified Rational Factor = 128 / 10125
+        // Steps/sec = Value * (128 / 10125) = Value * 79.1015625
+        static constexpr double GAIN_STEPS {128 / 10125.0};
 
         // MC_SET_POS_GUIDERATE & MC_SET_NEG_GUIDERATE use 24bit number rate in
         static constexpr uint8_t RATE_PER_ARCSEC {4};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -490,9 +490,9 @@ class CelestronAUX :
         // Steps per arcsecond = 16777216 / (360 * 3600) = 16777216 / 1296000
         // Scaling Factor (Units -> Steps/sec) = (1/1024) * (16777216 / 1296000)
         // Factor = 16777216 / (1024 * 1296000) = 16777216 / 1327104000
-        // Simplified Rational Factor = 128 / 10125
-        // Steps/sec = Value * (128 / 10125) = Value * 79.1015625
-        static constexpr double GAIN_STEPS {128 / 10125.0};
+        // Simplified Rational Factor = 10125 / 128
+        // Steps/sec = Value * (10125 / 128) = Value * 79.1015625
+        static constexpr double GAIN_STEPS {10125.0 / 128};
 
         // MC_SET_POS_GUIDERATE & MC_SET_NEG_GUIDERATE use 24bit number rate in
         static constexpr uint8_t RATE_PER_ARCSEC {4};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -488,8 +488,8 @@ class CelestronAUX :
         // Rate based on geometric analysis and testing against SkySafari 7, simulator and real mount:
         // Logical unit for guiding commands is 1/1024 arcsec/sec.
         // Steps per arcsecond = 16777216 / (360 * 3600) = 16777216 / 1296000
-        // Scaling Factor (Units -> Steps/sec) = (1/1024) * (16777216 / 1296000)
-        // Factor = 16777216 / (1024 * 1296000) = 16777216 / 1327104000
+        // Scaling Factor (Units -> Steps/sec) = 1024 * (1296000 / 16777216)
+        // Factor = (1024 * 1296000) / 16777216  = 1327104000 / 16777216
         // Simplified Rational Factor = 10125 / 128
         // Steps/sec = Value * (10125 / 128) = Value * 79.1015625
         static constexpr double GAIN_STEPS {10125.0 / 128};


### PR DESCRIPTION
Updated GAIN_STEPS to a new calculation based on geometric analysis and testing.

Rate based on geometric analysis and testing against SkySafari 7, simulator and real mount:
// Logical unit for guiding commands is 1/1024 arcsec/sec.
// Steps per arcsecond = 16777216 / (360 * 3600) = 16777216 / 1296000
// Scaling Factor (Units -> Steps/sec) = 1024 * (1296000 / 16777216)
// Factor = (1024 * 1296000) / 16777216  = 1327104000 / 16777216
 // Simplified Rational Factor = 10125 / 128
 // Steps/sec = Value * (10125 / 128) = Value * 79.1015625

The previous approximate measured value (80) - led to a small drift of ~10'/h
The correction makes this go away. 

This is tested agains SS7, unfortunately the wheather prohibits teting ATM - thus WIP designator.

I will report as soon as I get the data.