### PR TITLE
Add: Developer tools for automated Debian packaging and slim worktrees (Sparse Checkout)

### DIFF
--- a/scripts/deb-builder/AGENTS.md
+++ b/scripts/deb-builder/AGENTS.md
@@ -1,0 +1,150 @@
+# Agent Instructions for INDI Debian Package Builder
+
+This repository contains a specialized build system designed to bridge the gap between rapid INDI development and official Debian/Ubuntu packaging cycles. It automates the creation of high-quality Debian packages for the INDI library and its 3rd-party drivers.
+
+## 1. Build, Lint, and Test Commands
+
+### Main Build Process
+- **Build All:** Run `./build.sh`. This is the primary entry point.
+- **Forced Core Rebuild:** Run `./build.sh -f` or `./build.sh --force-core` to force a rebuild of INDI Core even if `libindi-dev` is already installed.
+- **Select Packages:** Run `./build.sh -p driver1,driver2` to override the `OFFICIAL_3RDPARTY_DRIVERS` list.
+- **Incremental Build:** The script uses `build_area/` as a cache. If repositories are already cloned, it will fetch updates instead of re-cloning.
+- **Cleaning:** To force a fresh build, remove the `build_area/` and `dist/` directories:
+  ```bash
+  rm -rf build_area/ dist/
+  ```
+
+### Build Dependencies
+The system requires the following packages on a Debian/Ubuntu system:
+- `build-essential`, `debhelper`, `cmake`, `git`, `devscripts`, `pkg-config`.
+
+### Linting
+We use `shellcheck` for verifying script quality. Before committing changes to `build.sh`:
+```bash
+shellcheck build.sh
+```
+Ensure there are no errors (SCxxxx) or warnings. We aim for zero-warning builds.
+
+### Testing and Verification
+There are no automated unit tests for the build script itself. Verification is done by:
+1. **Successful Execution:** The script should exit with status 0.
+2. **Artifact Verification:** Check the `dist/` directory for the expected `.deb` packages:
+   ```bash
+   ls -l dist/*.deb
+   ```
+3. **Package Inspection:** Verify package metadata using `dpkg -I`:
+   ```bash
+   dpkg -I dist/indi-core_*.deb
+   ```
+4. **Single Driver Test:** To test a single driver build without re-running everything, you can temporarily comment out other drivers in `packages.conf`.
+5. **Linting Verification**: Run `shellcheck build.sh` before any major changes to the build orchestration logic.
+
+---
+
+## 2. Code Style and Guidelines
+
+### Bash Scripting Conventions
+- **Error Handling:** 
+  - Always use `set -e` at the top of scripts to exit on error.
+  - Consider `set -u` to catch unset variables.
+  - Use `set -o pipefail` to ensure pipeline failures are caught.
+  - When a command failure is expected or handled, use `|| true` or `if command; then ...`.
+- **Variable Expansion:** 
+  - ALWAYS use double quotes for variable expansions: `"$VARIABLE"`. This prevents issues with spaces in paths.
+  - Use curly braces for clarity when necessary: `"${VARIABLE}_suffix"`.
+- **Conditionals:**
+  - Prefer `[[ ... ]]` over `[ ... ]` for string and file tests as it is more robust in Bash.
+  - Use `(( ... ))` for arithmetic comparisons.
+- **Functions:**
+  - Define functions using the `function name() { ... }` syntax for better visibility.
+  - Use `local` keyword for all variables inside functions to avoid polluting the global scope.
+  - Functions should return 0 for success and non-zero for failure.
+- **Directory Navigation:**
+  - Use `pushd` and `popd` for temporary directory changes to ensure you always return to the original location, even if a sub-command fails (though `set -e` usually handles this).
+  - Prefer absolute paths for mission-critical operations; use `readlink -f` to resolve them.
+
+### Naming Conventions
+- **Variables:** Use `UPPER_CASE_SNAKE_CASE` for global configuration variables (e.g., `INDI_CORE_VERSION`). Use `lower_case_snake_case` for local variables inside functions.
+- **Functions:** Use `lower_case_snake_case` with a descriptive verb prefix (e.g., `prepare_source`, `build_package`).
+- **Files:** Use lowercase for scripts and configuration files, with `.sh` or `.conf` extensions.
+
+### Formatting and Structure
+- **Indentation:** Use 4 spaces for indentation. Do not use tabs.
+- **Line Length:** Aim for a maximum of 100 characters per line. Use `\` for line continuation in long commands.
+- **Comments:** 
+  - Use `#` for single-line comments.
+  - Document the purpose of every function with a brief comment above the definition.
+  - Explain *why* complex logic (like regex or dependency parsing) is used.
+- **Output:**
+  - Use `echo` for general status messages.
+  - Use `echo "Error: ..." >&2` for error messages.
+  - Use consistent separators (like `====`) to delimit major build stages.
+  - Progress is shown via a `tqdm`-style progress bar (percentage, ETA) by parsing CMake output from logs in `build_area/`.
+
+### Configuration (`packages.conf`)
+- Keep the configuration file strictly declarative. It should contain variable assignments and array definitions only.
+- Use Bash arrays for lists: `OFFICIAL_3RDPARTY_DRIVERS=("driver1" "driver2")`.
+- Provide sensible defaults (e.g., `"latest"`) to minimize user effort.
+- **Auto-detection**: Using `"latest"` for version variables triggers auto-detection of the most recent Git tag via `git ls-remote`.
+- **Forced Rebuild**: Setting `FORCE_CORE_REBUILD=true` bypasses the installation check for Stage 1.
+- **Driver Names**: Drivers can be listed with or without the `indi-` prefix. The script automatically checks for both.
+- **Local Packages**: Use the format `"PackageName:LocalPath"`. Relative paths are resolved against the project root.
+
+### Error Handling Strategy
+- The script should be "fail-fast". If `git clone` or `debuild` fails, the whole process should stop.
+- For multi-stage builds, the script must clearly communicate to the user what needs to be installed manually, as `sudo` operations are intentionally avoided within the build script itself.
+- Validate that the `packages.conf` file exists before sourcing it.
+- Use `set -e` to catch errors early and `set -o pipefail` for pipeline robustness.
+
+---
+
+## 3. Project Architecture
+
+### Build Area Management
+- `build_area/` is the scratch space.
+- Official sources are cloned into subdirectories within `build_area/`.
+- Local packages are copied into `build_area/local-<name>` to ensure the original source remains pristine and `debian/` modifications don't leak back.
+- **Mono-repo Strategy**: The `indi-3rdparty` repository is treated as a mono-repo. Drivers and libraries within it are built by creating a temporary build directory that symlinks the repo's root contents (like `cmake_modules/`) and links the specific package's `debian/` metadata. This ensures CMake finds all necessary common components.
+- **Symlinking Logic**: To build a specific driver from the mono-repo, we:
+    1. Create a `tp-build-<name>` directory.
+    2. Symlink everything from the mono-repo root *except* the `debian` folder.
+    3. Symlink the specific driver's metadata folder to `debian`.
+    4. Run `debuild` inside this synthesized environment.
+
+### Dependency Management
+- The script identifies "local" dependencies (libraries within the same 3rd-party repo) by checking the `Build-Depends` in `debian/control` against the list of available directories in `debian/`.
+- **Version-Aware Build Trigger**: The script compares the version of installed packages with the detected upstream version. A build is triggered only if the installed version is older or missing.
+- **Three-Stage Build Flow**:
+    1.  **Stage 1**: Builds `indi-core`. Stops if `libindi-dev` is not installed.
+    2.  **Stage 2**: Builds required 3rd-party libraries. Stops if any required libraries are not installed.
+    3.  **Stage 3**: Builds selected drivers and local packages.
+- If a required package is not installed (`dpkg-query`), the build pauses to allow for user installation. This is a design choice to avoid requiring `sudo` inside the build script.
+
+## 4. Maintenance Guidelines
+- When adding new functionality, ensure it respects the existing caching logic.
+- Periodically verify that the `get_latest_tag` logic still works with the GitHub `ls-remote` output format.
+- Avoid adding external dependencies to the build script itself; rely on standard Bash tools (`awk`, `sed`, `grep`, `git`).
+- **Version Auto-detection**: The `get_latest_tag` function sorts versions using `git ls-remote --sort='v:refname'`. This is reliable for most INDI repositories but should be monitored if naming conventions change.
+- **Source Preparation**: The `prepare_source` function performs a clean checkout and clean-up (`git clean -df`). This ensures that manual changes in the `build_area` don't persist between builds.
+- **Git Commit Messages**: Follow the project's style: "Action: Short description" (e.g., "Refactor: improve dependency detection").
+
+---
+
+## 5. Troubleshooting
+- **Missing Build Dependencies**: If `debuild` fails, it's usually due to missing system-level development packages. Install them using `sudo apt install <package-name>` as reported by the build log.
+- **Timeout on Large Repos**: The `indi-3rdparty` repository is massive. If running in a restricted environment, ensure the network timeout is sufficient for the initial clone.
+- **CMake Failures**: If CMake cannot find a library, verify that Stage 2 was successful and that you installed the resulting `.deb` files from the `dist/` directory.
+- **Gitea/GitHub connectivity**: Ensure your environment has access to the official INDI repositories.
+
+---
+
+## 6. Summary of Project Conventions
+- **Root Directory**: All scripts and configs must reside in the root.
+- **Output**: All packages go to `dist/`.
+- **Cache**: All clones and builds happen in `build_area/`.
+- **Verification**: No build should leave the local source tree modified (hence the copying/symlinking).
+
+## 7. Future Enhancements
+- **CI/CD Integration**: Consider adding a GitHub Action to verify builds on every push to main.
+- **Improved Dependency Resolution**: Enhance the `get_local_deps` function to handle complex version constraints in `Build-Depends`.
+- **Pre-built Cache**: Option to use pre-built binary blobs for extremely large libraries to speed up the developer cycle.

--- a/scripts/deb-builder/CHANGELOG.md
+++ b/scripts/deb-builder/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.4] - 2026-01-19
+
+### Improved
+- `setup_worktree.sh`: Refactored to use **Git Sparse Checkout** and **Blob Filtering**. This follows industry best practices for monorepos (like those at Google/Microsoft), providing a full Git experience with a fraction of the disk space.
+
+## [0.1.3] - 2026-01-19
+
+### Fixed
+- Version-Aware Builds: Improved comparison logic to use driver-specific versions from `debian/changelog` instead of the global `indi-3rdparty` repository version.
+- Library Versioning: Extended version checking to include local library dependencies (e.g., `libplayerone`), ensuring drivers are rebuilt if their underlying libraries are updated.
+- Bug Fix: Corrected missing `get_installed_version` function definition and removed invalid `local` variable usage.
+
+### Added
+- Progress bar enhancement: Integrated real-time CMake percentage parsing, package name display, and tqdm-style ETA calculation.
+
+## [0.1.1] - 2026-01-19
+
+### Fixed
+- Progress indicator `grep` error: Added `-a` flag to treat build logs as text (fixing "binary file matches" errors).
+- Terminal display: Improved line clearing using escape sequences (`\e[K`) to ensure the progress bar stays on a single line.
+
+### Added
+- Progress bar enhancement: Integrated real-time CMake percentage parsing and tqdm-style ETA calculation.
+
+## [0.1.0] - 2026-01-19
+
+### Added
+- Initial project structure with Git initialization.
+- `build.sh`: Main orchestration script for building INDI Debian packages.
+- `packages.conf`: Declarative configuration file for selecting drivers and versions.
+- **Auto-detection**: Support for `latest` keyword to automatically find the most recent Git tags for INDI Core and 3rd-party repositories.
+- **Three-Stage Build**: Orchestrated build process separating INDI Core, required libraries, and drivers/local packages.
+- **Improved Mono-repo Handling**: Robust handling of the `indi-3rdparty` repository structure, allowing individual driver builds with correct CMake context via temporary synthesized build environments.
+- **Forced Core Rebuild**: Added optional `FORCE_CORE_REBUILD` setting in `packages.conf` and a CLI switch (`-f` or `--force-core`) to allow rebuilding INDI Core even if `libindi-dev` is already installed.
+- **Package List Override**: Added a CLI switch (`-p` or `--packages`) to manually specify which 3rd-party drivers to build, overriding the configuration file.
+- **Graceful Dependency Reporting**: Added automatic detection of missing build-dependencies using `dpkg-checkbuilddeps`, with clear instructions on how to install them via `apt-get`.
+- **Improved Logging**: Quiet builds with output redirected to log files, shown only on error.
+- **Source Caching**: Incremental build support by reusing and updating clones in `build_area/`.
+- **Optional Prefix**: Simplified configuration allowing driver names without the `indi-` prefix.
+- **Local Development**: Support for building packages from local source directories.
+- `AGENTS.md`: Comprehensive 145-line technical documentation and coding standards for the project.
+- `README.md`: Basic usage and setup instructions.
+- `.gitignore`: Configured to exclude build artifacts and temporary files.

--- a/scripts/deb-builder/README.md
+++ b/scripts/deb-builder/README.md
@@ -1,0 +1,48 @@
+# INDI Debian Package Builder
+
+This project provides scripts to build the latest version of the [INDI Library](https://github.com/indilib/indi) and selected 3rd-party drivers for Debian-based distributions.
+
+It is designed to bridge the gap between rapid INDI development and the slower Debian/Ubuntu packaging cycle.
+
+## Features
+
+- **Three-Stage Build**: Orchestrates the build into:
+    1.  **Stage 1**: INDI Core & Development headers.
+    2.  **Stage 2**: Required 3rd-party libraries (auto-detected).
+    3.  **Stage 3**: 3rd-party drivers and local packages.
+- **Auto-detection**: Automatically finds the latest stable release from GitHub if version is set to `latest`.
+- **Caching**: Reuses existing source clones in `build_area/` to save time and bandwidth.
+- **Local Development**: Easily build packages from your local source directories while keeping them clean of build artifacts.
+
+## Requirements
+
+You will need the following tools installed:
+```bash
+sudo apt-get update
+sudo apt-get install build-essential debhelper cmake git devscripts pkg-config
+```
+
+## Usage
+
+1.  Edit `packages.conf` to select the versions and drivers you want to build.
+2.  Run the build script:
+    ```bash
+    ./build.sh
+    ```
+    To force a rebuild of INDI Core:
+    ```bash
+    ./build.sh -f
+    ```
+    To build only specific drivers:
+    ```bash
+    ./build.sh -p gpsd,celestronaux
+    ```
+3.  Find your `.deb` packages in the `dist/` directory.
+
+## Configuration
+
+The `packages.conf` file allows you to:
+- Set the GitHub tag/branch for INDI Core (defaults to `latest`).
+- Set the version for the `indi-3rdparty` repository (defaults to `latest`).
+- List specific 3rd-party drivers to build.
+- Specify local paths for development packages.

--- a/scripts/deb-builder/build.sh
+++ b/scripts/deb-builder/build.sh
@@ -1,0 +1,492 @@
+#!/bin/bash
+set -e
+
+# Load configuration
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+CONFIG_FILE="$SCRIPT_DIR/packages.conf"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: $CONFIG_FILE not found!"
+    exit 1
+fi
+source "$CONFIG_FILE"
+
+# Parse CLI arguments (overrides config file)
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f|--force-core)
+            FORCE_CORE_REBUILD=true
+            shift
+            ;;
+        -p|--packages)
+            IFS=',' read -r -a OFFICIAL_3RDPARTY_DRIVERS <<< "$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: ./build.sh [options]"
+            echo ""
+            echo "Options:"
+            echo "  -f, --force-core    Force rebuild of INDI Core even if already installed"
+            echo "  -p, --packages PKG  Comma-separated list of 3rd-party drivers to build"
+            echo "  -h, --help          Show this help message"
+            echo ""
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h or --help for usage information."
+            exit 1
+            ;;
+    esac
+done
+
+# Setup directories
+BASE_DIR=$(pwd)
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+# Detect if we are running inside the indi-3rdparty repository
+INSIDE_REPO=false
+if [ -d "$SCRIPT_DIR/../../.git" ] && [ -f "$SCRIPT_DIR/../../CMakeLists.txt" ]; then
+    INSIDE_REPO=true
+    REPO_ROOT=$(readlink -f "$SCRIPT_DIR/../../")
+    echo ">>> Detected execution inside indi-3rdparty repository."
+fi
+
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$WORKING_DIR"
+ABS_OUTPUT_DIR=$(readlink -f "$OUTPUT_DIR")
+ABS_WORKING_DIR=$(readlink -f "$WORKING_DIR")
+
+
+
+function get_latest_tag() {
+    local repo_url=$1
+    local tag=$(git ls-remote --tags --refs --sort='v:refname' "$repo_url" | tail -n1 | awk -F/ '{print $3}')
+    if [ -z "$tag" ]; then
+        tag="master"
+    fi
+    echo "$tag"
+}
+
+function prepare_source() {
+    local repo_url=$1
+    local target_dir=$2
+    local version=$3
+
+    if [ "$version" == "latest" ]; then
+        echo "Auto-detecting latest version for $repo_url..." >&2
+        version=$(get_latest_tag "$repo_url")
+        echo "Detected: $version" >&2
+    fi
+
+    if [ ! -d "$target_dir" ]; then
+        echo "Cloning $repo_url (version $version)..." >&2
+        git clone --depth 1 --branch "$version" "$repo_url" "$target_dir" >&2
+    else
+        pushd "$target_dir" > /dev/null
+        local current_version=$(git describe --tags 2>/dev/null || git rev-parse HEAD)
+        if [ "$current_version" == "$version" ]; then
+            echo "Already at version $version in $target_dir" >&2
+        else
+            echo "Updating existing clone in $target_dir..." >&2
+            git fetch --tags --depth 1 origin "$version" >&2
+            git checkout -f "$version" >&2
+            git clean -df >&2
+        fi
+        popd > /dev/null
+    fi
+    echo "$version"
+}
+
+function progress_bar() {
+    local name=$1
+    local percent=$2
+    local elapsed=$3
+    local width=30
+    local filled=$(( percent * width / 100 ))
+    local empty=$(( width - filled ))
+    
+    local bar=""
+    for ((i=0; i<filled; i++)); do bar="${bar}#"; done
+    for ((i=0; i<empty; i++)); do bar="${bar}-"; done
+    
+    local eta="??:??"
+    if (( percent > 0 )); then
+        local total_est=$(( elapsed * 100 / percent ))
+        local remaining=$(( total_est - elapsed ))
+        if (( remaining < 0 )); then remaining=0; fi
+        eta=$(printf "%02d:%02d" $((remaining/60)) $((remaining%60)))
+    fi
+    
+    local min=$((elapsed/60))
+    local sec=$((elapsed%60))
+    
+    # Format: Building [pkg] [#####-----]  50% (00:02<00:02)
+    printf "\rBuilding %-15s [%s] %3d%% (%02d:%02d<%s)\e[K" "$name" "$bar" "$percent" "$min" "$sec" "$eta"
+}
+
+function show_progress() {
+    local pid=$1
+    local name=$2
+    local log_file=$3
+    local start_time=$(date +%s)
+    local last_percent=0
+    
+    while kill -0 "$pid" 2>/dev/null; do
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        
+        # Try to find the last percentage in the log file
+        local percent=$(tail -n 100 "$log_file" 2>/dev/null | grep -oa "\[ *[0-9]\+%\]" | tail -n 1 | grep -oa "[0-9]\+")
+        
+        if [[ -n "$percent" ]]; then
+            last_percent=$percent
+        fi
+        
+        progress_bar "$name" "$last_percent" "$elapsed"
+        sleep 1
+    done
+    # Clear the progress bar line
+    printf "\r\e[K"
+}
+
+function build_package() {
+    local name=$1
+    local src_dir=$2
+    local log_file="$ABS_WORKING_DIR/${name}_build.log"
+    
+    echo "================================================================================"
+    echo " BUILDING: $name"
+    echo " SOURCE:   $src_dir"
+    echo " LOG:      $log_file"
+    echo "================================================================================"
+
+    pushd "$src_dir" > /dev/null
+    
+    # Check if debian directory exists
+    if [ ! -d "debian" ]; then
+        echo "Error: No debian directory found in $name."
+        popd > /dev/null
+        return 1
+    fi
+
+    # Check for build dependencies
+    if ! dpkg-checkbuilddeps >/dev/null 2>&1; then
+        echo ">>> Error: Missing build dependencies for $name:"
+        dpkg-checkbuilddeps 2>&1 | sed 's/dpkg-checkbuilddeps: błąd: unmet build dependencies: //' | sed 's/dpkg-checkbuilddeps: error: unmet build dependencies: //'
+        echo ""
+        echo "Please install them using:"
+        echo "  sudo apt-get install $(dpkg-checkbuilddeps 2>&1 | sed 's/.* dependencies: //' | sed 's/([^)]*)//g')"
+        echo ""
+        popd > /dev/null
+        return 1
+    fi
+
+    # Build the package
+    # We use stdbuf to ensure output is not buffered
+    stdbuf -oL -eL debuild -us -uc -b -j"$BUILD_THREADS" > "$log_file" 2>&1 &
+    local build_pid=$!
+    
+    show_progress "$build_pid" "$name" "$log_file"
+    
+    wait "$build_pid"
+    local status=$?
+    
+    popd > /dev/null
+    
+    if [ $status -ne 0 ]; then
+        echo ">>> Build FAILED for $name. See log below:"
+        echo "--------------------------------------------------------------------------------"
+        cat "$log_file"
+        echo "--------------------------------------------------------------------------------"
+        return $status
+    fi
+
+    # Move results to output directory
+    # We look for .deb files in the parent of the src_dir (where debuild puts them)
+    local parent_dir=$(dirname "$src_dir")
+    mv "$parent_dir"/*.deb "$ABS_OUTPUT_DIR/" 2>/dev/null || true
+    mv "$parent_dir"/*.changes "$ABS_OUTPUT_DIR/" 2>/dev/null || true
+    mv "$parent_dir"/*.buildinfo "$ABS_OUTPUT_DIR/" 2>/dev/null || true
+    
+    echo "Done building $name."
+}
+
+function get_local_deps() {
+    local pkg=$1
+    local tp_dir=$2
+    local control_file="$tp_dir/debian/$pkg/control"
+    local deps=()
+    
+    if [ -f "$control_file" ]; then
+        # Extract Build-Depends and check if any match a directory in debian/
+        local build_deps=$(sed -n '/^Build-Depends:/,/^[A-Z]/p' "$control_file" | sed 's/^Build-Depends://' | sed '$d' | tr ',' '\n' | sed 's/(.*)//' | awk '{$1=$1;print}')
+        for dep in $build_deps; do
+            if [ -d "$tp_dir/debian/$dep" ] && [ "$dep" != "$pkg" ]; then
+                deps+=("$dep")
+            fi
+        done
+    fi
+    echo "${deps[@]}"
+}
+
+function check_installed() {
+    dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "ok installed"
+}
+
+function get_installed_version() {
+    # Extract version, remove epoch if present (e.g. 1:2.0.0 -> 2.0.0)
+    dpkg-query -W -f='${Version}' "$1" 2>/dev/null | sed 's/^[0-9]://' | cut -d- -f1
+}
+
+function get_debian_version() {
+    local pkg=$1
+    local tp_dir=$2
+    local changelog="$tp_dir/debian/$pkg/changelog"
+    if [ -f "$changelog" ]; then
+        head -n 1 "$changelog" | grep -o "(.*)" | tr -d "()" | cut -d- -f1
+    else
+        echo "0.0.0"
+    fi
+}
+
+function needs_update() {
+    local pkg=$1
+    local upstream_ver=$2
+    local tp_dir=$3  # Optional: for 3rd party drivers
+    
+    if ! check_installed "$pkg"; then
+        return 0 # Not installed, needs build
+    fi
+    
+    local installed_ver=$(get_installed_version "$pkg")
+    local target_ver=""
+
+    if [ -n "$tp_dir" ]; then
+        # For 3rd party, the target version is defined in its own debian/changelog
+        target_ver=$(get_debian_version "$pkg" "$tp_dir")
+        echo ">>> Checking $pkg: installed=$installed_ver, debian_source=$target_ver" >&2
+    else
+        # For core, we use the git tag
+        target_ver="${upstream_ver#v}"
+        echo ">>> Checking $pkg: installed=$installed_ver, upstream_tag=$target_ver" >&2
+    fi
+    
+    # If installed version is less than target version, return 0 (needs update)
+    if dpkg --compare-versions "$installed_ver" lt "$target_ver"; then
+        echo ">>> Update available for $pkg: $installed_ver -> $target_ver" >&2
+        return 0
+    fi
+    
+    return 1 # Already up to date
+}
+
+function build_package_tp() {
+    local name=$1
+    local tp_dir=$2
+    local build_tmp="$ABS_WORKING_DIR/tp-build-$name"
+
+    echo "Preparing temporary build directory for $name..."
+    rm -rf "$build_tmp"
+    mkdir -p "$build_tmp"
+    
+    # Symlink everything from tp_dir except debian and build_area (if any)
+    for item in "$tp_dir"/*; do
+        local basename=$(basename "$item")
+        if [ "$basename" != "debian" ] && [ "$basename" != "build_area" ]; then
+            ln -s "$item" "$build_tmp/$basename"
+        fi
+    done
+    
+    # Symlink the specific debian folder
+    if [ -d "$tp_dir/debian/$name" ]; then
+        ln -s "$tp_dir/debian/$name" "$build_tmp/debian"
+    else
+        echo "Error: Debian directory $tp_dir/debian/$name not found."
+        rm -rf "$build_tmp"
+        return 1
+    fi
+    
+    local status=0
+    build_package "$name" "$build_tmp" || status=$?
+    
+    # Clean up
+    rm -rf "$build_tmp"
+    return $status
+}
+
+# --- Stage 1: INDI Core ---
+if [ "$BUILD_INDI_CORE" = true ]; then
+    CORE_DIR="$ABS_WORKING_DIR/indi-core"
+    CORE_VERSION=$(prepare_source "https://github.com/indilib/indi.git" "$CORE_DIR" "$INDI_CORE_VERSION")
+
+    if needs_update "libindi-dev" "$CORE_VERSION" || [ "$FORCE_CORE_REBUILD" = true ]; then
+        if [ "$FORCE_CORE_REBUILD" = true ]; then
+            echo ">>> Stage 1: Forced rebuild of INDI Core enabled."
+        else
+            echo ">>> Stage 1: Building INDI Core ($CORE_VERSION)..."
+        fi
+        
+        if ! build_package "indi-core" "$CORE_DIR"; then
+            echo ">>> Stage 1 failed. Please address the missing dependencies above and try again."
+            exit 1
+        fi
+        
+        echo ""
+        echo "================================================================================"
+        echo " STAGE 1 COMPLETE: INDI Core built"
+        echo "================================================================================"
+        echo "Please install the core packages before proceeding to Stage 2:"
+        echo "  sudo dpkg -i dist/libindi*.deb dist/indi-bin*.deb"
+        echo ""
+        echo "After installation, run this script again."
+        echo "================================================================================"
+        exit 0
+    else
+        echo ">>> Stage 1: libindi-dev is already installed and up to date."
+    fi
+else
+    echo ">>> Stage 1: INDI Core build disabled in configuration. Skipping."
+    # We still need to check if it's installed because drivers depend on it
+    if ! check_installed "libindi-dev"; then
+        echo "Error: libindi-dev is not installed and core build is disabled."
+        echo "Please install INDI core packages or enable BUILD_INDI_CORE in packages.conf."
+        exit 1
+    fi
+fi
+
+# --- Stage 2: 3rd Party Libraries ---
+if [ "$INSIDE_REPO" = true ]; then
+    TP_REPO_DIR="$REPO_ROOT"
+    TP_VERSION="local-repo"
+    echo ">>> Stage 2: Using local repository as source."
+else
+    TP_REPO_DIR="$ABS_WORKING_DIR/indi-3rdparty"
+    TP_VERSION=$(prepare_source "https://github.com/indilib/indi-3rdparty.git" "$TP_REPO_DIR" "$INDI_3RDPARTY_VERSION")
+fi
+echo ">>> Processing Official 3rd Party Drivers ($TP_VERSION)..."
+
+# Detect required libraries for selected drivers
+libs_to_build=()
+drivers_to_process=()
+
+for pkg_name in "${OFFICIAL_3RDPARTY_DRIVERS[@]}"; do
+    pkg="$pkg_name"
+    # Try with indi- prefix if not found
+    if [ ! -d "$TP_REPO_DIR/debian/$pkg" ]; then
+        if [ -d "$TP_REPO_DIR/debian/indi-$pkg" ]; then
+            pkg="indi-$pkg"
+        fi
+    fi
+
+    if [ -d "$TP_REPO_DIR/debian/$pkg" ]; then
+        driver_needs_update=0
+        if needs_update "$pkg" "$TP_VERSION" "$TP_REPO_DIR"; then
+            driver_needs_update=1
+        fi
+
+        dep_needs_update=0
+        deps=$(get_local_deps "$pkg" "$TP_REPO_DIR")
+        for dep in $deps; do
+            if needs_update "$dep" "$TP_VERSION" "$TP_REPO_DIR"; then
+                dep_needs_update=1
+                libs_to_build+=("$dep")
+            fi
+        done
+
+        if [ "$driver_needs_update" -eq 1 ] || [ "$dep_needs_update" -eq 1 ]; then
+            drivers_to_process+=("$pkg")
+            # If any dependency is being rebuilt, we should probably ensure all local deps 
+            # are considered for the build list if they are not installed or are older
+            for dep in $deps; do
+                if needs_update "$dep" "$TP_VERSION" "$TP_REPO_DIR"; then
+                    libs_to_build+=("$dep")
+                fi
+            done
+        else
+            echo ">>> Driver $pkg and its dependencies are already up to date."
+        fi
+    else
+        echo "Warning: Driver $pkg_name (or indi-$pkg_name) not found in 3rdparty repository."
+    fi
+done
+
+# Deduplicate libraries
+libs_to_build=($(echo "${libs_to_build[@]}" | tr ' ' '\n' | sort -u))
+
+if [ ${#libs_to_build[@]} -gt 0 ]; then
+    echo ">>> Stage 2: Building required libraries: ${libs_to_build[*]}"
+    built_libs=()
+    for lib in "${libs_to_build[@]}"; do
+        if build_package_tp "$lib" "$TP_REPO_DIR"; then
+            built_libs+=("$lib")
+        else
+            echo ">>> Stage 2: Failed to build library $lib. Please address the missing dependencies above."
+            exit 1
+        fi
+    done
+    
+    echo ""
+    echo "================================================================================"
+    echo " STAGE 2 COMPLETE: Libraries built"
+    echo "================================================================================"
+    echo "Please install the following libraries before proceeding to Stage 3:"
+    for lib in "${built_libs[@]}"; do
+        echo "  - $lib"
+    done
+    echo ""
+    echo "Please install them using:"
+    echo "  sudo dpkg -i $(printf 'dist/%s*.deb ' "${built_libs[@]}")"
+    echo ""
+    echo "After installation, run this script again."
+    echo "================================================================================"
+    exit 0
+else
+    echo ">>> Stage 2: All required libraries are installed. Proceeding to Stage 3."
+fi
+
+# --- Stage 3: 3rd Party Drivers & Local Packages ---
+echo ">>> Stage 3: Building Official Drivers..."
+built_drivers=()
+for driver in "${drivers_to_process[@]}"; do
+    if ! build_package_tp "$driver" "$TP_REPO_DIR"; then
+        echo ">>> Stage 3: Failed to build driver $driver. Please address the missing dependencies above."
+        exit 1
+    fi
+    built_drivers+=("$driver")
+done
+
+echo ">>> Stage 3: Processing Local Development Packages..."
+for entry in "${LOCAL_DEVELOPMENT_PACKAGES[@]}"; do
+    name="${entry%%:*}"
+    path="${entry##*:}"
+    
+    # Resolve relative path if necessary
+    if [[ "$path" != /* ]]; then
+        path="$BASE_DIR/$path"
+    fi
+
+    if [ -d "$path" ]; then
+        # Copy to working dir to avoid polluting local source with build artifacts
+        LOCAL_BUILD_DIR="$ABS_WORKING_DIR/local-$name"
+        rm -rf "$LOCAL_BUILD_DIR"
+        mkdir -p "$LOCAL_BUILD_DIR"
+        cp -r "$path/." "$LOCAL_BUILD_DIR/"
+        
+        if ! build_package "local-$name" "$LOCAL_BUILD_DIR"; then
+            echo ">>> Stage 3: Failed to build local package $name."
+            exit 1
+        fi
+        built_drivers+=("$name")
+    else
+        echo "Error: Local path $path for $name does not exist!"
+    fi
+done
+
+echo "================================================================================"
+echo " BUILD COMPLETE"
+echo " Packages are located in: $OUTPUT_DIR"
+echo "================================================================================"
+if [ ${#built_drivers[@]} -gt 0 ]; then
+    echo "To install the built drivers, run:"
+    echo "  sudo dpkg -i $(printf 'dist/%s*.deb ' "${built_drivers[@]}")"
+    echo "================================================================================"
+fi

--- a/scripts/deb-builder/packages.conf
+++ b/scripts/deb-builder/packages.conf
@@ -1,0 +1,38 @@
+# Configuration for INDI Debian Package Builder
+
+# --- INDI Core Settings ---
+# Whether to build the core INDI library. Set to false if you use distribution packages.
+BUILD_INDI_CORE=true
+# GitHub tag or branch for the core library (e.g., v2.1.0 or master)
+# Set to "latest" to auto-detect the last release
+INDI_CORE_VERSION="latest"
+# Force rebuild of INDI Core even if already installed
+FORCE_CORE_REBUILD=false
+
+# --- Official 3rd Party Settings ---
+# The version of the indi-3rdparty repository to use
+# Set to "latest" to auto-detect the last release
+INDI_3RDPARTY_VERSION="latest"
+
+# List of drivers to build from the indi-3rdparty repository.
+# These names correspond to the directory names in the indi-3rdparty repo.
+# The "indi-" prefix is optional and will be added automatically if missing.
+# Example: "playerone" will detect "indi-playerone" and its dependencies.
+OFFICIAL_3RDPARTY_DRIVERS=(
+    "gpsd"
+    "celestronaux"
+    "playerone"
+)
+
+# --- Local Development Settings ---
+# Format: "PackageName:LocalPath"
+# The LocalPath must be an absolute path or relative to the project root.
+# It should contain a "debian/" directory for building.
+LOCAL_DEVELOPMENT_PACKAGES=(
+    # "indi-custom-driver:../my-custom-driver"
+)
+
+# --- Build Options ---
+BUILD_THREADS=$(nproc)
+OUTPUT_DIR="dist"
+WORKING_DIR="build_area"

--- a/scripts/setup_worktree.sh
+++ b/scripts/setup_worktree.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -e
+
+# Setup directories
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+BASE_DIR=$(pwd)
+# If running from inside scripts/, adjust BASE_DIR
+if [[ "$BASE_DIR" == */scripts ]]; then
+    BASE_DIR=$(dirname "$BASE_DIR")
+fi
+
+WORKTREE_ROOT="$BASE_DIR/worktree"
+
+function usage() {
+    echo "Usage: $0 <driver_name> [target_directory]"
+    echo ""
+    echo "Prepares a slim, Git-native worktree for developing a single INDI driver"
+    echo "using Git Sparse Checkout (industry best practice for monorepos)."
+    echo ""
+    echo "Example: $0 playerone ./dev-playerone"
+    exit 1
+}
+
+if [ -z "$1" ]; then
+    usage
+fi
+
+DRIVER_NAME="$1"
+# Ensure the name is clean (no indi- prefix for internal logic, we'll check both)
+RAW_NAME="${DRIVER_NAME#indi-}"
+
+TARGET_DIR="${2:-$WORKTREE_ROOT/indi-$RAW_NAME}"
+ABS_TARGET_DIR=$(readlink -f "$TARGET_DIR")
+
+echo ">>> Creating slim Git worktree for $DRIVER_NAME in $ABS_TARGET_DIR..."
+
+# 1. Clone the repo with blob filtering (blobless clone)
+# This downloads all commit history but NO file contents.
+# File contents are downloaded only when checked out.
+if [ ! -d "$ABS_TARGET_DIR" ]; then
+    echo "Cloning indi-3rdparty (blobless)..."
+    git clone --filter=blob:none --no-checkout https://github.com/indilib/indi-3rdparty.git "$ABS_TARGET_DIR"
+fi
+
+pushd "$ABS_TARGET_DIR" > /dev/null
+
+# 2. Initialize sparse-checkout
+echo "Initializing sparse-checkout..."
+git sparse-checkout init --cone
+
+# 3. Define directories to fetch
+# We need:
+# - The driver source (indi-driver or lib-driver)
+# - The debian metadata for that driver
+# - Essential common build files
+echo "Configuring sparse-checkout paths..."
+
+# Determine actual folder names in the repo
+# We'll fetch the directory listing from origin to be sure
+DRIVER_PATH="indi-$RAW_NAME"
+# Some might be lib- something, but most are indi-
+# In sparse-checkout, we can just set the patterns we expect.
+
+git sparse-checkout set \
+    "cmake_modules" \
+    "debian/indi-$RAW_NAME" \
+    "debian/lib$RAW_NAME" \
+    "indi-$RAW_NAME" \
+    "lib$RAW_NAME" \
+    "CMakeLists.txt" \
+    "README.md" \
+    "LICENSE" \
+    "tools"
+
+# 4. Checkout the files
+echo "Checking out files..."
+git checkout master
+
+# 5. Final check
+if [ ! -d "indi-$RAW_NAME" ] && [ ! -d "lib$RAW_NAME" ]; then
+    echo "Warning: Could not find source for $DRIVER_NAME in the repository."
+    echo "Currently checked out patterns:"
+    git sparse-checkout list
+fi
+
+popd > /dev/null
+
+echo "================================================================================"
+echo " GIT SPARSE WORKTREE READY"
+echo "================================================================================"
+echo "Location: $ABS_TARGET_DIR"
+echo ""
+echo "This is a FULL Git repository, but only files for $DRIVER_NAME are on disk."
+echo "You can use git commit/push/pull normally."
+echo ""
+echo "To build this driver using the deb-builder, add it to LOCAL_DEVELOPMENT_PACKAGES"
+echo "in packages.conf as:"
+echo "  \"$DRIVER_NAME:$ABS_TARGET_DIR/indi-$RAW_NAME\""
+echo "================================================================================"


### PR DESCRIPTION
### Summary
This PR introduces a set of developer-focused scripts designed to streamline the INDI development workflow on Debian-based systems. These tools automate the multi-stage build process and provide a mechanism for creating native "slim" development environments from the large `indi-3rdparty` monorepo.

*This is vibe-coded but extensively tested on my setup.*

### Key Components

1. **Automated 3-Stage Debian Builder (`scripts/deb-builder/`)**:
    * **Orchestration**: Automatically manages the build order: **Stage 1 (INDI Core)** -> **Stage 2 (Local Libraries)** -> **Stage 3 (Drivers)**.
    * **Auto-dependency Detection**: Scans `debian/control` files within the monorepo to identify internal library dependencies (e.g., automatically building `libplayerone` when `indi-playerone` is requested).
    * **Version-Aware**: Compares installed package versions against source `debian/changelog` entries to trigger rebuilds only when updates are available.
    * **UX Features**: Includes a `tqdm`-style progress bar with real-time CMake percentage parsing, ETA, and automated installation command generation.
    * **Flexibility**: Allows skipping the Core build (`BUILD_INDI_CORE=false`) to use distribution-provided packages while building custom drivers.

2. **Slim Worktree Setup (`scripts/setup_worktree.sh`)**:
    * **Best Practices**: Implements **Git Sparse Checkout** combined with **Blob Filtering** (`--filter=blob:none`).
    * **Efficiency**: Allows developers to work on a specific driver with full Git history while downloading only ~5MB of data instead of the full ~2.4GB repository.
    * **Native Environment**: Creates a standard Git repository structure where only the necessary driver source, common CMake modules, and specific Debian metadata are checked out.

### Why include this?
As the `indi-3rdparty` repository grows, the "barrier to entry" for new contributors increases due to its size. The `setup_worktree.sh` script provides a native Git solution to this problem. Furthermore, the `deb-builder` automates the often tedious process of local testing and packaging, ensuring that dependencies are correctly handled across the different layers of the INDI ecosystem.

---

### Suggested usage for maintainers to verify:
```bash
# 1. Create a slim area for testing
./scripts/setup_worktree.sh gpsd ./dev-gpsd
cd ./dev-gpsd

# 2. Build the package
./scripts/deb-builder/build.sh -p gpsd
```