### PR TITLE
playerone: Fix 100% CPU usage during video streaming

### DIFF
--- a/indi-playerone/playerone_base.cpp
+++ b/indi-playerone/playerone_base.cpp
@@ -176,16 +176,6 @@ void POABase::workerStreamVideo(const std::atomic_bool &isAbortToQuit)
 
     while (!isAbortToQuit)
     {
-        POABool pIsReady = POA_FALSE;
-        while (pIsReady == POA_FALSE)
-        {
-            //if (isAbortToQuit) //Triggered by external conditions
-            //    break;
-
-            //usleep(ExposureRequest / 10);
-            POAImageReady(mCameraInfo.cameraID, &pIsReady);
-        }
-
         ret = POAGetImageData(mCameraInfo.cameraID, targetFrame, totalBytes, waitMS);
         if (ret != POA_OK)
         {


### PR DESCRIPTION
## Problem

The PlayerOne driver consumes 100% of a CPU core during video streaming, regardless of exposure time. Even at 0.5s exposure (2 FPS), the `indi_playerone_ccd` process pins a core at 100%.

## Root Cause

`workerStreamVideo()` contains a tight busy-wait polling loop:

```cpp
while (pIsReady == POA_FALSE)
{
    POAImageReady(mCameraInfo.cameraID, &pIsReady);
}
```

This spins with no sleep between calls, burning CPU cycles while waiting for a frame.

## Fix

Remove the redundant `POAImageReady()` polling loop. `POAGetImageData()` already blocks internally until a frame is ready (up to `waitMS` timeout), making the polling unnecessary. This matches how the ASI driver uses `ASIGetVideoData()` — a single blocking call with timeout.

## Before / After

| | Before | After |
|---|---|---|
| CPU usage during streaming | ~100% on one core | Near-idle between frames |

indi settings:
<img width="1854" height="1221" alt="Screenshot From 2026-05-07 12-49-53" src="https://github.com/user-attachments/assets/4839a9e9-fed2-4eff-9711-79995e568a76" />
cpu before fix:
<img width="3081" height="1473" alt="Screenshot From 2026-05-07 12-49-39" src="https://github.com/user-attachments/assets/87192e24-868f-4b42-a35a-765b0083d22c" />
cpu after fix:
<img width="3091" height="1461" alt="Screenshot From 2026-05-07 12-58-15" src="https://github.com/user-attachments/assets/d877b31e-3d75-47b7-9962-fe7eb497a17c" />


## Testing

Tested with PlayerOne Xena 585M (IMX585) on Intel N150 (x64, Arch Linux):
- 8-bit and 16-bit streaming modes
- Exposures from 0.001s to 0.5s
- Hardware binning 1x1 and 2x2
- No frame drops or streaming issues observed after the fix
