### PR TITLE
fix(touptek): flush on timeout, fix bit depth and initial format, improve timeout management.

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -613,6 +613,8 @@ void ToupBase::setupParams()
         CaptureFormat rgb = {"INDI_RGB", "RGB", 8, false };
         CaptureFormat raw = {"INDI_RAW", (m_maxBitDepth > 8) ? "RAW 16" : "RAW 8", static_cast<uint8_t>((m_maxBitDepth > 8) ? 16 : 8), true };
 
+        // setupParams() enables RAW mode in the SDK, so keep the driver's format bookkeeping aligned.
+        m_CurrentVideoFormat = 1;
         m_Channels = 1;
         BayerTP[2].setText(getBayerString());// Get RAW Format
 
@@ -2294,7 +2296,12 @@ void ToupBase::eventCallBack(unsigned event)
             break;
         case CP(EVENT_NOFRAMETIMEOUT):
             LOG_ERROR("Camera timed out");
-            PrimaryCCD.setExposureFailed();
+            if (InExposure)
+            {
+                InExposure = false;
+                PrimaryCCD.setExposureLeft(0);
+                PrimaryCCD.setExposureFailed();
+            }
             break;
         default:
             break;
@@ -2330,7 +2337,7 @@ bool ToupBase::SetCaptureFormat(uint8_t index)
             return false;
         }
 
-        m_BitsPerPixel = index ? 8 : 16;
+        m_BitsPerPixel = index ? 16 : 8;
     }
     // Color
     else

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1873,6 +1873,11 @@ void ToupBase::TimerHit()
             LOG_ERROR("Exposure timed out waiting for image frame.");
             InExposure = false;
             PrimaryCCD.setExposureFailed();
+            LOG_ERROR("Exposure timed out - flushing to unlock camera.");
+            if(FAILED(FP(put_Option(m_Handle, CP(OPTION_FLUSH), 3))))
+            {
+                LOG_ERROR("Failed to flush camera after exposure timeout.");
+            }
         }
     }
 


### PR DESCRIPTION
This MR fixes a frame corruption issue when starting the Touptek driver.

An incorrect initial frame format requires the end-user to switch between RGB and RAW16 to restore functionality.

An incorrect bit depth mapping causes frame corruption until the firmware fixes the parameter by itself.

These fixes resolved all the timeout issues I had with my G3M662, even for frames under one second.