### PR TITLE
indi-eqmod: enable home indexer access for SkyWatcher Wave 150i

### DIFF
--- a/indi-eqmod/skywatcher.cpp
+++ b/indi-eqmod/skywatcher.cpp
@@ -209,7 +209,7 @@ uint32_t Skywatcher::GetDEPeriod()
 
 uint32_t Skywatcher::GetlastreadRAIndexer()
 {
-    if (MountCode != 0x04 && MountCode != 0x05 && MountCode != 0x20 && MountCode != 0x25)
+    if (MountCode != 0x04 && MountCode != 0x05 && MountCode != 0x20 && MountCode != 0x25 && MountCode != 0x45)
         throw EQModError(EQModError::ErrInvalidCmd, "Incorrect mount type");
     DEBUGF(telescope->DBG_SCOPE_STATUS, "%s() = %ld", __FUNCTION__, static_cast<long>(lastreadIndexer[Axis1]));
     return lastreadIndexer[Axis1];
@@ -217,7 +217,7 @@ uint32_t Skywatcher::GetlastreadRAIndexer()
 
 uint32_t Skywatcher::GetlastreadDEIndexer()
 {
-    if (MountCode != 0x04 && MountCode != 0x05 && MountCode != 0x20 && MountCode != 0x25)
+    if (MountCode != 0x04 && MountCode != 0x05 && MountCode != 0x20 && MountCode != 0x25 && MountCode != 0x45)
         throw EQModError(EQModError::ErrInvalidCmd, "Incorrect mount type");
     DEBUGF(telescope->DBG_SCOPE_STATUS, "%s() = %ld", __FUNCTION__, static_cast<long>(lastreadIndexer[Axis2]));
     return lastreadIndexer[Axis2];


### PR DESCRIPTION
SkyWatcher Wave 150i reports MountCode 0x45.

The mount reports home indexer support through axis feature bits, so EQMod enables TELESCOPE_CAN_HOME_FIND. However, AutoHome fails because GetlastreadRAIndexer() and GetlastreadDEIndexer() reject MountCode 0x45 with "Incorrect mount type".

This change allows MountCode 0x45 to use the existing home indexer path.

Tested on SkyWatcher Wave 150i with KStars/Ekos and INDI EQMod. FindHome completes normally.