### PR TITLE
Use Nicknames for ASI & QHY CCDs

### DIFF
--- a/indi-asi/README.md
+++ b/indi-asi/README.md
@@ -1,8 +1,12 @@
+ZWO Optics ASI CCD Driver
+=========================
+
 This is the INDI driver for the ZWO Optics ASI cameras. It was tested
 with the ASI120MC and the ASI120MM but, hopefully, should work with
 other cameras from ZWO Optical too.
 
 COMPILING
+---------
 
 Go to the directory where  you unpacked indi_asi sources and do:
 
@@ -16,12 +20,14 @@ make
 should build the indi_asicam executable.
 
 RUNNING
+-------
 
 The Driver can run multiple devices if required, to run the driver:
 
 `indiserver -v indi_asi_ccd`
 
 AVAILABLE CONTROLS
+------------------
 
 You can set the exposure time and the gain (in the range between 1 and
 100) You can also change the USB Bandwidth control. It defaults to -1
@@ -32,6 +38,7 @@ set a value of 40 if you find problems with many broken frames.
 You can also start video stream.
 
 TESTING
+-------
 
 The driver was tested with KStars/EKOS as a remote INDI
 server (just select remote driver, the IP of machine where indi_asicam
@@ -39,6 +46,7 @@ is running and the default port 7624). Connect to the camera you want
 to use and have fun!
 
 NOTES
+-----
 
 The ASICameras are very USB bandwidth hungry when running at high
 FPS. If you see "broken frames" with more that one of them running,
@@ -51,31 +59,42 @@ find any problem with parameters changes not being immediately applied
 please report.
 
 NICKNAMES
+---------
 
-The ASI SDK exposes device serial numbers for at least CCDs and EAFs.
-You may associate nicknames with specific serial numbers to make, *e.g.*,
-setups with multiple identical devices reliably associate the same name
-with the same device across restarts.
-
-Nicknames are stored in an xml-format file in a format like the below.
-The hard-wired location for this file is ``~/.indi/ZWONicknames.xml``.
-Nicknames are assoicated with the serial number of the camera, and are
-entered/changed with the NicknameTP text property. Since the device-name
-can't be changed once the driver is running, changes to nicknames can
-only take effect at the next INDI startup.
-
-You may mix CCD and EAF nicknames in the same file, using the format:
+The `indi_asi_ccd` and `indi_asi_focuser` drivers use the generalized INDI
+nickname scheme introduced in [INDI PR #2343](https://github.com/indilib/indi/pull/2343).
+Nicknames are stored in `~/.indi/INDINicknames.xml` in a format like the below,
+and are assoicated with a driver and stable device identifier.
 
 ```
-<?xml version="1.0"?>
-<Nicknames>
-  <Nickname SerialNumber="serialNumber1">nickname1</Nickname>
-  <Nickname SerialNumber="serialNumber2">nickname2</Nickname>
-  <Nickname SerialNumber="serialNumber3">nickname3</Nickname>
-</Nicknames>
+<INDINicknames>
+ <nickname driver="AcmeFocuser" identifier="SN123">MainScope</nickname>
+ <nickname driver="AcmeFocuser" identifier="SN456">GuideScope</nickname>
+ <nickname driver="AcmeDustCap" identifier="CAP-1-2-3">MainScope</nickname>
+</INDINicknames>
 ```
+
+For the specific case of ASI cameras and focusers, the format looks something like this:
+```
+<INDINicknames>
+  <device name="ZWO EAF">
+    <nickname identifier="0F23C2003020F901">SM</nickname>
+    <nickname identifier="0F23218028DBC1A1">WR</nickname>
+    <nickname identifier="6000206EF19EE420">WB</nickname>
+  </device>
+  <device name="ZWO CCD">
+    <nickname identifier="081a0f011a020900">ASI6200MM-Pro WB</nickname>
+    <nickname identifier="212b810522020900">ASI6200MM-Pro WR</nickname>
+    <nickname identifier="091c920d2d010900">ASI183MM-Pro SM</nickname>
+  </device>
+</INDINicknames>
+```
+where the device name is simply "`ZWO CCD`" or "`ZWO EAF`", and the
+identifier is the device "`Serial Number`" property, as show with the
+tool `indi_getprop` or similar.
 
 CREDITS
+-------
 
 The origianl INDI driver was written by Chrstian Pellegrin <chripell@gmail.com> based on ASI SDK v1.0+
 

--- a/indi-asi/asi_ccd.cpp
+++ b/indi-asi/asi_ccd.cpp
@@ -26,7 +26,6 @@
 
 #include <hotplugmanager.h>
 #include "asi_ccd_hotplug_handler.h"
-#include <map>
 //#define USE_SIMULATION
 
 #ifdef USE_SIMULATION
@@ -58,122 +57,6 @@ static class Loader
         }
 } loader;
 
-namespace
-{
-
-// trim from start (in place)
-static inline void ltrim(std::string &s)
-{
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }));
-}
-
-// trim from end (in place)
-static inline void rtrim(std::string &s)
-{
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }).base(), s.end());
-}
-
-// trim from both ends (in place)
-static inline void trim(std::string &s)
-{
-    ltrim(s);
-    rtrim(s);
-}
-
-std::string GetHomeDirectory()
-{
-    // Check first the HOME environmental variable
-    const char *HomeDir = getenv("HOME");
-
-    // ...otherwise get the home directory of the current user.
-    if (!HomeDir)
-    {
-        HomeDir = getpwuid(getuid())->pw_dir;
-    }
-    return (HomeDir ? std::string(HomeDir) : "");
-}
-
-}  // namespace
-
-// Nicknames are stored in an xml-format NICKNAME_FILE in a format like the below.
-// Nicknames are assoicated with the serial number of the camera, and are entered/changed
-// with NicknameTP. Since the device-name can't be changed once the driver is running,
-// changes to nicknames can only take effect at the next INDI startup.
-// <Nicknames>
-//  <Nickname SerialNumber="serialNumber1">nickname1</Nickname>
-//  <Nickname SerialNumber="serialNumber2">nickname2</Nickname>
-//  <Nickname SerialNumber="serialNumber3">nickname3</Nickname>
-// </Nicknames>
-
-#define ROOTNODE "Nicknames"
-#define ENTRYNODE "Nickname"
-#define ATTRIBUTE "SerialNumber"
-
-void ASICCD::loadZWONicknames()
-{
-    const std::string filename = GetHomeDirectory() + NICKNAME_FILE;
-    mZWONicknames.clear();
-
-    LilXML *xmlHandle = newLilXML();
-    XMLEle *rootXmlNode = nullptr;
-    char errorMessage[512] = {0};
-    FILE *file = fopen(filename.c_str(), "r");
-    if (file)
-    {
-        rootXmlNode = readXMLFile(file, xmlHandle, errorMessage);
-        fclose(file);
-    }
-    delLilXML(xmlHandle);
-
-    if (rootXmlNode == nullptr)
-        return;
-
-    XMLEle *currentXmlNode = nextXMLEle(rootXmlNode, 1);
-    while (currentXmlNode)
-    {
-        const char *id = findXMLAttValu(currentXmlNode, ATTRIBUTE);
-        if (id != nullptr)
-        {
-            std::string name = pcdataXMLEle(currentXmlNode);
-            if (!name.empty())
-                trim(name);
-            if (!name.empty())
-                mZWONicknames[id] = name;
-        }
-        currentXmlNode = nextXMLEle(rootXmlNode, 0);
-    }
-
-    delXMLEle(rootXmlNode);
-}
-
-void ASICCD::saveZWONicknames()
-{
-    const std::string filename = GetHomeDirectory() + NICKNAME_FILE;
-    XMLEle *rootXmlNode = nullptr;
-    XMLEle *oneElement = nullptr;
-
-    FILE *file = fopen(filename.c_str(), "w");
-
-    rootXmlNode = addXMLEle(nullptr, ROOTNODE);
-
-    for (const auto &kv : mZWONicknames)
-    {
-        oneElement = addXMLEle(rootXmlNode, ENTRYNODE);
-        addXMLAtt(oneElement, ATTRIBUTE, kv.first.c_str());
-        editXMLEle(oneElement, kv.second.c_str());
-    }
-
-    prXMLEle(file, rootXmlNode, 0);
-    fclose(file);
-    delXMLEle(rootXmlNode);
-}
-
 bool ASICCD::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
     return INDI::CCD::ISNewText(dev, name, texts, names, n);
@@ -186,18 +69,10 @@ ASICCD::ASICCD(const ASI_CAMERA_INFO &camInfo, const std::string &cameraName,
                const std::string &serialNumber)
     : ASIBase(camInfo, serialNumber)
 {
-    auto name = cameraName;
+    setDeviceName(cameraName.c_str());
 
-    loadZWONicknames();
     if (!mSerialNumber.empty())
-    {
-        auto nickname = mZWONicknames[mSerialNumber];
-        if (!nickname.empty())
-        {
-            name = nickname;
-        }
-    }
+        setDeviceNicknameFromId(mSerialNumber.c_str());
 
-    setDeviceNickname(name.c_str());
-    LOGF_INFO("Using camera name [%s] for serial number %s.", getDeviceName(), mSerialNumber.c_str());
+    mCameraName = getDeviceName();
 }

--- a/indi-asi/asi_ccd.h
+++ b/indi-asi/asi_ccd.h
@@ -50,13 +50,4 @@ class ASICCD : public ASIBase
 
     protected:
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-
-    private:
-        void loadZWONicknames();
-        void saveZWONicknames();
-        const std::string NICKNAME_FILE = "/.indi/ZWONicknames.xml";
-        // This is the map for ZWONicknames.xml for legacy compatibility. On
-        // load, all nicknames in that file will be migrated to the generic
-        // nickname support in DefaultDevice.
-        std::map<std::string, std::string> mZWONicknames;
 };

--- a/indi-asi/asi_focuser.cpp
+++ b/indi-asi/asi_focuser.cpp
@@ -49,36 +49,6 @@ static class Loader
         }
 } loader;
 
-namespace
-{
-
-// trim from start (in place)
-static inline void ltrim(std::string &s)
-{
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }));
-}
-
-// trim from end (in place)
-static inline void rtrim(std::string &s)
-{
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch)
-    {
-        return !std::isspace(ch);
-    }).base(), s.end());
-}
-
-// trim from both ends (in place)
-static inline void trim(std::string &s)
-{
-    ltrim(s);
-    rtrim(s);
-}
-
-}  // namespace
-
 ASIEAF::ASIEAF(const EAF_INFO &info, const char *name, const std::string &serialNumber)
     : m_ID(info.ID)
     , m_MaxSteps(info.MaxStep)

--- a/indi-qhy/README.md
+++ b/indi-qhy/README.md
@@ -1,10 +1,10 @@
 QHY CCD Driver
-==================
+==============
 
 This package provides QHY CCD/CMOS and Filter Wheels INDI driver.
 
 Requirements
-============
+------------
 
 + INDI >= v2.1.0 (http://www.indilib.org)
 
@@ -33,12 +33,12 @@ Requirements
 	It can be installed via APT as 'nlohmann-json3-dev' on Debian-based distros.
 
 Installation
-============
+------------
 
 	See INSTALL
 	
 How to Use
-==========
+----------
 
 	You can use the QHY INDI Driver in any INDI-compatible client such as KStars or Xephem. 
 	
@@ -56,3 +56,29 @@ How to Use
 
         Share the test result output in INDI & QHY forums. Be as thorough as possible with your environment conditions (OS, architecture..etc)
 	 
+Nicknames
+---------
+
+The `indi_qhy_ccd` driver uses the generalized INDI nickname scheme
+introduced in [INDI PR #2343](https://github.com/indilib/indi/pull/2343).
+Nicknames are stored in `~/.indi/INDINicknames.xml` in a format like the below,
+and are assoicated with a driver and stable device identifier.
+
+```
+<INDINicknames>
+ <nickname driver="AcmeFocuser" identifier="SN123">MainScope</nickname>
+ <nickname driver="AcmeFocuser" identifier="SN456">GuideScope</nickname>
+ <nickname driver="AcmeDustCap" identifier="CAP-1-2-3">MainScope</nickname>
+</INDINicknames>
+```
+
+For the specific case of QHY cameras, the format looks something like this:
+```
+<INDINicknames>
+  <device name="QHY CCD">
+    <nickname identifier="QHY294PROC-4ce22a4b811ae7175">QHY294C UW</nickname>
+  </device>
+</INDINicknames>
+```
+where the device name is simply "`QHY CCD`", and the identifier is printed in
+the `indiserver` output and log in the line "`*** This is the camera ID: [______]`".

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -62,6 +62,8 @@ QHYCCD::QHYCCD(const char *name, const char *camID) : FilterInterface(this)
     snprintf(this->m_CamID, MAXINDINAME, "%s", camID);
     setDeviceName(this->m_Name);
 
+    setDeviceNicknameFromId(m_CamID);
+
     setVersion(INDI_QHY_VERSION_MAJOR, INDI_QHY_VERSION_MINOR);
 
     m_QHYLogCallback = [this](const std::string & message)

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -60,6 +60,10 @@ QHYCCD::QHYCCD(const char *name, const char *camID) : FilterInterface(this)
 
     snprintf(this->m_Name, MAXINDINAME, "QHY CCD %.15s", name);
     snprintf(this->m_CamID, MAXINDINAME, "%s", camID);
+
+    LOGF_INFO("*** This is the camera name: [%s]", m_Name);
+    LOGF_INFO("*** This is the camera ID: [%s]", m_CamID);
+
     setDeviceName(this->m_Name);
 
     setDeviceNicknameFromId(m_CamID);


### PR DESCRIPTION
Use the new generalized nickname scheme in INDI core (https://github.com/indilib/indi/pull/2343) for ZWO/ASI and QHY CCD cameras.  The this basically involves calling the `DefaultDevice` function `setDeviceNicknameFromId()`, and the functionality in the core library takes it from there.

#### Example

Here is an example `Nicknames.xml` file from a setup that uses four different cameras and three focusers:

```
<?xml version="1.0"?>
<INDINicknames>
  <device name="ZWO EAF">
    <nickname identifier="0F23C2003020F901">SM</nickname>
    <nickname identifier="0F23218028DBC1A1">WR</nickname>
    <nickname identifier="6000206EF19EE420">WB</nickname>
  </device>
  <device name="ZWO CCD">
    <nickname identifier="081a0f011a020900">ASI6200MM-Pro WB</nickname>
    <nickname identifier="212b810522020900">ASI6200MM-Pro WR</nickname>
    <nickname identifier="091c920d2d010900">ASI183MM-Pro SM</nickname>
  </device>
  <device name="QHY CCD">
    <nickname identifier="QHY294PROC-4ce22a4b811ae7175">QHY294C UW</nickname>
  </device>
</INDINicknames>
```

When these are queried using the command `indi_getprop | awk -F'.' '{print $1}' | sort -u1`, the resulting list is:
```
QHY CCD QHY294C UW
ZWO CCD ASI183MM-Pro SM
ZWO CCD ASI6200MM-Pro WB
ZWO CCD ASI6200MM-Pro WR
ZWO EAF SM
ZWO EAF WB
ZWO EAF WR
```