### PR TITLE
Update libqsi version number in debian meta

### DIFF
--- a/debian/libqsi/changelog
+++ b/debian/libqsi/changelog
@@ -1,3 +1,9 @@
+libqsi (7.6.2) noble; urgency=medium
+
+  * New release
+
+ -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Sat, 30 May 2026 20:18:11 +0300
+
 libqsi (7.6.1) bionic; urgency=medium
 
   * New release

--- a/debian/libqsi/libqsi7.install
+++ b/debian/libqsi/libqsi7.install
@@ -1,4 +1,4 @@
-usr/lib/*/libqsiapi.so.7.6.1
+usr/lib/*/libqsiapi.so.7.6.2
 usr/lib/*/libqsiapi.so.7
 usr/bin/qsiapitest
 usr/bin/qsiapidemo


### PR DESCRIPTION
The QSI SDK provides `get_ImageArraySize()` to query the image array dimensions and element size used for `get_ImageArray()`. The driver previously declared the frame buffer pointer before querying this size and relied on the existing frame buffer allocation, which could be based on stale and/or predicted dimensions rather than the actual size.

This PR revises the `grabImage()` function to call `get_ImageArraySize()` immediately before image download, resize the INDI frame buffer from the SDK-reported `x * y * z` size, and then refresh the frame buffer pointer before passing it to `get_ImageArray()`. This should hopefully avoid the buffer overflow issue reported in #1240, #1241, and indilib/indi#2207.