### PR TITLE
indi-libcamera: add black levels to fits data

### DIFF
--- a/indi-libcamera/indi_libcamera.h
+++ b/indi-libcamera/indi_libcamera.h
@@ -161,8 +161,10 @@ class INDILibCamera : public INDI::CCD
         // std::unique_ptr<RPiCamApp> m_CameraApp;
         // std::unique_ptr<RPiCamEncoder> m_CameraEncoder;
 
+        INDI_PIXEL_FORMAT m_pixel_format {INDI_BAYER_RGGB};
         bool m_csi_format_packed {false};
         unsigned int m_bit_depth {8};
+        int m_black_levels[4] {0, 0, 0, 0};
         int m_LiveVideoWidth {-1}, m_LiveVideoHeight {-1};
         uint8_t m_CameraIndex;
         libcamera::ControlList m_ControlList;


### PR DESCRIPTION
What I see in rpicam output:
```
2026-02-12T23:13:07: Driver indi_libcamera_ccd: Bayer format is RGGB-12
2026-02-12T23:13:07: Driver indi_libcamera_ccd: Black levels 240 240 240 240, exposure time 1e+06us, ISO 100
```

What I get in FITS:
<img width="750" height="497" alt="image" src="https://github.com/user-attachments/assets/8c672deb-0776-4386-8cbf-83d714e5bf14" />
