### PR TITLE
indi-toupbase: fix streaming with binning

### DIFF
--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -832,19 +832,24 @@ void ToupBase::setupParams()
 
 void ToupBase::allocateFrameBuffer()
 {
+    uint32_t binX = PrimaryCCD.getBinX();
+    uint32_t binY = PrimaryCCD.getBinY();
+    uint32_t width = PrimaryCCD.getXRes() / binX;
+    uint32_t height = PrimaryCCD.getYRes() / binY;
+
     // Allocate memory
     if (m_MonoCamera)
     {
         if (0 == m_CurrentVideoFormat)
         {
-            PrimaryCCD.setFrameBufferSize(PrimaryCCD.getXRes() * PrimaryCCD.getYRes());
+            PrimaryCCD.setFrameBufferSize(width * height);
             PrimaryCCD.setBPP(8);
             PrimaryCCD.setNAxis(2);
             Streamer->setPixelFormat(INDI_MONO, 8);
         }
         else
         {
-            PrimaryCCD.setFrameBufferSize(PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * 2);
+            PrimaryCCD.setFrameBufferSize(width * height * 2);
             PrimaryCCD.setBPP(16);
             PrimaryCCD.setNAxis(2);
             Streamer->setPixelFormat(INDI_MONO, 16);
@@ -855,21 +860,21 @@ void ToupBase::allocateFrameBuffer()
         if (0 == m_CurrentVideoFormat)
         {
             // RGB24 or RGB888
-            PrimaryCCD.setFrameBufferSize(PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * 3);
+            PrimaryCCD.setFrameBufferSize(width * height * 3);
             PrimaryCCD.setBPP(8);
             PrimaryCCD.setNAxis(3);
             Streamer->setPixelFormat(INDI_RGB, 8);
         }
         else
         {
-            PrimaryCCD.setFrameBufferSize(PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * m_BitsPerPixel / 8);
+            PrimaryCCD.setFrameBufferSize(width * height * m_BitsPerPixel / 8);
             PrimaryCCD.setBPP(m_BitsPerPixel);
             PrimaryCCD.setNAxis(2);
             Streamer->setPixelFormat(m_CameraPixelFormat, m_BitsPerPixel);
         }
     }
 
-    Streamer->setSize(PrimaryCCD.getXRes(), PrimaryCCD.getYRes());
+    Streamer->setSize(width, height);
 }
 
 bool ToupBase::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
@@ -1558,6 +1563,14 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState *states, c
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 bool ToupBase::StartStreaming()
 {
+    // Re-apply current binning to hardware before streaming.
+    // This ensures the SDK uses the correct binning even if it was changed
+    // by another module (e.g., capture module set 2x2, guide module expects 1x1).
+    updateBinningMode(PrimaryCCD.getBinX(), m_BinningMode);
+
+    // Ensure frame buffer and streamer size are correct for current binning
+    allocateFrameBuffer();
+
     const uint32_t uSecs = static_cast<uint32_t>(1000000.0f / Streamer->getTargetFPS());
     HRESULT rc = FP(put_ExpoTime(m_Handle, uSecs));
     if (FAILED(rc))

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -834,8 +834,8 @@ void ToupBase::allocateFrameBuffer()
 {
     uint32_t binX = PrimaryCCD.getBinX();
     uint32_t binY = PrimaryCCD.getBinY();
-    uint32_t width = PrimaryCCD.getXRes() / binX;
-    uint32_t height = PrimaryCCD.getYRes() / binY;
+    uint32_t width = PrimaryCCD.getSubW() / binX;
+    uint32_t height = PrimaryCCD.getSubH() / binY;
 
     // Allocate memory
     if (m_MonoCamera)
@@ -1779,13 +1779,19 @@ bool ToupBase::UpdateCCDFrame(int x, int y, int w, int h)
     // Set UNBINNED coords
     PrimaryCCD.setFrame(x, y, w, h);
 
-    // Total bytes required for image buffer
-    uint32_t nbuf = (w * h * PrimaryCCD.getBPP() / 8) * m_Channels;
-    LOGF_DEBUG("Updating frame buffer size to %d bytes", nbuf);
+    // Total bytes required for image buffer.
+    // With digital binning active, the SDK delivers (w/binX * h/binY) pixels,
+    // so the buffer must be sized for the binned dimensions.
+    uint32_t binX = PrimaryCCD.getBinX();
+    uint32_t binY = PrimaryCCD.getBinY();
+    uint32_t binW = w / binX;
+    uint32_t binH = h / binY;
+    uint32_t nbuf = (binW * binH * PrimaryCCD.getBPP() / 8) * m_Channels;
+    LOGF_DEBUG("Updating frame buffer size to %d bytes (binned %dx%d)", nbuf, binW, binH);
     PrimaryCCD.setFrameBufferSize(nbuf);
 
-    // Always set BINNED size
-    Streamer->setSize(w / PrimaryCCD.getBinX(), h / PrimaryCCD.getBinY());
+    // Always set BINNED size for the streamer
+    Streamer->setSize(binW, binH);
     return true;
 }
 


### PR DESCRIPTION
Fix frame size mismatch when streaming with binning > 1x1 on ToupTek cameras.

**Problem**: `allocateFrameBuffer()` always used full sensor resolution for buffer 
size and `Streamer->setSize()`, ignoring the current binning. This caused streaming 
to deliver wrong-sized frames when binning was active. Additionally, binning changes 
from other modules (e.g. capture at 2x2) persisted into streaming even when the 
client requested 1x1.

**Fix**:
- `allocateFrameBuffer()` now divides by BinX/BinY when calculating dimensions
- `StartStreaming()` re-applies current binning to hardware before entering video mode

**Tested with**: ToupTek GPM174M at 1x1 and 2x2 binning in streaming mode.
