### PR TITLE
alignment: migrate to TransformCelestialToTelescopeJD / TransformTelescopeToCelestialJD

### DIFF
--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -1269,7 +1269,7 @@ INDI::IHorizontalCoordinates CelestronAUX::AltAzFromRaDec(double ra, double dec,
     TelescopeDirectionVector TDV;
     INDI::IHorizontalCoordinates AltAz;
 
-    if (TransformCelestialToTelescope(ra, dec, ts, TDV))
+    if (TransformCelestialToTelescopeJD(ra, dec, ln_get_julian_from_sys() + ts, TDV))
         // The alignment subsystem has successfully transformed my coordinate
         AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
     else
@@ -1745,6 +1745,7 @@ bool CelestronAUX::Goto(double ra, double dec)
     }
 
     uint32_t axis1Steps {0}, axis2Steps {0};
+    double JDnow {ln_get_julian_from_sys()};
 
     TelescopeDirectionVector TDV;
     INDI::IEquatorialCoordinates MountRADE { ra, dec };
@@ -1764,8 +1765,8 @@ bool CelestronAUX::Goto(double ra, double dec)
 
             // Calculate tracking direction
             TelescopeDirectionVector TDV_now, TDV_offset;
-            if (TransformCelestialToTelescope(ra, dec, 0.0, TDV_now) &&
-                    TransformCelestialToTelescope(ra, dec, julianOffsetForGoto, TDV_offset))
+            if (TransformCelestialToTelescopeJD(ra, dec, JDnow, TDV_now) &&
+                    TransformCelestialToTelescopeJD(ra, dec, JDnow + julianOffsetForGoto, TDV_offset))
             {
                 INDI::IHorizontalCoordinates now {0, 0}, offset {0, 0};
                 AltitudeAzimuthFromTelescopeDirectionVector(TDV_now, now);
@@ -1785,7 +1786,7 @@ bool CelestronAUX::Goto(double ra, double dec)
     // We have no good way to estimate how long will the mount takes to reach target (with deceleration,
     // and not just speed). So we will use iterative GOTO once the first GOTO is complete.
     // Stages are GOTO --> SLEWING FAST --> APPROACH --> SLEWING SLOW --> TRACKING
-    if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
+    if (TransformCelestialToTelescopeJD(ra, dec, JDnow, TDV))
     {
         // For Alt-Az Mounts, we get the Mount AltAz coords
         if (m_MountType == ALT_AZ)
@@ -1939,13 +1940,14 @@ bool CelestronAUX::Sync(double ra, double dec)
 bool CelestronAUX::mountToSkyCoords()
 {
     double RightAscension, Declination;
+    double JDnow {ln_get_julian_from_sys()};
 
     // TODO for Alt-Az Mounts on a Wedge, we need a watch to set this.
     if (m_MountType == ALT_AZ)
     {
         INDI::IHorizontalCoordinates AltAz = m_MountCurrentAltAz;
         TelescopeDirectionVector TDV = TelescopeDirectionVectorFromAltitudeAzimuth(AltAz);
-        if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+        if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, JDnow))
         {
             TelescopeDirectionVector RotatedTDV(TDV);
             switch (GetApproximateMountAlignment())
@@ -1978,7 +1980,7 @@ bool CelestronAUX::mountToSkyCoords()
     {
         INDI::IEquatorialCoordinates EquatorialCoordinates = m_MountCurrentRADE;
         TelescopeDirectionVector TDV = TelescopeDirectionVectorFromEquatorialCoordinates(EquatorialCoordinates);
-        if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+        if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, JDnow))
         {
             RightAscension = EquatorialCoordinates.rightascension;
             Declination = EquatorialCoordinates.declination;
@@ -2106,25 +2108,25 @@ void CelestronAUX::TimerHit()
                 INDI::IHorizontalCoordinates futureMountAxisCoordinates { 0, 0 };
                 double timeStep { 5.0 }; // time step for tracking rate estimation in seconds
                 double JDoffset { timeStep / (60 * 60 * 24) } ; // The same in days
+                double JDnow {ln_get_julian_from_sys()};
 
                 // Start by transforming tracking target celestial coordinates to telescope coordinates.
-                if (TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                                  0, TDV))
+                if (TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                                    JDnow, TDV))
                 {
                     // If mount is Alt-Az then that's all we need to do
                     AltitudeAzimuthFromTelescopeDirectionVector(TDV, targetMountAxisCoordinates);
-                    TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                                  JDoffset, futureTDV);
+                    TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                                    JDnow + JDoffset, futureTDV);
                     AltitudeAzimuthFromTelescopeDirectionVector(futureTDV, futureMountAxisCoordinates);
-                    TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                                  -JDoffset, pastTDV);
+                    TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                                    JDnow - JDoffset, pastTDV);
                     AltitudeAzimuthFromTelescopeDirectionVector(pastTDV, pastMountAxisCoordinates);
 
                 }
                 // If transformation failed.
                 else
                 {
-                    double JDnow {ln_get_julian_from_sys()};
                     INDI::IEquatorialCoordinates EquatorialCoordinates { 0, 0 };
                     EquatorialCoordinates.rightascension  = m_SkyTrackingTarget.rightascension;
                     EquatorialCoordinates.declination = m_SkyTrackingTarget.declination;

--- a/indi-eqmod/eqmodbase.cpp
+++ b/indi-eqmod/eqmodbase.cpp
@@ -862,7 +862,7 @@ bool EQMod::ReadScopeStatus()
             DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, " Direction RA(deg.)  %lf DEC %lf TDV(x %lf y %lf z %lf)",
                    RaDec.rightascension, RaDec.declination, TDV.x, TDV.y, TDV.z);
             aligned = true;
-            if (!TransformTelescopeToCelestial(TDV, alignedRA, alignedDEC))
+            if (!TransformTelescopeToCelestialJD(TDV, alignedRA, alignedDEC, juliandate))
             {
                 aligned = false;
                 DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT,
@@ -1855,7 +1855,7 @@ bool EQMod::Goto(double r, double d)
     {
         TelescopeDirectionVector TDV;
         aligned = true;
-        if (!TransformCelestialToTelescope(r, d, 0.0, TDV))
+        if (!TransformCelestialToTelescopeJD(r, d, ln_get_julian_from_sys(), TDV))
         {
             DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT,
                    "Failed TransformCelestialToTelescope:  RA=%lf DE=%lf, Goto RA=%lf DE=%lf", r, d, gotoparams.ratarget,

--- a/indi-eqmod/test/test_eqmod.cpp
+++ b/indi-eqmod/test/test_eqmod.cpp
@@ -280,7 +280,7 @@ TEST(EqmodTest, scope_limits_empty)
     auto limitgoto = onlimit.findWidgetByName("HORIZONLIMITSONLIMITGOTO");
     ASSERT_NE(limitgoto, nullptr);
 
-    HorizonLimits * const hl = eqmod.horizon;
+    HorizonLimits * const hl = eqmod.horizon.get();
     ASSERT_NE(hl, nullptr);
 
     // Because there are no horizon limits set, any altitude under the horizon will trigger the limit check
@@ -362,7 +362,7 @@ TEST(EqmodTest, scope_limits_altaz)
     auto limitgoto = onlimit.findWidgetByName("HORIZONLIMITSONLIMITGOTO");
     ASSERT_NE(limitgoto, nullptr);
 
-    HorizonLimits * const hl = eqmod.horizon;
+    HorizonLimits * const hl = eqmod.horizon.get();
     ASSERT_NE(hl, nullptr);
 
     // Use a configuration that aborts tracking out of limits


### PR DESCRIPTION
## Summary

- Migrate all deprecated `TransformCelestialToTelescope` / `TransformTelescopeToCelestial` call sites in `indi-celestronaux` and `indi-eqmod` to the JD-explicit variants introduced in indilib#2388
- In `celestronaux.cpp`, hoist `ln_get_julian_from_sys()` at the top of each affected scope so multiple call sites in `Goto()`, `mountToSkyCoords()`, and the TimerHit tracking block share a single clock read per tick
- In `eqmodbase.cpp`, reuse the existing `juliandate` variable already in scope for `TransformTelescopeToCelestialJD`; call `ln_get_julian_from_sys()` inline for `TransformCelestialToTelescopeJD`
- Fix `test_eqmod.cpp`: `eqmod.horizon` was changed from a raw pointer to a `unique_ptr`, requiring `.get()` when assigning to a raw pointer local

## Test plan

- [ ] `indi_celestron_aux` builds without deprecation warnings
- [ ] `indi_eqmod_telescope` builds without deprecation warnings
- [ ] `test_eqmod` encoder/hemisphere tests pass (5/8; 3 scope-limits tests require installed XML data files and were already failing before this change)
