### PR TITLE
Add rule for Astroasis HID raw devices

### DIFF
--- a/libastroasis/99-astroasis.rules
+++ b/libastroasis/99-astroasis.rules
@@ -1,2 +1,3 @@
 # Astroasis devices
 SUBSYSTEMS=="usb", ATTR{idVendor}=="338f", MODE="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="338f", MODE="0666"


### PR DESCRIPTION
added missing rule for /dev/hidraw*

Before:
```
$ ll /dev/hidraw1 
crw------- 1 root root 242, 1 14. Apr 11:01 /dev/hidraw1
```
After:
```
$ ll /dev/hidraw1
crw-rw-rw- 1 root root 242, 1 14. Apr 11:10 /dev/hidraw1
```