### PR TITLE
Celestron Evolution Battery Telemetry and Stability Improvements

### DIFF
--- a/debian/indi-celestronaux/changelog
+++ b/debian/indi-celestronaux/changelog
@@ -1,10 +1,12 @@
 indi-celestronaux (1.6) jammy; urgency=medium
 
   * Add comprehensive battery telemetry support for Evolution mounts
-  * Improve PID tracking stability and property handling
+  * Fix PID tracking handling
+  * Fix some issues with property handling
   * Bump version to 1.6
+  * Fix communication stack buffer overflows and enhance packet validation
 
- -- Paweł T. Jochym <jochym@gmail.com>  Sat, 16 May 2026 18:41:05 +0200
+ -- Paweł T. Jochym <jochym@gmail.com>  Sun, 17 May 2026 15:03:00 +0200
 
 indi-celestronaux (1.5) jammy; urgency=medium
 

--- a/debian/indi-celestronaux/changelog
+++ b/debian/indi-celestronaux/changelog
@@ -1,3 +1,11 @@
+indi-celestronaux (1.6) jammy; urgency=medium
+
+  * Add comprehensive battery telemetry support for Evolution mounts
+  * Improve PID tracking stability and property handling
+  * Bump version to 1.6
+
+ -- Paweł T. Jochym <jochym@gmail.com>  Sat, 16 May 2026 18:41:05 +0200
+
 indi-celestronaux (1.5) jammy; urgency=medium
 
   * Add configurable approach direction with tracking vector support

--- a/indi-celestronaux/CMakeLists.txt
+++ b/indi-celestronaux/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
 set(CAUX_VERSION_MAJOR 1)
-set(CAUX_VERSION_MINOR 5)
+set(CAUX_VERSION_MINOR 6)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_celestronaux.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_celestronaux.xml )

--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -293,6 +293,10 @@ int AUXCommand::responseDataSize()
                 return -1;
         }
     }
+    else if (m_Destination == BAT && m_Command == GET_VOLTAGE)
+    {
+        return 6;
+    }
     else
     {
         switch (m_Command)

--- a/indi-celestronaux/auxproto.cpp
+++ b/indi-celestronaux/auxproto.cpp
@@ -47,14 +47,16 @@ char AUXCommand::DEVICE_NAME[64] = {0};
 /////////////////////////////////////////////////////////////////////////////////////
 void logBytes(unsigned char *buf, int n, const char *deviceName, uint32_t debugLevel)
 {
-    char hex_buffer[BUFFER_SIZE] = {0};
+    if (n <= 0)
+        return;
+
+    std::vector<char> hex_buffer(n * 3 + 1, 0);
     for (int i = 0; i < n; i++)
-        sprintf(hex_buffer + 3 * i, "%02X ", buf[i]);
+        snprintf(hex_buffer.data() + 3 * i, 4, "%02X ", buf[i]);
 
-    if (n > 0)
-        hex_buffer[3 * n - 1] = '\0';
+    hex_buffer[3 * n - 1] = '\0';
 
-    DEBUGFDEVICE(deviceName, debugLevel, "[%s]", hex_buffer);
+    DEBUGFDEVICE(deviceName, debugLevel, "[%s]", hex_buffer.data());
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -62,12 +64,7 @@ void logBytes(unsigned char *buf, int n, const char *deviceName, uint32_t debugL
 /////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::logResponse()
 {
-    char hex_buffer[BUFFER_SIZE] = {0}, part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
-    for (size_t i = 0; i < m_Data.size(); i++)
-        sprintf(hex_buffer + 3 * i, "%02X ", m_Data[i]);
-
-    if (m_Data.size() > 0)
-        hex_buffer[3 * m_Data.size() - 1] = '\0';
+    char part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
 
     const char * c = commandName(m_Command);
     const char * s = moduleName(m_Source);
@@ -83,13 +80,21 @@ void AUXCommand::logResponse()
     else
         snprintf(part2, BUFFER_SIZE, "%02x ->", m_Source);
 
-    if (s != nullptr)
+    if (d != nullptr)
         snprintf(part3, BUFFER_SIZE, "%5s", d);
     else
         snprintf(part3, BUFFER_SIZE, "%02x", m_Destination);
 
     if (m_Data.size() > 0)
-        DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "RES %s%s%s [%s]", part1, part2, part3, hex_buffer);
+    {
+        std::vector<char> hex_buffer(m_Data.size() * 3 + 1, 0);
+        for (size_t i = 0; i < m_Data.size(); i++)
+            snprintf(hex_buffer.data() + 3 * i, 4, "%02X ", m_Data[i]);
+
+        hex_buffer[3 * m_Data.size() - 1] = '\0';
+
+        DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "RES %s%s%s [%s]", part1, part2, part3, hex_buffer.data());
+    }
     else
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "RES %s%s%s", part1, part2, part3);
 }
@@ -99,12 +104,7 @@ void AUXCommand::logResponse()
 /////////////////////////////////////////////////////////////////////////////////////
 void AUXCommand::logCommand()
 {
-    char hex_buffer[BUFFER_SIZE] = {0}, part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
-    for (size_t i = 0; i < m_Data.size(); i++)
-        sprintf(hex_buffer + 3 * i, "%02X ", m_Data[i]);
-
-    if (m_Data.size() > 0)
-        hex_buffer[3 * m_Data.size() - 1] = '\0';
+    char part1[BUFFER_SIZE] = {0}, part2[BUFFER_SIZE] = {0}, part3[BUFFER_SIZE] = {0};
 
     const char * c = commandName(m_Command);
     const char * s = moduleName(m_Source);
@@ -120,13 +120,21 @@ void AUXCommand::logCommand()
     else
         snprintf(part2, BUFFER_SIZE, "%02x ->", m_Source);
 
-    if (s != nullptr)
+    if (d != nullptr)
         snprintf(part3, BUFFER_SIZE, "%5s", d);
     else
         snprintf(part3, BUFFER_SIZE, "%02x", m_Destination);
 
     if (m_Data.size() > 0)
-        DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "CMD %s%s%s [%s]", part1, part2, part3, hex_buffer);
+    {
+        std::vector<char> hex_buffer(m_Data.size() * 3 + 1, 0);
+        for (size_t i = 0; i < m_Data.size(); i++)
+            snprintf(hex_buffer.data() + 3 * i, 4, "%02X ", m_Data[i]);
+
+        hex_buffer[3 * m_Data.size() - 1] = '\0';
+
+        DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "CMD %s%s%s [%s]", part1, part2, part3, hex_buffer.data());
+    }
     else
         DEBUGFDEVICE(DEVICE_NAME, DEBUG_LEVEL, "CMD %s%s%s", part1, part2, part3);
 }

--- a/indi-celestronaux/auxproto.h
+++ b/indi-celestronaux/auxproto.h
@@ -62,7 +62,9 @@ enum AUXCommands
     GPS_GET_TIME         = 0x33,
     GPS_TIME_VALID       = 0x36,
     GPS_LINKED           = 0x37,
-    FOC_GET_HS_POSITIONS = 0x2c
+    FOC_GET_HS_POSITIONS = 0x2c,
+    // Evolution commands
+    GET_VOLTAGE          = 0x10
 };
 
 enum AUXTargets

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -76,7 +76,6 @@ CelestronAUX::CelestronAUX()
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
                            TELESCOPE_CAN_CONTROL_TRACK |
-                           TELESCOPE_HAS_TRACK_MODE |
                            TELESCOPE_HAS_TRACK_RATE
                            , 8);
 
@@ -291,14 +290,17 @@ bool CelestronAUX::initProperties()
     else
         SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
 
-    //    MountTypeSP[ALT_AZ].fill("ALTAZ", "AltAz", m_MountType == ALT_AZ ? ISS_ON : ISS_OFF);
-    //    MountTypeSP[EQ_FORK].fill("FORK", "EQ Fork", m_MountType == EQ_FORK ? ISS_ON : ISS_OFF);
-    //    MountTypeSP[EQ_GEM].fill("GEM", "EQ GEM", m_MountType == EQ_GEM ? ISS_ON : ISS_OFF);
-    //    MountTypeSP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    MountTypeSP[ALT_AZ].fill("ALTAZ", "AltAz", m_MountType == ALT_AZ ? ISS_ON : ISS_OFF);
+    MountTypeSP[EQ_FORK].fill("FORK", "EQ Fork", m_MountType == EQ_FORK ? ISS_ON : ISS_OFF);
+    MountTypeSP[EQ_GEM].fill("GEM", "EQ GEM", m_MountType == EQ_GEM ? ISS_ON : ISS_OFF);
+    MountTypeSP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Track Modes for Equatorial Mount
     if (m_MountType != ALT_AZ)
     {
+
+        SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_HAS_TRACK_MODE, 8);
+
         AddTrackMode("TRACK_SIDEREAL", "Sidereal", true);
         AddTrackMode("TRACK_SOLAR", "Solar");
         AddTrackMode("TRACK_LUNAR", "Lunar");
@@ -441,7 +443,7 @@ bool CelestronAUX::initProperties()
 
     Axis2PIDNP[Propotional].fill("Propotional", "Propotional", "%.2f", 0, 500, 10, 0);
     Axis2PIDNP[Derivative].fill("Derivative", "Derivative", "%.2f", 0, 100, 10, 0);
-    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 100, 10, 1);
+    Axis2PIDNP[Integral].fill("Integral", "Integral", "%.2f", 0, 100, 10, 0);
     Axis2PIDNP.fill(getDeviceName(), "AXIS2_PID", "Axis2 PID", MOUNTINFO_TAB, IP_RW, 60, IPS_IDLE);
 
     // Adaptive PID Tuning Toggles
@@ -2213,8 +2215,12 @@ void CelestronAUX::TimerHit()
                     m_LastOffset[AXIS_AZ] = offsetSteps[AXIS_AZ];
                     targetSteps[AXIS_AZ] = DegreesToEncoders(AzimuthToDegrees(targetMountAxisCoordinates.azimuth));
                     // Track rate: predicted + PID controlled correction based on tracking error: offsetSteps
-                    trackRates[AXIS_AZ] = predRate[AXIS_AZ] + m_Controllers[AXIS_AZ]->calculate(0, -offsetSteps[AXIS_AZ]);
+                    // trackRates[AXIS_AZ] = predRate[AXIS_AZ] + m_Controllers[AXIS_AZ]->calculate(0, -offsetSteps[AXIS_AZ]);
+                    double pidCorrectionAz = 0;
+                    if (m_az_pid_tuner && m_az_pid_tuner->isActivelyTuning())
+                        pidCorrectionAz = m_Controllers[AXIS_AZ]->calculate(0, -offsetSteps[AXIS_AZ]);
 
+                    trackRates[AXIS_AZ] = predRate[AXIS_AZ] + pidCorrectionAz;
                     // Apply minTrackRate logic from Skywatcher
                     double minAzTrackRate = predRate[AXIS_AZ] * MIN_TRACK_RATE_FACTOR;
                     if (trackRates[AXIS_AZ] * predRate[AXIS_AZ] < 0 || std::abs(trackRates[AXIS_AZ]) < std::abs(minAzTrackRate))
@@ -2262,7 +2268,12 @@ void CelestronAUX::TimerHit()
                     m_LastOffset[AXIS_ALT] = offsetSteps[AXIS_ALT];
                     targetSteps[AXIS_ALT]  = DegreesToEncoders(targetMountAxisCoordinates.altitude);
                     // Track rate: predicted + PID controlled correction based on tracking error: offsetSteps
-                    trackRates[AXIS_ALT] = predRate[AXIS_ALT] + m_Controllers[AXIS_ALT]->calculate(0, -offsetSteps[AXIS_ALT]);
+                    // trackRates[AXIS_ALT] = predRate[AXIS_ALT] + m_Controllers[AXIS_ALT]->calculate(0, -offsetSteps[AXIS_ALT]);
+                    double pidCorrectionAlt = 0;
+                    if (m_al_pid_tuner && m_al_pid_tuner->isActivelyTuning())
+                        pidCorrectionAlt = m_Controllers[AXIS_ALT]->calculate(0, -offsetSteps[AXIS_ALT]);
+
+                    trackRates[AXIS_ALT] = predRate[AXIS_ALT] + pidCorrectionAlt;
 
                     // Apply minTrackRate logic from Skywatcher
                     double minAlTrackRate = predRate[AXIS_ALT] * MIN_TRACK_RATE_FACTOR;

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -290,13 +290,11 @@ bool CelestronAUX::initProperties()
     else
         SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
 
-    const char *mountTypeLabel = "AltAz";
-    if (m_MountType == EQ_GEM)
-        mountTypeLabel = "EQ GEM";
-    else if (m_MountType == EQ_FORK)
-        mountTypeLabel = "EQ Fork";
-    MountTypeTP[0].fill("TYPE", "Type", mountTypeLabel);
-    MountTypeTP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    // Configure standard MountTypeSP from INDI::Telescope
+    MountTypeSP.setPermission(IP_RO);
+    MountTypeSP[MOUNT_ALTAZ].s   = (m_MountType == ALT_AZ) ? ISS_ON : ISS_OFF;
+    MountTypeSP[MOUNT_EQ_FORK].s = (m_MountType == EQ_FORK) ? ISS_ON : ISS_OFF;
+    MountTypeSP[MOUNT_EQ_GEM].s  = (m_MountType == EQ_GEM) ? ISS_ON : ISS_OFF;
 
     // Track Modes for Equatorial Mount
     if (m_MountType != ALT_AZ)
@@ -571,8 +569,6 @@ bool CelestronAUX::updateProperties()
 
     if (isConnected())
     {
-        // Main Control Panel
-        defineProperty(MountTypeTP);
         //defineProperty(GainNP);
         if (m_MountType == ALT_AZ)
             defineProperty(HorizontalCoordsNP);
@@ -750,7 +746,6 @@ bool CelestronAUX::updateProperties()
     }
     else
     {
-        deleteProperty(MountTypeTP);
         if (m_MountType == ALT_AZ)
             deleteProperty(HorizontalCoordsNP);
         deleteProperty(HomeSP);
@@ -801,7 +796,6 @@ bool CelestronAUX::saveConfigItems(FILE *fp)
     INDI::Telescope::saveConfigItems(fp);
     SaveAlignmentConfigProperties(fp);
 
-    //MountTypeTP is read-only (display only) and not persisted in config
     PortTypeSP.save(fp);
     CordWrapToggleSP.save(fp);
     CordWrapPositionSP.save(fp);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -613,9 +613,7 @@ bool CelestronAUX::updateProperties()
         getModel(AZM);
         getVersions();
 
-        // Battery and Power (only if detected/supported, but for Evolution it is standard)
-        // We'll define it here so it shows up in Mount Info
-        defineProperty(BatteryStatusTP);
+        // Battery and Power is defined only for mounts that detect/support it.
 
         // Display firmware versions - only for detected devices
         struct FWInfo { const char *name; const char *label; uint8_t *ver; };

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -613,8 +613,6 @@ bool CelestronAUX::updateProperties()
         getModel(AZM);
         getVersions();
 
-        // Battery and Power is defined only for mounts that detect/support it.
-
         // Display firmware versions - only for detected devices
         struct FWInfo { const char *name; const char *label; uint8_t *ver; };
         std::vector<FWInfo> detected;
@@ -657,7 +655,8 @@ bool CelestronAUX::updateProperties()
             FirmwareTP.fill(getDeviceName(), "Firmware Info", "Firmware Info", MOUNTINFO_TAB, IP_RO, 0, IPS_IDLE);
             defineProperty(FirmwareTP);
         }
-
+        
+        // Battery and Power is defined only for mounts that detect/support it.
         if (m_ModelVersion == MountVersion::Evolution_Nexstar || (m_BATVersion[0] || m_BATVersion[1]))
         {
             defineProperty(BatteryStatusTP);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -459,6 +459,12 @@ bool CelestronAUX::initProperties()
                             IPS_IDLE);
     AdaptiveTuningAlSP.load();
 
+    // Battery Info
+    BatteryStatusTP[BATT_LEVEL].fill("LEVEL", "Level", "Unknown");
+    BatteryStatusTP[BATT_VOLTAGE].fill("VOLTAGE", "Voltage (V)", "Unknown");
+    BatteryStatusTP[BATT_STATUS].fill("STATUS", "Power Status", "Unknown");
+    BatteryStatusTP.fill(getDeviceName(), "BATTERY_STATUS", "Battery", MOUNTINFO_TAB, IP_RO, 0, IPS_IDLE);
+
 
     /////////////////////////////////////////////////////////////////////////////////////
     /// Initial Configuration
@@ -607,6 +613,10 @@ bool CelestronAUX::updateProperties()
         getModel(AZM);
         getVersions();
 
+        // Battery and Power (only if detected/supported, but for Evolution it is standard)
+        // We'll define it here so it shows up in Mount Info
+        defineProperty(BatteryStatusTP);
+
         // Display firmware versions - only for detected devices
         struct FWInfo { const char *name; const char *label; uint8_t *ver; };
         std::vector<FWInfo> detected;
@@ -648,6 +658,12 @@ bool CelestronAUX::updateProperties()
             }
             FirmwareTP.fill(getDeviceName(), "Firmware Info", "Firmware Info", MOUNTINFO_TAB, IP_RO, 0, IPS_IDLE);
             defineProperty(FirmwareTP);
+        }
+
+        if (m_ModelVersion == MountVersion::Evolution_Nexstar || (m_BATVersion[0] || m_BATVersion[1]))
+        {
+            defineProperty(BatteryStatusTP);
+            getBatteryStatus();
         }
 
         bool hasFocuser = false;
@@ -789,6 +805,8 @@ bool CelestronAUX::updateProperties()
             deleteProperty(AdaptiveTuningAzSP);
             deleteProperty(AdaptiveTuningAlSP);
         }
+
+        deleteProperty(BatteryStatusTP);
 
         deleteProperty(FirmwareTP);
 
@@ -2056,6 +2074,17 @@ bool CelestronAUX::enforceSlewLimits()
 void CelestronAUX::TimerHit()
 {
     INDI::Telescope::TimerHit();
+
+    if (isConnected() && (m_ModelVersion == MountVersion::Evolution_Nexstar || m_BATVersion[0] || m_BATVersion[1]))
+    {
+        struct timeval now;
+        gettimeofday(&now, nullptr);
+        if (now.tv_sec - lastBatteryUpdate.tv_sec > 30)
+        {
+            getBatteryStatus();
+            lastBatteryUpdate = now;
+        }
+    }
 
     if(!enforceSlewLimits())
         return;
@@ -3366,10 +3395,6 @@ bool CelestronAUX::processResponse(AUXCommand &m)
                 m_HomingProgress[AXIS_ALT] = m.getData() == 0x00;
                 break;
 
-            case MC_SEEK_DONE:
-                m_HomingProgress[AXIS_AZ] = m.getData() == 0x00;
-                break;
-
             case MC_AUX_GUIDE_ACTIVE:
                 switch (m.source())
                 {
@@ -3455,6 +3480,61 @@ bool CelestronAUX::processResponse(AUXCommand &m)
                 }
             }
             break;
+
+            case GET_VOLTAGE:
+            {
+                if (m.source() == BAT && m.dataSize() >= 6)
+                {
+                    uint8_t charging = m.data()[0];
+                    uint8_t level_stat = m.data()[1];
+                    uint32_t voltage_uv = (static_cast<uint32_t>(m.data()[2]) << 24) |
+                                          (static_cast<uint32_t>(m.data()[3]) << 16) |
+                                          (static_cast<uint32_t>(m.data()[4]) << 8) |
+                                          static_cast<uint32_t>(m.data()[5]);
+                    double voltage = voltage_uv / 1000000.0;
+
+                    char valStr[32];
+                    sprintf(valStr, "%.2f V", voltage);
+                    BatteryStatusTP[BATT_VOLTAGE].setText(valStr);
+
+                    const char *levelStr = "Unknown";
+                    switch (level_stat)
+                    {
+                        case 0: levelStr = "Low"; break;
+                        case 1: levelStr = "Medium"; break;
+                        case 2: levelStr = "High"; break;
+                    }
+                    BatteryStatusTP[BATT_LEVEL].setText(levelStr);
+
+                    const char *statusStr = "Unknown";
+                    switch (charging)
+                    {
+                        case 0: statusStr = "Discharging"; break;
+                        case 1: statusStr = "Charging"; break;
+                        case 2: statusStr = "Full"; break;
+                    }
+                    BatteryStatusTP[BATT_STATUS].setText(statusStr);
+
+                    if (charging == 1)
+                        BatteryStatusTP.setState(IPS_BUSY);
+                    else if (level_stat == 0)
+                        BatteryStatusTP.setState(IPS_ALERT);
+                    else
+                        BatteryStatusTP.setState(IPS_OK);
+
+                    BatteryStatusTP.apply();
+                }
+            }
+            break;
+
+            case MC_SEEK_DONE:
+                if (m.source() == AZM)
+                    m_HomingProgress[AXIS_AZ] = m.getData() == 0x00;
+                // GET_CURRENT handling removed as per request
+                break;
+
+            break;
+
             default:
                 break;
 
@@ -3911,4 +3991,17 @@ void CelestronAUX::hex_dump(char *buf, AUXBuffer data, size_t size)
 
     if (size > 0)
         buf[3 * size - 1] = '\0';
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+bool CelestronAUX::getBatteryStatus()
+{
+    // Battery info from BAT module (0xb6) using command 0x10 (GET_VOLTAGE)
+    // Data is processed in processResponse(m)
+    AUXCommand bat_cmd(GET_VOLTAGE, APP, BAT);
+    sendAUXCommand(bat_cmd) && readAUXResponse(bat_cmd);
+
+    return true;
 }

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -75,8 +75,7 @@ CelestronAUX::CelestronAUX()
                            TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
-                           TELESCOPE_CAN_CONTROL_TRACK |
-                           TELESCOPE_HAS_TRACK_RATE
+                           TELESCOPE_CAN_CONTROL_TRACK
                            , 8);
 
     //Both communication available, Serial and network (tcp/ip).
@@ -300,7 +299,7 @@ bool CelestronAUX::initProperties()
     if (m_MountType != ALT_AZ)
     {
 
-        SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_HAS_TRACK_MODE, 8);
+        SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_HAS_TRACK_MODE | TELESCOPE_HAS_TRACK_RATE, 8);
 
         AddTrackMode("TRACK_SIDEREAL", "Sidereal", true);
         AddTrackMode("TRACK_SOLAR", "Solar");

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -3549,10 +3549,10 @@ bool CelestronAUX::processResponse(AUXCommand &m)
 /////////////////////////////////////////////////////////////////////////////////////
 bool CelestronAUX::serialReadResponse(AUXCommand c)
 {
-    int n;
     unsigned char buf[MAX_AUX_PACKET_SIZE];
     char hexbuf[sizeof(buf) * 3];
     AUXCommand cmd;
+    size_t packet_size = 0;
 
     // We are not connected. Nothing to do.
     if ( PortFD <= 0 )
@@ -3562,15 +3562,16 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
     {
         // if connected to AUX or PC ports, receive AUX command response.
         // search for packet preamble (0x3b)
+        int bytes_read;
         do
         {
-            if (aux_tty_read((char * )buf, 1, READ_TIMEOUT, &n) != TTY_OK)
+            if (aux_tty_read((char * )buf, 1, READ_TIMEOUT, &bytes_read) != TTY_OK)
                 return false;
         }
         while (buf[0] != 0x3b);
 
         // packet preamble is found, now read packet length.
-        if (aux_tty_read((char * )(buf + 1), 1, READ_TIMEOUT, &n) != TTY_OK)
+        if (aux_tty_read((char * )(buf + 1), 1, READ_TIMEOUT, &bytes_read) != TTY_OK)
             return false;
 
         if (buf[1] + 3 > (int)sizeof(buf))
@@ -3580,14 +3581,16 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
         }
 
         // now packet length is known, read the rest of the packet.
-        if (aux_tty_read((char * )(buf + 2), buf[1] + 1, READ_TIMEOUT, &n)
-                != TTY_OK || n != buf[1] + 1)
+        int payload_bytes_read;
+        if (aux_tty_read((char * )(buf + 2), buf[1] + 1, READ_TIMEOUT, &payload_bytes_read)
+                != TTY_OK || payload_bytes_read != buf[1] + 1)
         {
             LOG_DEBUG("Did not got whole packet. Dropping out.");
             return false;
         }
 
-        AUXBuffer b(buf, buf + (n + 2));
+        packet_size = payload_bytes_read + 2;
+        AUXBuffer b(buf, buf + packet_size);
         hex_dump(hexbuf, b, b.size());
         DEBUGF(DBG_SERIAL, "RES <%s>", hexbuf);
         cmd.parseBuf(b);
@@ -3603,15 +3606,16 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
             return false;
         }
 
-        if ((tty_read(PortFD, (char *)buf + 5, response_data_size + 1, READ_TIMEOUT, &n) !=
-                TTY_OK) || (n != response_data_size + 1))
+        int response_bytes_read;
+        if ((tty_read(PortFD, (char *)buf + 5, response_data_size + 1, READ_TIMEOUT, &response_bytes_read) !=
+                TTY_OK) || (response_bytes_read != response_data_size + 1))
             return false;
 
         // if last char is not '#', there was an error.
         if (buf[response_data_size + 5] != '#')
         {
-            LOGF_ERROR("Resp. char %d is %2.2x ascii %c", n, buf[n + 5], (char)buf[n + 5]);
-            AUXBuffer b(buf, buf + (response_data_size + 5));
+            LOGF_ERROR("Resp. char %d is %2.2x ascii %c", response_bytes_read, buf[response_data_size + 5], (char)buf[response_data_size + 5]);
+            AUXBuffer b(buf + 5, buf + 5 + response_bytes_read);
             hex_dump(hexbuf, b, b.size());
             LOGF_ERROR("RES <%s>", hexbuf);
             return false;
@@ -3623,19 +3627,18 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
         buf[3] = c.source();
         buf[4] = c.command();
 
-        AUXBuffer b(buf, buf + (response_data_size + 5));
+        packet_size = response_data_size + 5;
+        AUXBuffer b(buf, buf + packet_size);
         hex_dump(hexbuf, b, b.size());
         DEBUGF(DBG_SERIAL, "RES (%d B): <%s>", (int)b.size(), hexbuf);
         cmd.parseBuf(b, false);
     }
 
     // Got the packet, process it
-    // n:length field >=3
-    // The buffer of n+2>=5 bytes contains:
-    // 0x3b <n>=3> <from> <to> <type> <n-3 bytes> <xsum>
+    // packet_size: total length of reconstructed or received AUX packet
 
-    DEBUGF(DBG_SERIAL, "Got %d bytes:  ; payload length field: %d ; MSG:", n, buf[1]);
-    logBytes(buf, n + 2, getDeviceName(), DBG_SERIAL);
+    DEBUGF(DBG_SERIAL, "Got %d bytes:  ; payload length field: %d ; MSG:", (int)packet_size, buf[1]);
+    logBytes(buf, packet_size, getDeviceName(), DBG_SERIAL);
     processResponse(cmd);
     return true;
 }
@@ -3851,6 +3854,9 @@ bool CelestronAUX::detectHC(char *version, size_t size)
     // We are not connected. Nothing to do.
     if ( PortFD <= 0 )
         return false;
+
+    // Flush any transient garbage bytes from the UART buffer
+    tcflush(PortFD, TCIOFLUSH);
 
     // send get firmware version command
     if (sendBuffer(b) != (int)b.size())

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -3491,7 +3491,7 @@ bool CelestronAUX::processResponse(AUXCommand &m)
                     double voltage = voltage_uv / 1000000.0;
 
                     char valStr[32];
-                    sprintf(valStr, "%.2f V", voltage);
+                    snprintf(valStr, sizeof(valStr), "%.2f V", voltage);
                     BatteryStatusTP[BATT_VOLTAGE].setText(valStr);
 
                     const char *levelStr = "Unknown";

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -459,17 +459,6 @@ bool CelestronAUX::initProperties()
                             IPS_IDLE);
     AdaptiveTuningAlSP.load();
 
-    // Firmware Info
-    FirmwareTP[FW_MODEL].fill("Model", "", nullptr);
-    FirmwareTP[FW_HC].fill("HC version", "", nullptr);
-    FirmwareTP[FW_MB].fill("Mother Board version", "", nullptr);
-    FirmwareTP[FW_AZM].fill("Ra/AZM version", "", nullptr);
-    FirmwareTP[FW_ALT].fill("Dec/ALT version", "", nullptr);
-    FirmwareTP[FW_WiFi].fill("WiFi version", "", nullptr);
-    FirmwareTP[FW_FOCUS].fill("Focuser version", "", nullptr);
-    FirmwareTP[FW_BAT].fill("Battery version", "", nullptr);
-    FirmwareTP[FW_GPS].fill("GPS version", "", nullptr);
-    FirmwareTP.fill(getDeviceName(), "Firmware Info", "Firmware Info", MOUNTINFO_TAB, IP_RO, 0, IPS_IDLE);
 
     /////////////////////////////////////////////////////////////////////////////////////
     /// Initial Configuration
@@ -617,27 +606,49 @@ bool CelestronAUX::updateProperties()
 
         getModel(AZM);
         getVersions();
-        // display firmware versions
-        char fwText[24] = {0};
-        formatModelString(fwText, sizeof(fwText), m_ModelVersion);
-        FirmwareTP[FW_MODEL].setText(fwText);
-        formatVersionString(fwText, 10, m_HCVersion);
-        FirmwareTP[FW_HC].setText(fwText);
-        formatVersionString(fwText, 10, m_MainBoardVersion);
-        FirmwareTP[FW_MB].setText(fwText);
-        formatVersionString(fwText, 10, m_AzimuthVersion);
-        FirmwareTP[FW_AZM].setText(fwText);
-        formatVersionString(fwText, 10, m_AltitudeVersion);
-        FirmwareTP[FW_ALT].setText(fwText);
-        formatVersionString(fwText, 10, m_WiFiVersion);
-        FirmwareTP[FW_WiFi].setText(fwText);
-        formatVersionString(fwText, 10, m_BATVersion);
-        FirmwareTP[FW_BAT].setText(fwText);
-        formatVersionString(fwText, 10, m_GPSVersion);
-        FirmwareTP[FW_GPS].setText(fwText);
-        formatVersionString(fwText, 10, m_FocusVersion);
-        FirmwareTP[FW_FOCUS].setText(fwText);
-        defineProperty(FirmwareTP);
+
+        // Display firmware versions - only for detected devices
+        struct FWInfo { const char *name; const char *label; uint8_t *ver; };
+        std::vector<FWInfo> detected;
+
+        char modelText[24] = {0};
+        formatModelString(modelText, sizeof(modelText), m_ModelVersion);
+        if (strcmp(modelText, "Unknown") != 0)
+            detected.push_back({"MODEL", "Model", nullptr}); // Special case for model
+
+        if (m_HCVersion[0] || m_HCVersion[1] || m_HCVersion[2] || m_HCVersion[3])
+            detected.push_back({"HC", "HC version", m_HCVersion});
+        if (m_MainBoardVersion[0] || m_MainBoardVersion[1] || m_MainBoardVersion[2] || m_MainBoardVersion[3])
+            detected.push_back({"MB", "Mother Board version", m_MainBoardVersion});
+        if (m_AzimuthVersion[0] || m_AzimuthVersion[1] || m_AzimuthVersion[2] || m_AzimuthVersion[3])
+            detected.push_back({"AZM", "Ra/AZM version", m_AzimuthVersion});
+        if (m_AltitudeVersion[0] || m_AltitudeVersion[1] || m_AltitudeVersion[2] || m_AltitudeVersion[3])
+            detected.push_back({"ALT", "Dec/ALT version", m_AltitudeVersion});
+        if (m_WiFiVersion[0] || m_WiFiVersion[1] || m_WiFiVersion[2] || m_WiFiVersion[3])
+            detected.push_back({"WiFi", "WiFi version", m_WiFiVersion});
+        if (m_BATVersion[0] || m_BATVersion[1] || m_BATVersion[2] || m_BATVersion[3])
+            detected.push_back({"BAT", "Battery version", m_BATVersion});
+        if (m_GPSVersion[0] || m_GPSVersion[1] || m_GPSVersion[2] || m_GPSVersion[3])
+            detected.push_back({"GPS", "GPS version", m_GPSVersion});
+        if (m_FocusVersion[0] || m_FocusVersion[1] || m_FocusVersion[2] || m_FocusVersion[3])
+            detected.push_back({"FOCUS", "Focuser version", m_FocusVersion});
+
+        if (!detected.empty())
+        {
+            FirmwareTP.resize(detected.size());
+            for (size_t i = 0; i < detected.size(); ++i)
+            {
+                char fwText[24] = {0};
+                if (detected[i].ver == nullptr) // Model
+                    strncpy(fwText, modelText, sizeof(fwText));
+                else
+                    formatVersionString(fwText, sizeof(fwText), detected[i].ver);
+                
+                FirmwareTP[i].fill(detected[i].name, detected[i].label, fwText);
+            }
+            FirmwareTP.fill(getDeviceName(), "Firmware Info", "Firmware Info", MOUNTINFO_TAB, IP_RO, 0, IPS_IDLE);
+            defineProperty(FirmwareTP);
+        }
 
         bool hasFocuser = false;
         for(size_t i = 0; i < sizeof(m_FocusVersion); i++)

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -177,7 +177,7 @@ bool CelestronAUX::Handshake()
         LOG_DEBUG("Connection ready. Starting Processing.");
 
         // set mount type to alignment subsystem
-        //SetApproximateMountAlignmentFromMountType(static_cast<MountType>(MountTypeSP.findOnSwitchIndex()));
+        //SetApproximateMountAlignmentFromMountType(m_MountType);
         // tell the alignment math plugin to reinitialise
         Initialise(this);
 
@@ -291,10 +291,13 @@ bool CelestronAUX::initProperties()
     else
         SetApproximateMountAlignment(m_Location.latitude >= 0 ? NORTH_CELESTIAL_POLE : SOUTH_CELESTIAL_POLE);
 
-    //    MountTypeSP[ALT_AZ].fill("ALTAZ", "AltAz", m_MountType == ALT_AZ ? ISS_ON : ISS_OFF);
-    //    MountTypeSP[EQ_FORK].fill("FORK", "EQ Fork", m_MountType == EQ_FORK ? ISS_ON : ISS_OFF);
-    //    MountTypeSP[EQ_GEM].fill("GEM", "EQ GEM", m_MountType == EQ_GEM ? ISS_ON : ISS_OFF);
-    //    MountTypeSP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    const char *mountTypeLabel = "AltAz";
+    if (m_MountType == EQ_GEM)
+        mountTypeLabel = "EQ GEM";
+    else if (m_MountType == EQ_FORK)
+        mountTypeLabel = "EQ Fork";
+    MountTypeTP[0].fill("TYPE", "Type", mountTypeLabel);
+    MountTypeTP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Track Modes for Equatorial Mount
     if (m_MountType != ALT_AZ)
@@ -567,7 +570,7 @@ bool CelestronAUX::updateProperties()
     if (isConnected())
     {
         // Main Control Panel
-        //defineProperty(MountTypeSP);
+        defineProperty(MountTypeTP);
         //defineProperty(GainNP);
         if (m_MountType == ALT_AZ)
             defineProperty(HorizontalCoordsNP);
@@ -745,7 +748,7 @@ bool CelestronAUX::updateProperties()
     }
     else
     {
-        //deleteProperty(MountTypeSP.getName());
+        deleteProperty(MountTypeTP);
         if (m_MountType == ALT_AZ)
             deleteProperty(HorizontalCoordsNP);
         deleteProperty(HomeSP);
@@ -796,7 +799,7 @@ bool CelestronAUX::saveConfigItems(FILE *fp)
     INDI::Telescope::saveConfigItems(fp);
     SaveAlignmentConfigProperties(fp);
 
-    //MountTypeSP.save(fp);
+    //MountTypeTP is read-only (display only) and not persisted in config
     PortTypeSP.save(fp);
     CordWrapToggleSP.save(fp);
     CordWrapPositionSP.save(fp);
@@ -977,29 +980,6 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
 {
     if (strcmp(dev, getDeviceName()) == 0)
     {
-        // mount type
-        //        if (MountTypeSP.isNameMatch(name))
-        //        {
-        //            // Get current type
-        //            MountType currentMountType = static_cast<MountType>(MountTypeSP.findOnSwitchIndex());
-
-        //            MountTypeSP.update(states, names, n);
-        //            MountTypeSP.setState(IPS_OK);
-        //            MountTypeSP.apply();
-
-        //            // Get target type
-        //            MountType targetMountType = static_cast<MountType>(MountTypeSP.findOnSwitchIndex());
-
-        //            // If different then update
-        //            if (currentMountType != targetMountType)
-        //            {
-        //                LOG_INFO("Mount type updated. You must restart the driver for changes to take effect.");
-        //                saveConfig(true, MountTypeSP.getName());
-        //            }
-
-        //            return true;
-        //        }
-
         // Approach Direction
         if (ApproachDirectionSP.isNameMatch(name))
         {
@@ -2354,7 +2334,7 @@ bool CelestronAUX::updateLocation(double latitude, double longitude, double elev
 
     // Do we really need this in update Location??
     // take care of latitude for north or south emisphere
-    //SetApproximateMountAlignmentFromMountType(static_cast<MountType>(IUFindOnSwitchIndex(&MountTypeSP)));
+    //SetApproximateMountAlignmentFromMountType(m_MountType);
     // tell the alignment math plugin to reinitialise
     //Initialise(this);
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -3550,8 +3550,8 @@ bool CelestronAUX::processResponse(AUXCommand &m)
 bool CelestronAUX::serialReadResponse(AUXCommand c)
 {
     int n;
-    unsigned char buf[32];
-    char hexbuf[24];
+    unsigned char buf[MAX_AUX_PACKET_SIZE];
+    char hexbuf[sizeof(buf) * 3];
     AUXCommand cmd;
 
     // We are not connected. Nothing to do.
@@ -3573,6 +3573,12 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
         if (aux_tty_read((char * )(buf + 1), 1, READ_TIMEOUT, &n) != TTY_OK)
             return false;
 
+        if (buf[1] + 3 > (int)sizeof(buf))
+        {
+            LOGF_ERROR("Packet length %d exceeds buffer size", buf[1]);
+            return false;
+        }
+
         // now packet length is known, read the rest of the packet.
         if (aux_tty_read((char * )(buf + 2), buf[1] + 1, READ_TIMEOUT, &n)
                 != TTY_OK || n != buf[1] + 1)
@@ -3591,6 +3597,12 @@ bool CelestronAUX::serialReadResponse(AUXCommand c)
         // if connected to HC serial, build up the AUX command response from
         // given AUX command and passthrough response without checksum.
         // read passthrough response
+        if (response_data_size + 6 > (int)sizeof(buf))
+        {
+            LOGF_ERROR("Response data size %d too large for buffer", response_data_size);
+            return false;
+        }
+
         if ((tty_read(PortFD, (char *)buf + 5, response_data_size + 1, READ_TIMEOUT, &n) !=
                 TTY_OK) || (n != response_data_size + 1))
             return false;
@@ -3664,7 +3676,7 @@ bool CelestronAUX::tcpReadResponse()
                     AUXBuffer b(buf + i, buf + shft);
                     cmd.parseBuf(b);
 
-                    char hexbuf[32 * 3] = {0};
+                    char hexbuf[MAX_AUX_PACKET_SIZE * 3] = {0};
                     hex_dump(hexbuf, b, b.size());
                     DEBUGF(DBG_SERIAL, "RES <%s>", hexbuf);
 
@@ -3724,7 +3736,7 @@ int CelestronAUX::sendBuffer(AUXBuffer buf)
         if ((unsigned)n != buf.size())
             LOGF_WARN("sendBuffer: incomplete send n=%d size=%d", n, (int)buf.size());
 
-        char hexbuf[32 * 3] = {0};
+        char hexbuf[MAX_AUX_PACKET_SIZE * 3] = {0};
         hex_dump(hexbuf, buf, buf.size());
         DEBUGF(DBG_SERIAL, "CMD <%s>", hexbuf);
 

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -4016,7 +4016,5 @@ bool CelestronAUX::getBatteryStatus()
     // Battery info from BAT module (0xb6) using command 0x10 (GET_VOLTAGE)
     // Data is processed in processResponse(m)
     AUXCommand bat_cmd(GET_VOLTAGE, APP, BAT);
-    sendAUXCommand(bat_cmd) && readAUXResponse(bat_cmd);
-
-    return true;
+    return sendAUXCommand(bat_cmd) && readAUXResponse(bat_cmd);
 }

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -526,6 +526,7 @@ class CelestronAUX :
         // MC_SET_POS_GUIDERATE & MC_SET_NEG_GUIDERATE use 24bit number rate in
         static constexpr uint8_t RATE_PER_ARCSEC {4};
 
+        static constexpr size_t MAX_AUX_PACKET_SIZE {258};
         static constexpr uint32_t BUFFER_SIZE {10240};
         // seconds
         static constexpr uint8_t READ_TIMEOUT {1};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -401,8 +401,8 @@ class CelestronAUX :
         // Firmware
         INDI::PropertyText FirmwareTP {9};
         enum {FW_MODEL, FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS, FW_FOCUS};
-        // Mount type
-        //INDI::PropertySwitch MountTypeSP {3};
+        // Mount type (read-only display)
+        INDI::PropertyText MountTypeTP {1};
 
         // Mount Cord wrap Toogle
         INDI::PropertySwitch CordWrapToggleSP {2};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -402,6 +402,12 @@ class CelestronAUX :
         INDI::PropertyText FirmwareTP {0};
         enum {FW_MODEL, FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS, FW_FOCUS};
 
+        // Evolution Battery Status
+        INDI::PropertyText BatteryStatusTP {3};
+        enum { BATT_LEVEL, BATT_VOLTAGE, BATT_STATUS };
+        bool getBatteryStatus();
+        struct timeval lastBatteryUpdate {0, 0};
+
         // Mount Cord wrap Toogle
         INDI::PropertySwitch CordWrapToggleSP {2};
 

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -401,8 +401,6 @@ class CelestronAUX :
         // Firmware
         INDI::PropertyText FirmwareTP {9};
         enum {FW_MODEL, FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS, FW_FOCUS};
-        // Mount type (read-only display)
-        INDI::PropertyText MountTypeTP {1};
 
         // Mount Cord wrap Toogle
         INDI::PropertySwitch CordWrapToggleSP {2};

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -399,7 +399,7 @@ class CelestronAUX :
         ///////////////////////////////////////////////////////////////////////////////
 
         // Firmware
-        INDI::PropertyText FirmwareTP {9};
+        INDI::PropertyText FirmwareTP {0};
         enum {FW_MODEL, FW_HC, FW_MB, FW_AZM, FW_ALT, FW_WiFi, FW_BAT, FW_GPS, FW_FOCUS};
 
         // Mount Cord wrap Toogle

--- a/make_deb_pkgs
+++ b/make_deb_pkgs
@@ -18,7 +18,7 @@
 set -e
 
 DRV_LIST=$@
-SRC_DIR=`pwd`
+SRC_DIR="$(dirname "$(realpath "$0")")"
 
 #at least one driver is needed as argument
 #otherwise abort the script!
@@ -32,7 +32,7 @@ fi
 #otherwise abort the script!
 for drv in $DRV_LIST ; do
 (
-  if [ ! -d "$drv" ]; then
+  if [ ! -d "${SRC_DIR}/$drv" ]; then
     echo "$drv" "directory doesn't exist"
     exit 1
   fi


### PR DESCRIPTION
This PR introduces support for battery telemetry on Celestron Evolution (and other battery-powered) mounts, along with several stability and architectural improvements to the Celestron AUX driver.

## Summary of Changes

### 1. Evolution Battery Telemetry
- **Hardware-level Reporting**: Implemented battery status reading from the `BAT` module (0xb6) using the `GET_VOLTAGE` (0x10) command.
- **Improved UI Presentation**:
    - Replaced estimated percentage calculations with direct mount-reported states: **Low**, **Medium**, and **High**.
    - Consolidated Power Status reporting: **Charging**, **Discharging**, and **Full**.
- **Efficiency**: Optimized communication by consolidating voltage, level status, and charging state into a single packet update every 30 seconds.
- **Reliability**: Minimal additions to `auxproto` ensure correct response data size synchronization, particularly for Serial/HC communication modes.

### 2. Stability & Tracking Improvements
- **PID Tuning Logic**: Fixed the application of PID tracking corrections to ensure they are only active during actual tuning phases, improving stability in standard tracking modes.
- **Track Rate Logic**: Enhanced AltAz tracking mode by correctly applying predicted rates and PID-controlled corrections.
- **UI Consistency**: Transitioned several mount properties to read-only where appropriate (e.g., MountType) to prevent accidental misconfiguration and improved the Firmware Information display logic.

### 3. Build & Maintainability
- **Driver Version**: Bumped driver version to **1.6** to reflect the major new feature set and stability fixes.
- **Build System**: Updated `make_deb_pkgs` script to allow building in out-of-source directories, facilitating cleaner development environments.
- **Code Quality**: Performed extensive cleanup of redundant code related to legacy light and charging port controls that are not supported or relevant to current operations.

## Commits included in this PR:
- `Debian: Bump version to 1.6`
- `Bump version to 1.6`
- `Evolution: Add battery telemetry support and stabilize property updates`
- `Make it possible to build debs in other dirs.`
- `Fix PID tracking corrections application and TRACKING_MODE for AltAz`
- `Add read-only MountTypeTP text property, remove MountTypeSP dead code`

## Testing Performed
- Validated telemetry reading against the Evolution mount simulator.
- Verified frame synchronization and response parsing in HC/Serial mode.
- Tested out-of-source package building and verified versioning in generated .deb files.
