### PR TITLE
Improves/updates/fixes indi-gige driver

### DIFF
--- a/indi-gige/AUTHORS
+++ b/indi-gige/AUTHORS
@@ -1,1 +1,2 @@
 Hendrik Beijeman  (hbeyeman@gmail.com) http://phym.nl
+Spencer E. Olson (olsonse@umich.edu)

--- a/indi-gige/README
+++ b/indi-gige/README
@@ -15,7 +15,7 @@ Requirements
 
 	cfitsio-devel is required to compile support for FITS.
 	
-+ aravis >= v0.6
++ aravis >= v0.8
 
 	aravis is required, see https://github.com/AravisProject/aravis
 
@@ -57,9 +57,9 @@ GigE machine vision overview
             (2b) Vendor specific set
 
     Project Aravis only uses genicam standard. For some features you need to
-    access the CSR directly. These can easily be queried with arv-tool-0.6  that come
+    access the CSR directly. These can easily be queried with arv-tool-0.8  that come
     with aravis, i.e.
-        $ arv-tool-0.6 control R[0xF0F00A00] R[0xF0F00A04] R[0xF0F00A08] R[0xF0F00A10] R[0xF0F00A14]
+        $ arv-tool-0.8 control R[0xF0F00A00] R[0xF0F00A04] R[0xF0F00A08] R[0xF0F00A10] R[0xF0F00A14]
 
             Point Grey Research-16048874
             R[0xf0f00a00] = 0x08000600

--- a/indi-gige/indi_gige_ccd.xml
+++ b/indi-gige/indi_gige_ccd.xml
@@ -1,7 +1,7 @@
 <devGroup group="CCDs">
         <device label="GigE CCD" mdpd="true">
                 <driver name="GigE CCD">indi_gige_ccd</driver>
-		<version>0.1</version>
+		<version>0.2</version>
 	</device>
 </devGroup>
 

--- a/indi-gige/src/ArvFactory.cpp
+++ b/indi-gige/src/ArvFactory.cpp
@@ -36,7 +36,7 @@ arv::ArvCamera *ArvFactory::find_first_available(void)
         return nullptr;
 
 
-    const char *device_id = arv_get_device_serial_nbr(0);
+    const char *device_id = arv_get_device_id(0);
     const char *model_name = arv_get_device_model(0);
 
     if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL)))

--- a/indi-gige/src/ArvFactory.cpp
+++ b/indi-gige/src/ArvFactory.cpp
@@ -26,27 +26,49 @@
 
 #define BLACKFLY_MODEL "BFLY-PGE-31S4M"
 
+namespace arv {
+  std::unique_ptr<arv::ArvCamera> create_camera(unsigned int index)
+  {
+      if (index >= arv_get_n_devices())
+          /* no devices found */
+          return nullptr;
+
+      const char *device_id = arv_get_device_id(index);
+      const char *model_name = arv_get_device_model(index);
+
+      if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL)))
+      {
+          printf("Creating BlackFly... for %s-%s\n", model_name, device_id);
+          return std::unique_ptr<ArvCamera>(new BlackFly(device_id, model_name));
+      }
+      else
+      {
+          printf("Creating Generic... for %s-%s\n", model_name, device_id);
+          return std::unique_ptr<ArvCamera>(new ArvGeneric(device_id, model_name));
+      }
+  }
+}
+
 std::unique_ptr<arv::ArvCamera> ArvFactory::find_first_available(void)
 {
     /* We first ensure the library knows of all available devices and info */
     arv_update_device_list();
+    return create_camera(0);
+}
 
-    if (arv_get_n_devices() == 0)
-        /* no devices found */
-        return nullptr;
+ArvFactory::Iterator ArvFactory::begin(void)
+{
+    /* We first ensure the library knows of all available devices and info */
+    arv_update_device_list();
+    return ArvFactory::Iterator(0);
+}
 
+ArvFactory::Iterator ArvFactory::end(void)
+{
+    return ArvFactory::Iterator(arv_get_n_devices());
+}
 
-    const char *device_id = arv_get_device_id(0);
-    const char *model_name = arv_get_device_model(0);
-
-    if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL)))
-    {
-        printf("Creating BlackFly... for %s-%s\n", model_name, device_id);
-        return std::unique_ptr<ArvCamera>(new BlackFly(device_id, model_name));
-    }
-    else
-    {
-        printf("Creating Generic... for %s-%s\n", model_name, device_id);
-        return std::unique_ptr<ArvCamera>(new ArvGeneric(device_id, model_name));
-    }
+std::unique_ptr<arv::ArvCamera> ArvFactory::Index::instantiate(void) const
+{
+    return create_camera(this->index);
 }

--- a/indi-gige/src/ArvFactory.cpp
+++ b/indi-gige/src/ArvFactory.cpp
@@ -26,7 +26,7 @@
 
 #define BLACKFLY_MODEL "BFLY-PGE-31S4M"
 
-arv::ArvCamera *ArvFactory::find_first_available(void)
+std::unique_ptr<arv::ArvCamera> ArvFactory::find_first_available(void)
 {
     /* We first ensure the library knows of all available devices and info */
     arv_update_device_list();
@@ -42,11 +42,11 @@ arv::ArvCamera *ArvFactory::find_first_available(void)
     if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL)))
     {
         printf("Creating BlackFly... for %s-%s\n", model_name, device_id);
-        return new BlackFly(device_id, model_name);
+        return std::unique_ptr<ArvCamera>(new BlackFly(device_id, model_name));
     }
     else
     {
         printf("Creating Generic... for %s-%s\n", model_name, device_id);
-        return new ArvGeneric(device_id, model_name);
+        return std::unique_ptr<ArvCamera>(new ArvGeneric(device_id, model_name));
     }
 }

--- a/indi-gige/src/ArvFactory.cpp
+++ b/indi-gige/src/ArvFactory.cpp
@@ -28,21 +28,25 @@
 
 arv::ArvCamera *ArvFactory::find_first_available(void)
 {
-    GError *error = NULL;
-    ::ArvCamera *camera    = arv_camera_new(nullptr, &error);
-    const char *model_name = arv_camera_get_model_name(camera, &error);
+    /* We first ensure the library knows of all available devices and info */
+    arv_update_device_list();
 
-    if ((camera == nullptr) || (model_name == nullptr))
+    if (arv_get_n_devices() == 0)
+        /* no devices found */
         return nullptr;
+
+
+    const char *device_id = arv_get_device_serial_nbr(0);
+    const char *model_name = arv_get_device_model(0);
 
     if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL)))
     {
-        printf("Creating BlackFly...\n");
-        return new BlackFly((void *)camera);
+        printf("Creating BlackFly... for %s-%s\n", model_name, device_id);
+        return new BlackFly(device_id, model_name);
     }
     else
     {
-        printf("Creating Generic...\n");
-        return new ArvGeneric((void *)camera);
+        printf("Creating Generic... for %s-%s\n", model_name, device_id);
+        return new ArvGeneric(device_id, model_name);
     }
 }

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -404,6 +404,19 @@ ARV_EXPOSURE_STATUS ArvGeneric::exposure_poll(void (*fn_image_callback)(void *co
     if (!this->_stream_active())
         return ARV_EXPOSURE_UNKNOWN;
 
+    {
+        /* There is no point in examining the buffer status until it in the
+         * output queue of the stream. */
+        gint n_inputs = 0, n_outputs = 0;
+        arv_stream_get_n_buffers(this->stream, &n_inputs, &n_outputs);
+        if (n_outputs < 1) {
+            if (n_inputs == 0) {
+                LOG_ERROR("Waiting for image data without input buffer!");
+            }
+            return ARV_EXPOSURE_BUSY;
+        }
+    }
+
     ::ArvBufferStatus const status = arv_buffer_get_status(this->buffer);
     switch (status)
     {

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -137,17 +137,27 @@ bool ArvGeneric::_get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max
     return true;
 }
 
-bool ArvGeneric::is_exposing()
+bool ArvGeneric::is_exposing_single()
 {
-    return this->stream_active;
+    bool single = this->single_acquisition_active.load();
+    bool stream = this->stream_active.load();
+    if (single && stream)
+        LOG_ERROR("Streaming during single-frame acquisition?!?");
+    return single;
 }
+
+bool ArvGeneric::is_streaming()
+{
+    bool single = this->single_acquisition_active.load();
+    bool stream = this->stream_active.load();
+    if (single && stream)
+        LOG_ERROR("Streaming during single-frame acquisition?!?");
+    return stream;
+}
+
 bool ArvGeneric::is_connected()
 {
     return (this->camera ? true : false);
-}
-bool ArvGeneric::_stream_active()
-{
-    return this->stream_active;
 }
 
 ArvGeneric::ArvGeneric(std::string device_id, std::string model_name)
@@ -197,8 +207,8 @@ bool ArvGeneric::_configure(void)
 void ArvGeneric::_init()
 {
     this->camera        = nullptr;
-    this->buffer        = nullptr;
     this->stream        = nullptr;
+    this->single_acquisition_active = false;
     this->stream_active = false;
 
     /* Don't clear device_id, its needed to re-attach with connect() */
@@ -208,7 +218,8 @@ bool ArvGeneric::disconnect()
 {
     if (this->is_connected())
     {
-        this->_test_exposure_and_abort();
+        this->exposure_abort();
+        g_clear_object(&this->stream);
         g_clear_object(&this->camera);
     }
     this->_init();
@@ -220,12 +231,10 @@ bool ArvGeneric::_set_initial_config()
     /* Configure "manual" mode
      *      (1) disable auto exposure
      *      (2) disable auto framerate (to enable maximum possible exposure time)
-     *      (3) set binning to 1x1
-     *      (4) set software trigger */
+     *      (3) set binning to 1x1 */
     CALL(arv_camera_set_binning, camera, 1, 1);
     CALL(arv_camera_set_gain_auto, camera, ARV_AUTO_OFF);
     CALL(arv_camera_set_exposure_time_auto, camera, ARV_AUTO_OFF);
-    CALL(arv_camera_set_trigger, camera, "Software");
     return true;
 }
 
@@ -289,122 +298,120 @@ void ArvGeneric::set_bin(int const bin_x, int const bin_y)
     CALL(arv_camera_set_binning, this->camera, this->cam.bin_x.val(), this->cam.bin_y.val());
 }
 
-void ArvGeneric::_test_exposure_and_abort(void)
-{
-    if (this->_stream_active())
-        this->exposure_abort();
-}
-
 template <typename T>
-void ArvGeneric::_set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**), min_max_property<T> *prop,
-                                            T const new_val)
+void ArvGeneric::set_cam_exposure_property(
+  void (*arv_set)(::ArvCamera *, T, GError**),
+  min_max_property<T> *prop, T const new_val,
+  T (*arv_get)(::ArvCamera *, GError**) )
 {
-    this->_test_exposure_and_abort();
+    if (this->is_exposing_single())
+        this->exposure_abort();
     prop->set(new_val);
     CALL(arv_set, this->camera, prop->val());
+
+    if (arv_get != nullptr)
+      prop->set(CALL_RETURN(arv_get, this->camera));
 }
 
 void ArvGeneric::set_gain(double const val)
 {
-    this->_set_cam_exposure_property(arv_camera_set_gain, &this->cam.gain, val);
+    this->set_cam_exposure_property(arv_camera_set_gain, &this->cam.gain, val,
+                                    arv_camera_get_gain);
 }
+
 void ArvGeneric::set_exposure_time(double const val)
 {
-    this->_set_cam_exposure_property(arv_camera_set_exposure_time, &this->cam.exposure, val);
+    this->set_cam_exposure_property(arv_camera_set_exposure_time,
+                                    &this->cam.exposure, val,
+                                    arv_camera_get_exposure_time);
 }
 
-::ArvBuffer *ArvGeneric::_buffer_create(void)
+void ArvGeneric::create_stream(unsigned int n_buffers)
 {
-    ::ArvBuffer *buffer;
-
-    /* Ensure no buffers in stream */
-    while (1)
-    {
-        buffer = arv_stream_try_pop_buffer(this->stream);
-        if (buffer)
-            g_clear_object(&buffer);
-        else
-            break;
+    this->stream = CALL_RETURN(arv_camera_create_stream, this->camera, nullptr, nullptr);
+    if (this->stream == nullptr) {
+        LOG_ERROR("Could not allocate a stream object!");
+        return;
     }
 
     gint const payload = CALL_RETURN(arv_camera_get_payload, this->camera);
-    buffer             = arv_buffer_new(payload, nullptr);
-    arv_stream_push_buffer(this->stream, buffer);
-    return buffer;
+    for (; n_buffers > 0; --n_buffers) {
+        auto buffer = arv_buffer_new(payload, nullptr);
+        if (this->stream == nullptr) {
+            LOG_ERROR("Could not allocate stream buffer!");
+            break;
+        }
+        arv_stream_push_buffer(this->stream, buffer);
+    }
 }
 
-::ArvStream *ArvGeneric::_stream_create(void)
+void ArvGeneric::start_acquisition(unsigned int n_buffers,
+                                   ArvAcquisitionMode mode)
 {
-    ::ArvStream *stream = CALL_RETURN(arv_camera_create_stream, this->camera, nullptr, nullptr);
-    return stream;
-}
+    this->exposure_abort();
 
-void ArvGeneric::_stream_start()
-{
-    this->stream_active = true;
+    // 1. make stream
+    this->create_stream(n_buffers);
 
-    /* Start the acquisition stream */
-    CALL(arv_camera_set_acquisition_mode, this->camera, ARV_ACQUISITION_MODE_SINGLE_FRAME);
+    // 2. Disable triggers; just acquire as soon as possible.
+    CALL(arv_camera_clear_triggers, this->camera);
+
+    // 3. start the acquisition stream
+    CALL(arv_camera_set_acquisition_mode, this->camera, mode);
     CALL(arv_camera_start_acquisition, this->camera);
 }
 
-void ArvGeneric::_stream_stop()
+void ArvGeneric::start_streaming_impl(unsigned int n_buffers)
+{
+    this->start_acquisition(n_buffers, ARV_ACQUISITION_MODE_CONTINUOUS);
+    this->stream_active = true;
+}
+
+void ArvGeneric::stop_streaming()
+{
+    this->stop_acquisition();
+}
+
+void ArvGeneric::stop_acquisition()
 {
     /* stop the acquisition stream */
     CALL(arv_camera_stop_acquisition, this->camera);
-    g_object_unref(this->stream);
+    /* Free stream resources. */
+    g_clear_object(&this->stream);
 
     this->stream_active = false;
-}
-
-void ArvGeneric::_trigger_exposure()
-{
-    /* Trigger for an exposure */
-    CALL(arv_camera_software_trigger, this->camera);
+    this->single_acquisition_active = false;
 }
 
 void ArvGeneric::exposure_start(void)
 {
-    this->_test_exposure_and_abort();
-    this->stream = this->_stream_create();
-    this->buffer = this->_buffer_create();
-
-    this->_stream_start();
-    this->_trigger_exposure();
+    this->start_acquisition(1, ARV_ACQUISITION_MODE_SINGLE_FRAME);
+    this->single_acquisition_active = true;
 }
 
 void ArvGeneric::exposure_abort(void)
 {
-    if (this->_stream_active())
+    if (this->is_acquiring())
     {
         CALL(arv_camera_abort_acquisition, this->camera);
-        this->_stream_stop();
+        this->stop_acquisition();
     }
 }
 
-void ArvGeneric::_get_image(void (*fn_image_callback)(void *const, uint8_t const *const, size_t), void *const usr_ptr)
+void ArvGeneric::_get_image(ArvGeneric::HandleImgCB fn_image_callback,
+                            ArvBuffer * buf)
 {
-    ArvBuffer *const popped_buf = arv_stream_timeout_pop_buffer(this->stream, 100000);
-    if ((popped_buf != nullptr) && (popped_buf == this->buffer) &&
-        arv_buffer_get_status(this->buffer) == ARV_BUFFER_STATUS_SUCCESS)
+    if (fn_image_callback != nullptr)
     {
-        if (fn_image_callback != nullptr)
-        {
-            size_t size;
-            uint8_t const * data = (uint8_t const *)arv_buffer_get_data(this->buffer, &size);
-            fn_image_callback(usr_ptr, data, size);
-        }
-    }
-    else
-    {
-        //TODO: failure...
+        size_t size;
+        uint8_t const * data = (uint8_t const *)arv_buffer_get_data(buf, &size);
+        fn_image_callback(data, size);
     }
 }
 
-ARV_EXPOSURE_STATUS ArvGeneric::exposure_poll(void (*fn_image_callback)(void *const, uint8_t const *const, size_t),
-                                              void *const usr_ptr)
+ARV_EXPOSURE_STATUS ArvGeneric::exposure_poll(ArvGeneric::HandleImgCB fn_image_callback)
 {
-    if (!this->_stream_active())
+    if (!this->is_exposing_single())
         return ARV_EXPOSURE_UNKNOWN;
 
     {
@@ -420,27 +427,111 @@ ARV_EXPOSURE_STATUS ArvGeneric::exposure_poll(void (*fn_image_callback)(void *co
         }
     }
 
-    ::ArvBufferStatus const status = arv_buffer_get_status(this->buffer);
+    ArvBuffer * buf = arv_stream_timeout_pop_buffer(
+      this->stream, static_cast<guint64>(this->get_exposure().val()));
+    if (buf == nullptr)
+        return ARV_EXPOSURE_BUSY;
+    ARV_EXPOSURE_STATUS retval;
+
+    ::ArvBufferStatus const status = arv_buffer_get_status(buf);
     switch (status)
     {
         case ARV_BUFFER_STATUS_CLEARED:
-            return ARV_EXPOSURE_BUSY;
+            retval = ARV_EXPOSURE_BUSY;
+            break;
         case ARV_BUFFER_STATUS_FILLING:
-            return ARV_EXPOSURE_FILLING;
+            retval = ARV_EXPOSURE_FILLING;
+            break;
         case ARV_BUFFER_STATUS_UNKNOWN:
-            return ARV_EXPOSURE_UNKNOWN;
+            retval = ARV_EXPOSURE_UNKNOWN;
+            break;
         case ARV_BUFFER_STATUS_SUCCESS:
-            this->_get_image(fn_image_callback, usr_ptr);
-            this->_stream_stop();
-            return ARV_EXPOSURE_FINISHED;
+            this->_get_image(fn_image_callback, buf);
+            this->stop_acquisition();
+            retval = ARV_EXPOSURE_FINISHED;
+            break;
         case ARV_BUFFER_STATUS_TIMEOUT:
         case ARV_BUFFER_STATUS_MISSING_PACKETS:
         case ARV_BUFFER_STATUS_WRONG_PACKET_ID:
         case ARV_BUFFER_STATUS_SIZE_MISMATCH:
         case ARV_BUFFER_STATUS_ABORTED:
-            this->_stream_stop();
-            return ARV_EXPOSURE_FAILED;
+            this->stop_acquisition();
+            retval = ARV_EXPOSURE_FAILED;
+            break;
         default:
-            return ARV_EXPOSURE_UNKNOWN;
+            retval = ARV_EXPOSURE_UNKNOWN;
+            break;
     }
+
+    if (this->is_acquiring())
+      /* give buffer back to stream and let the stream own buffer memory.
+       * This case seems unlikely.
+       */
+      arv_stream_push_buffer(this->stream, buf);
+    else
+      // free orphaned buffer
+      g_clear_object(&buf);
+    return retval;
+}
+
+ARV_EXPOSURE_STATUS ArvGeneric::next_streaming_image(ArvGeneric::HandleImgCB fn_image_callback)
+{
+    auto get_n_inputs = [this]() {
+        /* There is no point in examining the buffer status until it in the
+         * output queue of the stream. */
+        gint n_inputs = 0, n_outputs = 0;
+        arv_stream_get_n_buffers(this->stream, &n_inputs, &n_outputs);
+        return static_cast<int>(n_inputs);
+    };
+
+    if (!this->is_streaming())
+        return ARV_EXPOSURE_UNKNOWN;
+
+    auto pre_inputs = get_n_inputs();
+    ArvBuffer *const buf = arv_stream_timeout_pop_buffer(
+      this->stream, static_cast<guint64>(this->get_exposure().val()));
+    if (buf == nullptr) {
+        //LOG_DEBUG("Timed out getting next streaming image");
+        auto post_inputs = get_n_inputs();
+        if (pre_inputs != post_inputs)
+          LOGF_ERROR("Leaked %d buffers when buffer pop returned NULL!!!",
+                     (pre_inputs - post_inputs));
+        return ARV_EXPOSURE_BUSY;
+    }
+
+    ::ArvBufferStatus const status = arv_buffer_get_status(buf);
+    ARV_EXPOSURE_STATUS retval = ARV_EXPOSURE_UNKNOWN;
+    switch (status)
+    {
+        case ARV_BUFFER_STATUS_TIMEOUT:
+        case ARV_BUFFER_STATUS_CLEARED:
+            retval = ARV_EXPOSURE_BUSY;
+            break;
+        case ARV_BUFFER_STATUS_FILLING:
+            retval = ARV_EXPOSURE_FILLING;
+            break;
+        case ARV_BUFFER_STATUS_UNKNOWN:
+            retval = ARV_EXPOSURE_UNKNOWN;
+            break;
+        case ARV_BUFFER_STATUS_SUCCESS:
+            this->_get_image(fn_image_callback, buf);
+            retval = ARV_EXPOSURE_FINISHED;
+            break;
+        case ARV_BUFFER_STATUS_MISSING_PACKETS:
+        case ARV_BUFFER_STATUS_WRONG_PACKET_ID:
+        case ARV_BUFFER_STATUS_SIZE_MISMATCH:
+        case ARV_BUFFER_STATUS_ABORTED:
+            LOG_ERROR("Exposure failed, stopping acquisition");
+            this->stop_acquisition();
+            retval = ARV_EXPOSURE_FAILED;
+            break;
+        default:
+            retval = ARV_EXPOSURE_UNKNOWN;
+            break;
+    }
+
+    // give buffer back to stream and let the stream own buffer memory.
+    //LOG_DEBUG("Pushing buffer back to stream");
+    arv_stream_push_buffer(this->stream, buf);
+    return retval;
 }

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -87,6 +87,7 @@ bool ArvGeneric::_get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max
     T min, max;
     fn_arv_bounds(this->camera, &min, &max, &(this->error));
     prop->update(min, max);
+    return true;
 }
 
 bool ArvGeneric::is_exposing()
@@ -163,6 +164,7 @@ bool ArvGeneric::disconnect()
         g_clear_object(&this->camera);
     }
     this->_init();
+    return true;
 }
 
 bool ArvGeneric::_set_initial_config()
@@ -342,7 +344,7 @@ void ArvGeneric::_get_image(void (*fn_image_callback)(void *const, uint8_t const
         if (fn_image_callback != nullptr)
         {
             size_t size;
-            uint8_t const *const data = (uint8_t const *const)arv_buffer_get_data(this->buffer, &size);
+            uint8_t const * data = (uint8_t const *)arv_buffer_get_data(this->buffer, &size);
             fn_image_callback(usr_ptr, data, size);
         }
     }

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -175,12 +175,13 @@ bool ArvGeneric::connect()
             return false;
 
         this->dev             = arv_camera_get_device(this->camera);
-        const char * di = CALL_RETURN(arv_camera_get_device_id,this->camera);
-        const char * mn = CALL_RETURN(arv_camera_get_model_name,this->camera);
-        const char * vn = CALL_RETURN(arv_camera_get_vendor_name,this->camera);
-        this->cam.device_id = di;
-        this->cam.model_name = mn;
-        this->cam.vendor_name = vn;
+        this->cam.model_name  = CALL_RETURN(arv_camera_get_model_name, this->camera);
+        this->cam.vendor_name = CALL_RETURN(arv_camera_get_vendor_name,this->camera);
+        // do not change device_id since arv_camera_get_device_id seems to just
+        // return the serial number instead of the less useful
+        // "{vendor} {model}-{serial}" than arv_get_device_id that is used in
+        // camera enumeration.
+        //this->cam.device_id   = CALL_RETURN(arv_camera_get_device_id,this->camera);
     }
     this->_configure();
     return true;

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -43,7 +43,7 @@ void ArvGeneric::call_log(const char *func_description, Func &&func, Args&&... a
     }
 }
 #define CALL(func, ...) \
-  this->call_log(#func, func, __VA_ARGS__)
+  this->call_log(#func "(" #__VA_ARGS__ ")", func, __VA_ARGS__)
 
 // Variadic template error handler function
 template<typename Func, typename... Args>
@@ -59,7 +59,7 @@ auto ArvGeneric::call_log_return(const char *func_description, Func &&func, Args
     return ret;
 }
 #define CALL_RETURN(func, ...) \
-  this->call_log_return(#func, func, __VA_ARGS__)
+  this->call_log_return(#func "(" #__VA_ARGS__ ")", func, __VA_ARGS__)
 
 const char *ArvGeneric::vendor_name()
 {

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -137,6 +137,13 @@ bool ArvGeneric::_get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max
     return true;
 }
 
+template <typename T>
+bool ArvGeneric::_get_incr(T (*fn_arv_incr)(::ArvCamera *, GError**), min_max_property<T> *prop)
+{
+    prop->set_increment(CALL_RETURN(fn_arv_incr, this->camera));
+    return true;
+}
+
 bool ArvGeneric::is_exposing_single()
 {
     bool single = this->single_acquisition_active.load();
@@ -238,17 +245,24 @@ bool ArvGeneric::_set_initial_config()
     return true;
 }
 
+#define _GET_BOUNDS(T, feature, prop) \
+  this->_get_bounds<T>(arv_camera_get_ ## feature ## _bounds, &this->cam.prop)
+#define _GET_BOUNDS_INCR(T, feature, prop) \
+  _GET_BOUNDS(T, feature, prop); \
+  this->_get_incr<T>(arv_camera_get_ ## feature ## _increment, &this->cam.prop)
+
+
 bool ArvGeneric::_get_initial_config()
 {
-    this->_get_bounds<gint>(arv_camera_get_x_binning_bounds, &this->cam.bin_x);
-    this->_get_bounds<gint>(arv_camera_get_y_binning_bounds, &this->cam.bin_y);
-    this->_get_bounds<gint>(arv_camera_get_x_offset_bounds, &this->cam.x_offset);
-    this->_get_bounds<gint>(arv_camera_get_y_offset_bounds, &this->cam.y_offset);
-    this->_get_bounds<gint>(arv_camera_get_width_bounds, &this->cam.width);
-    this->_get_bounds<gint>(arv_camera_get_height_bounds, &this->cam.height);
-    this->_get_bounds<double>(arv_camera_get_frame_rate_bounds, &this->cam.frame_rate);
-    this->_get_bounds<double>(arv_camera_get_exposure_time_bounds, &this->cam.exposure);
-    this->_get_bounds<double>(arv_camera_get_gain_bounds, &this->cam.gain);
+    _GET_BOUNDS_INCR(gint, x_binning, bin_x);
+    _GET_BOUNDS_INCR(gint, y_binning, bin_y);
+    _GET_BOUNDS_INCR(gint, x_offset, x_offset);
+    _GET_BOUNDS_INCR(gint, y_offset, y_offset);
+    _GET_BOUNDS_INCR(gint, width, width);
+    _GET_BOUNDS_INCR(gint, height, height);
+    _GET_BOUNDS(double, frame_rate, frame_rate);
+    _GET_BOUNDS(double, exposure_time, exposure);
+    _GET_BOUNDS(double, gain, gain);
 
     /* No GVCP call for this..., specializations of this class could make this
      * read-only by setting min=max=val (see BlackFly implementation). */
@@ -275,19 +289,17 @@ void ArvGeneric::set_geometry(int const x, int const y, int const w, int const h
                                 this->cam.height.val());
 }
 
-void ArvGeneric::update_geometry(void)
+std::tuple<int,int,int,int> ArvGeneric::update_geometry(void)
 {
-    gint x, y, w, h, binx, biny;
+    gint x, y, w, h;
 
     CALL(arv_camera_get_region, this->camera, &x, &y, &w, &h);
-    CALL(arv_camera_get_binning, this->camera, &binx, &biny);
 
     this->cam.x_offset.set(x);
     this->cam.y_offset.set(y);
     this->cam.width.set(w);
     this->cam.height.set(h);
-    this->cam.bin_x.set(binx);
-    this->cam.bin_y.set(biny);
+    return std::tuple<int,int,int,int>(x, y, w, h);
 }
 
 void ArvGeneric::set_bin(int const bin_x, int const bin_y)
@@ -296,6 +308,17 @@ void ArvGeneric::set_bin(int const bin_x, int const bin_y)
     this->cam.bin_y.set(bin_y);
 
     CALL(arv_camera_set_binning, this->camera, this->cam.bin_x.val(), this->cam.bin_y.val());
+}
+
+std::pair<int,int> ArvGeneric::update_bin()
+{
+    /* read this back to ensure we know what binning was actually set.  For at
+     * least some cameras, a binning of 3 gets promoted to a binning of 4. */
+    gint binx, biny;
+    CALL(arv_camera_get_binning, this->camera, &binx, &biny);
+    this->cam.bin_x.set(binx);
+    this->cam.bin_y.set(biny);
+    return std::pair<int,int>(binx, biny);
 }
 
 template <typename T>

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -18,6 +18,7 @@
  */
 #include "ArvGeneric.h"
 
+#include <indilogger.h>
 #include <string>
 
 using namespace arv;
@@ -28,6 +29,37 @@ namespace {
         return (s != "" ? s.c_str() : "None");
     }
 }
+
+// Variadic template error handler function
+template<typename Func, typename... Args>
+void ArvGeneric::call_log(const char *func_description, Func &&func, Args&&... args) {
+    GError * error = nullptr;
+    func(args..., &error);
+    if (error) {
+        if (error->message)
+            LOGF_ERROR("%s: %s", func_description, error->message);
+        else
+            LOGF_ERROR("%s: unknown error!", func_description);
+    }
+}
+#define CALL(func, ...) \
+  this->call_log(#func, func, __VA_ARGS__)
+
+// Variadic template error handler function
+template<typename Func, typename... Args>
+auto ArvGeneric::call_log_return(const char *func_description, Func &&func, Args&&... args) {
+    GError * error = nullptr;
+    auto ret = func(args..., &error);
+    if (error) {
+        if (error->message)
+            LOGF_ERROR("%s: %s", func_description, error->message);
+        else
+            LOGF_ERROR("%s: unknown error!", func_description);
+    }
+    return ret;
+}
+#define CALL_RETURN(func, ...) \
+  this->call_log_return(#func, func, __VA_ARGS__)
 
 const char *ArvGeneric::vendor_name()
 {
@@ -86,11 +118,21 @@ min_max_property<double> ArvGeneric::get_frame_rate()
     return min_max_property<double>(this->cam.frame_rate);
 }
 
+bool ArvGeneric::has_feature(const char * feature)
+{
+    return CALL_RETURN(arv_camera_is_feature_available, this->camera, feature) == TRUE;
+}
+
+double ArvGeneric::get_float(const char * feature)
+{
+    return CALL_RETURN(arv_camera_get_float, this->camera, feature);
+}
+
 template <typename T>
 bool ArvGeneric::_get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop)
 {
     T min, max;
-    fn_arv_bounds(this->camera, &min, &max, &(this->error));
+    CALL(fn_arv_bounds, this->camera, &min, &max);
     prop->update(min, max);
     return true;
 }
@@ -128,12 +170,17 @@ bool ArvGeneric::connect()
     /* (Re-)connect by means of the device-id */
     if (!this->camera)
     {
-        this->camera = ::arv_camera_new(this->cam.device_id.c_str(), &(this->error));
+        this->camera = CALL_RETURN(::arv_camera_new,this->cam.device_id.c_str());
         if (!this->camera)
             return false;
 
         this->dev             = arv_camera_get_device(this->camera);
-        this->cam.vendor_name = arv_camera_get_vendor_name(this->camera, &(this->error));
+        const char * di = CALL_RETURN(arv_camera_get_device_id,this->camera);
+        const char * mn = CALL_RETURN(arv_camera_get_model_name,this->camera);
+        const char * vn = CALL_RETURN(arv_camera_get_vendor_name,this->camera);
+        this->cam.device_id = di;
+        this->cam.model_name = mn;
+        this->cam.vendor_name = vn;
     }
     this->_configure();
     return true;
@@ -174,10 +221,10 @@ bool ArvGeneric::_set_initial_config()
      *      (2) disable auto framerate (to enable maximum possible exposure time)
      *      (3) set binning to 1x1
      *      (4) set software trigger */
-    arv_camera_set_binning(camera, 1, 1, &error);
-    arv_camera_set_gain_auto(camera, ARV_AUTO_OFF, &error);
-    arv_camera_set_exposure_time_auto(camera, ARV_AUTO_OFF, &error);
-    arv_camera_set_trigger(camera, "Software", &error);
+    CALL(arv_camera_set_binning, camera, 1, 1);
+    CALL(arv_camera_set_gain_auto, camera, ARV_AUTO_OFF);
+    CALL(arv_camera_set_exposure_time_auto, camera, ARV_AUTO_OFF);
+    CALL(arv_camera_set_trigger, camera, "Software");
     return true;
 }
 
@@ -201,7 +248,7 @@ bool ArvGeneric::_get_initial_config()
 
 int ArvGeneric::get_frame_byte_size()
 {
-    return arv_camera_get_payload(this->camera, &(this->error));
+    return CALL_RETURN(arv_camera_get_payload, this->camera);
 }
 
 void ArvGeneric::set_geometry(int const x, int const y, int const w, int const h)
@@ -211,16 +258,17 @@ void ArvGeneric::set_geometry(int const x, int const y, int const w, int const h
     this->cam.width.set(w);
     this->cam.height.set(h);
 
-    arv_camera_set_region(this->camera, this->cam.x_offset.val(), this->cam.y_offset.val(), this->cam.width.val(),
-                          this->cam.height.val(), &(this->error));
+    CALL(arv_camera_set_region, this->camera, this->cam.x_offset.val(),
+                                this->cam.y_offset.val(), this->cam.width.val(),
+                                this->cam.height.val());
 }
 
 void ArvGeneric::update_geometry(void)
 {
     gint x, y, w, h, binx, biny;
 
-    arv_camera_get_region(this->camera, &x, &y, &w, &h, &(this->error));
-    arv_camera_get_binning(this->camera, &binx, &biny, &(this->error));
+    CALL(arv_camera_get_region, this->camera, &x, &y, &w, &h);
+    CALL(arv_camera_get_binning, this->camera, &binx, &biny);
 
     this->cam.x_offset.set(x);
     this->cam.y_offset.set(y);
@@ -235,7 +283,7 @@ void ArvGeneric::set_bin(int const bin_x, int const bin_y)
     this->cam.bin_x.set(bin_x);
     this->cam.bin_y.set(bin_y);
 
-    arv_camera_set_binning(this->camera, this->cam.bin_x.val(), this->cam.bin_y.val(), &(this->error));
+    CALL(arv_camera_set_binning, this->camera, this->cam.bin_x.val(), this->cam.bin_y.val());
 }
 
 void ArvGeneric::_test_exposure_and_abort(void)
@@ -250,7 +298,7 @@ void ArvGeneric::_set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GE
 {
     this->_test_exposure_and_abort();
     prop->set(new_val);
-    arv_set(this->camera, prop->val(), &(this->error));
+    CALL(arv_set, this->camera, prop->val());
 }
 
 void ArvGeneric::set_gain(double const val)
@@ -276,7 +324,7 @@ void ArvGeneric::set_exposure_time(double const val)
             break;
     }
 
-    gint const payload = arv_camera_get_payload(this->camera, &(this->error));
+    gint const payload = CALL_RETURN(arv_camera_get_payload, this->camera);
     buffer             = arv_buffer_new(payload, nullptr);
     arv_stream_push_buffer(this->stream, buffer);
     return buffer;
@@ -284,7 +332,7 @@ void ArvGeneric::set_exposure_time(double const val)
 
 ::ArvStream *ArvGeneric::_stream_create(void)
 {
-    ::ArvStream *stream = arv_camera_create_stream(this->camera, nullptr, nullptr, &(this->error));
+    ::ArvStream *stream = CALL_RETURN(arv_camera_create_stream, this->camera, nullptr, nullptr);
     return stream;
 }
 
@@ -293,14 +341,14 @@ void ArvGeneric::_stream_start()
     this->stream_active = true;
 
     /* Start the acquisition stream */
-    arv_camera_set_acquisition_mode(this->camera, ARV_ACQUISITION_MODE_SINGLE_FRAME, &(this->error));
-    arv_camera_start_acquisition(this->camera, &(this->error));
+    CALL(arv_camera_set_acquisition_mode, this->camera, ARV_ACQUISITION_MODE_SINGLE_FRAME);
+    CALL(arv_camera_start_acquisition, this->camera);
 }
 
 void ArvGeneric::_stream_stop()
 {
     /* stop the acquisition stream */
-    arv_camera_stop_acquisition(this->camera, &(this->error));
+    CALL(arv_camera_stop_acquisition, this->camera);
     g_object_unref(this->stream);
 
     this->stream_active = false;
@@ -309,7 +357,7 @@ void ArvGeneric::_stream_stop()
 void ArvGeneric::_trigger_exposure()
 {
     /* Trigger for an exposure */
-    arv_camera_software_trigger(this->camera, &(this->error));
+    CALL(arv_camera_software_trigger, this->camera);
 }
 
 void ArvGeneric::exposure_start(void)
@@ -326,7 +374,7 @@ void ArvGeneric::exposure_abort(void)
 {
     if (this->_stream_active())
     {
-        arv_camera_abort_acquisition(this->camera, &(this->error));
+        CALL(arv_camera_abort_acquisition, this->camera);
         this->_stream_stop();
     }
 }

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -18,23 +18,28 @@
  */
 #include "ArvGeneric.h"
 
+#include <string>
+
 using namespace arv;
 
-const char *ArvGeneric::_str_val(const char *s)
-{
-    return (s ? s : "None");
+namespace {
+    inline const char *_str_val(const std::string & s)
+    {
+        return (s != "" ? s.c_str() : "None");
+    }
 }
+
 const char *ArvGeneric::vendor_name()
 {
-    return this->_str_val(this->cam.vendor_name);
+    return _str_val(this->cam.vendor_name);
 }
 const char *ArvGeneric::model_name()
 {
-    return this->_str_val(this->cam.model_name);
+    return _str_val(this->cam.model_name);
 }
 const char *ArvGeneric::device_id()
 {
-    return this->_str_val(this->cam.device_id);
+    return _str_val(this->cam.device_id);
 }
 min_max_property<int> ArvGeneric::get_bin_x()
 {
@@ -103,45 +108,40 @@ bool ArvGeneric::_stream_active()
     return this->stream_active;
 }
 
-ArvGeneric::ArvGeneric(void *camera_device) : ArvCamera(camera_device)
+ArvGeneric::ArvGeneric(std::string device_id, std::string model_name)
+: ArvCamera(device_id, model_name)
 {
     this->_init();
-    this->camera = (::ArvCamera *)camera_device;
-    this->dev    = arv_camera_get_device(this->camera);
-
-    this->cam.model_name  = arv_camera_get_model_name(this->camera, &(this->error));
-    this->cam.vendor_name = arv_camera_get_vendor_name(this->camera, &(this->error));
-    this->cam.device_id   = arv_camera_get_device_id(this->camera, &(this->error));
+    /* device_id and model name must be available to INDI before Connect */
+    this->cam.device_id = device_id;
+    this->cam.model_name  = model_name;
 }
 
 ArvGeneric::~ArvGeneric()
 {
-    if (this->is_connected())
-    {
-        this->disconnect();
-    }
-    this->_init();
+    this->disconnect();
 }
 
 bool ArvGeneric::connect()
 {
+    printf("%s\n", __PRETTY_FUNCTION__);
     /* (Re-)connect by means of the device-id */
     if (!this->camera)
     {
-        this->camera = ::arv_camera_new(this->cam.device_id, &(this->error));
+        this->camera = ::arv_camera_new(this->cam.device_id.c_str(), &(this->error));
         if (!this->camera)
             return false;
 
         this->dev             = arv_camera_get_device(this->camera);
-        this->cam.model_name  = arv_camera_get_model_name(this->camera, &(this->error));
         this->cam.vendor_name = arv_camera_get_vendor_name(this->camera, &(this->error));
-        this->cam.device_id   = arv_camera_get_device_id(this->camera, &(this->error));
     }
+    this->_configure();
     return true;
 }
 
 bool ArvGeneric::_configure(void)
 {
+    printf("%s\n", __PRETTY_FUNCTION__);
     this->_set_initial_config();
     return this->_get_initial_config();
 }
@@ -192,10 +192,6 @@ bool ArvGeneric::_get_initial_config()
     this->_get_bounds<double>(arv_camera_get_frame_rate_bounds, &this->cam.frame_rate);
     this->_get_bounds<double>(arv_camera_get_exposure_time_bounds, &this->cam.exposure);
     this->_get_bounds<double>(arv_camera_get_gain_bounds, &this->cam.gain);
-
-    this->cam.vendor_name = arv_camera_get_vendor_name(camera, &error);
-    this->cam.model_name  = arv_camera_get_model_name(camera, &error);
-    this->cam.device_id   = arv_camera_get_device_id(camera, &error);
 
     /* No GVCP call for this..., specialize if necessary */
     this->cam.pixel_pitch.set_single(1.0);

--- a/indi-gige/src/ArvGeneric.cpp
+++ b/indi-gige/src/ArvGeneric.cpp
@@ -241,8 +241,10 @@ bool ArvGeneric::_get_initial_config()
     this->_get_bounds<double>(arv_camera_get_exposure_time_bounds, &this->cam.exposure);
     this->_get_bounds<double>(arv_camera_get_gain_bounds, &this->cam.gain);
 
-    /* No GVCP call for this..., specialize if necessary */
-    this->cam.pixel_pitch.set_single(1.0);
+    /* No GVCP call for this..., specializations of this class could make this
+     * read-only by setting min=max=val (see BlackFly implementation). */
+    this->cam.pixel_pitch.update(1.0, 40.0);
+    this->cam.pixel_pitch.set(1.0);
 
     return true;
 }

--- a/indi-gige/src/ArvGeneric.h
+++ b/indi-gige/src/ArvGeneric.h
@@ -64,8 +64,9 @@ class ArvGeneric : public arv::ArvCamera
     virtual double get_float(const char * feature) override;
 
     virtual void set_bin(int const bin_x, int const bin_y) override;
+    virtual std::pair<int,int> update_bin(void) override;
     virtual void set_geometry(int const x, int const y, int const w, int const h) override;
-    virtual void update_geometry(void) override;
+    virtual std::tuple<int,int,int,int> update_geometry(void) override;
     virtual void set_exposure_time(double const val) override;
     virtual void set_gain(double const val) override;
 
@@ -83,6 +84,8 @@ class ArvGeneric : public arv::ArvCamera
   private:
     template <typename T>
     bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop);
+    template <typename T>
+    bool _get_incr(T (*fn_arv_incr)(::ArvCamera *, GError**), min_max_property<T> *prop);
 
     /** Set a given property where it should not be changed during a
      * single-frame acquisition and attemping to do so should cause the

--- a/indi-gige/src/ArvGeneric.h
+++ b/indi-gige/src/ArvGeneric.h
@@ -56,6 +56,8 @@ class ArvGeneric : public arv::ArvCamera
     virtual min_max_property<double> get_exposure() override;
     virtual min_max_property<double> get_gain() override;
     virtual min_max_property<double> get_frame_rate() override;
+    virtual bool has_feature(const char * feature) override;
+    virtual double get_float(const char * feature) override;
 
     virtual void set_bin(int const bin_x, int const bin_y) override;
     virtual void set_geometry(int const x, int const y, int const w, int const h) override;
@@ -78,6 +80,13 @@ class ArvGeneric : public arv::ArvCamera
     bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop);
     template <typename T>
     void _set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**), min_max_property<T> *prop, T const new_val);
+    const char * getDeviceName() { return this->device_id(); }
+    // Variadic template error handler function with no return value
+    template<typename Func, typename... Args>
+    void call_log(const char *func_description, Func &&func, Args&&... args);
+    // Variadic template error handler function with no return value
+    template<typename Func, typename... Args>
+    auto call_log_return(const char *func_description, Func &&func, Args&&... args);
 
   protected:
     virtual bool _get_initial_config();
@@ -89,7 +98,6 @@ class ArvGeneric : public arv::ArvCamera
     ::ArvDevice *dev;
     ::ArvStream *stream;
     ::ArvBuffer *buffer;
-    ::GError *error;
 
     /* streaming, capturing functions */
     ::ArvStream *_stream_create(void);

--- a/indi-gige/src/ArvGeneric.h
+++ b/indi-gige/src/ArvGeneric.h
@@ -19,6 +19,8 @@
 #ifndef CPP_ARV_GENERIC_H
 #define CPP_ARV_GENERIC_H
 
+#include <string>
+
 //#extern "C" {
 #include <stddef.h>
 #include <stdio.h>
@@ -32,52 +34,54 @@ using namespace arv;
 class ArvGeneric : public arv::ArvCamera
 {
   public:
-    ArvGeneric(void *camera_device);
-    ~ArvGeneric();
+    ArvGeneric(std::string device_id, std::string model_name);
+    virtual ~ArvGeneric();
 
-    bool is_connected();
-    bool is_exposing();
-    bool connect();
-    bool disconnect();
-    const char *vendor_name();
-    const char *model_name();
-    const char *device_id();
-    int get_frame_byte_size();
-    min_max_property<int> get_bin_x();
-    min_max_property<int> get_bin_y();
-    min_max_property<int> get_x_offset();
-    min_max_property<int> get_y_offset();
-    min_max_property<int> get_width();
-    min_max_property<int> get_height();
-    min_max_property<int> get_bpp();
-    min_max_property<double> get_pixel_pitch();
-    min_max_property<double> get_exposure();
-    min_max_property<double> get_gain();
-    min_max_property<double> get_frame_rate();
+    virtual bool is_connected() override;
+    virtual bool is_exposing() override;
+    virtual bool connect() override;
+    virtual bool disconnect() override;
+    virtual const char *vendor_name() override;
+    virtual const char *model_name() override;
+    virtual const char *device_id() override;
+    virtual int get_frame_byte_size() override;
+    virtual min_max_property<int> get_bin_x() override;
+    virtual min_max_property<int> get_bin_y() override;
+    virtual min_max_property<int> get_x_offset() override;
+    virtual min_max_property<int> get_y_offset() override;
+    virtual min_max_property<int> get_width() override;
+    virtual min_max_property<int> get_height() override;
+    virtual min_max_property<int> get_bpp() override;
+    virtual min_max_property<double> get_pixel_pitch() override;
+    virtual min_max_property<double> get_exposure() override;
+    virtual min_max_property<double> get_gain() override;
+    virtual min_max_property<double> get_frame_rate() override;
 
-    void set_bin(int const bin_x, int const bin_y);
-    void set_geometry(int const x, int const y, int const w, int const h);
-    void update_geometry(void);
-    void set_exposure_time(double const val);
-    void set_gain(double const val);
+    virtual void set_bin(int const bin_x, int const bin_y) override;
+    virtual void set_geometry(int const x, int const y, int const w, int const h) override;
+    virtual void update_geometry(void) override;
+    virtual void set_exposure_time(double const val) override;
+    virtual void set_gain(double const val) override;
 
-    void exposure_start(void);
-    void exposure_abort(void);
-    ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void *const, uint8_t const *const, size_t),
-                                      void *const usr_ptr);
+    virtual void exposure_start(void) override;
+    virtual void exposure_abort(void) override;
+    virtual ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void *const, uint8_t const *const, size_t),
+                                              void *const usr_ptr) override;
 
   protected:
     void _init(void);
-    bool _configure(void);
+    virtual bool _configure(void);
     void _test_exposure_and_abort(void);
+
+  private:
     template <typename T>
     bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop);
     template <typename T>
     void _set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**), min_max_property<T> *prop, T const new_val);
 
-    const char *_str_val(const char *s);
-    bool _get_initial_config();
-    bool _set_initial_config();
+  protected:
+    virtual bool _get_initial_config();
+    virtual bool _set_initial_config();
     void _get_image(void (*fn_image_callback)(void *const, uint8_t const *const, size_t), void *const usr_ptr);
 
     /* aravis library state variables */
@@ -113,9 +117,9 @@ class ArvGeneric : public arv::ArvCamera
         min_max_property<double> gain;
         min_max_property<double> frame_rate;
 
-        const char *vendor_name;
-        const char *model_name;
-        const char *device_id;
+        std::string vendor_name;
+        std::string model_name;
+        std::string device_id;
     } cam;
 };
 

--- a/indi-gige/src/ArvGeneric.h
+++ b/indi-gige/src/ArvGeneric.h
@@ -20,6 +20,7 @@
 #define CPP_ARV_GENERIC_H
 
 #include <string>
+#include <atomic>
 
 //#extern "C" {
 #include <stddef.h>
@@ -34,11 +35,14 @@ using namespace arv;
 class ArvGeneric : public arv::ArvCamera
 {
   public:
+    using arv::ArvCamera::HandleImgCB;
+
     ArvGeneric(std::string device_id, std::string model_name);
     virtual ~ArvGeneric();
 
     virtual bool is_connected() override;
-    virtual bool is_exposing() override;
+    virtual bool is_exposing_single() override;
+    virtual bool is_streaming() override;
     virtual bool connect() override;
     virtual bool disconnect() override;
     virtual const char *vendor_name() override;
@@ -67,19 +71,34 @@ class ArvGeneric : public arv::ArvCamera
 
     virtual void exposure_start(void) override;
     virtual void exposure_abort(void) override;
-    virtual ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void *const, uint8_t const *const, size_t),
-                                              void *const usr_ptr) override;
+    virtual ARV_EXPOSURE_STATUS exposure_poll(HandleImgCB fn_image_callback) override;
+    virtual ARV_EXPOSURE_STATUS next_streaming_image(HandleImgCB fn_image_callback) override;
+    virtual void stop_streaming(void)  override;
 
   protected:
+    virtual void start_streaming_impl(unsigned int n_buffers) override;
     void _init(void);
     virtual bool _configure(void);
-    void _test_exposure_and_abort(void);
 
   private:
     template <typename T>
     bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera *, T *min, T *max, GError**), min_max_property<T> *prop);
+
+    /** Set a given property where it should not be changed during a
+     * single-frame acquisition and attemping to do so should cause the
+     * acquisition to be aborted.
+     * This function does *not* stop acquisition if a change is made during a
+     * streaming operation.
+     * If the 'get' function is also passed, the value of the parameter will be
+     * queried from the camera after the 'set' function has been called.  This
+     * can be useful since the camera can often demote/promote settings to some
+     * gridded pattern internal to the camera.
+     */
     template <typename T>
-    void _set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**), min_max_property<T> *prop, T const new_val);
+    void set_cam_exposure_property(void (*arv_set)(::ArvCamera *, T, GError**),
+                                   min_max_property<T> *prop, T const new_val,
+                                   T (*arv_get)(::ArvCamera *, GError**) = nullptr);
+
     const char * getDeviceName() { return this->device_id(); }
     // Variadic template error handler function with no return value
     template<typename Func, typename... Args>
@@ -91,23 +110,22 @@ class ArvGeneric : public arv::ArvCamera
   protected:
     virtual bool _get_initial_config();
     virtual bool _set_initial_config();
-    void _get_image(void (*fn_image_callback)(void *const, uint8_t const *const, size_t), void *const usr_ptr);
+    void _get_image(HandleImgCB fn_image_callback, ArvBuffer * buf);
 
     /* aravis library state variables */
     ::ArvCamera *camera;
     ::ArvDevice *dev;
-    ::ArvStream *stream;
-    ::ArvBuffer *buffer;
+    ::ArvStream *stream; /// Hold all buffers in queues until freed
 
     /* streaming, capturing functions */
-    ::ArvStream *_stream_create(void);
-    ::ArvBuffer *_buffer_create(void);
-    bool _stream_active();
-    void _stream_start();
-    void _stream_stop();
-    void _trigger_exposure();
+    /** Creates the current stream and pushes buffers to its input queue. */
+    void create_stream(unsigned int n_buffers = 1);
+    void start_acquisition(unsigned int n_buffers, ArvAcquisitionMode mode);
+    /** Stops all acquisition. */
+    void stop_acquisition();
 
-    bool stream_active;
+    std::atomic<bool> single_acquisition_active;
+    std::atomic<bool> stream_active;
 
     /* Camera properties */
     struct

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -98,6 +98,8 @@ class ArvCamera
     virtual min_max_property<double> get_exposure()    = 0;
     virtual min_max_property<double> get_gain()        = 0;
     virtual min_max_property<double> get_frame_rate()  = 0;
+    virtual bool has_feature(const char * feature)     = 0;
+    virtual double get_float(const char * feature)     = 0;
 
     /* Set geometry */
     virtual void set_bin(int const bin_x, int const bin_y)                        = 0;

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include <string>
+
 namespace arv
 {
 typedef enum {
@@ -73,7 +75,8 @@ class min_max_property
 class ArvCamera
 {
   public:
-    ArvCamera([[maybe_unused]] void *camera_device) {}
+    ArvCamera([[maybe_unused]] std::string device_id, [[maybe_unused]] std::string model_name) {}
+    virtual ~ArvCamera() = default;
     virtual bool connect()      = 0;
     virtual bool disconnect()   = 0;
     virtual bool is_connected() = 0;

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -24,6 +24,7 @@
 
 #include <string>
 #include <utility>
+#include <memory>
 #include <functional>
 
 namespace arv
@@ -159,7 +160,7 @@ class ArvCamera
 class ArvFactory
 {
   public:
-    static ArvCamera *find_first_available(void);
+    static std::unique_ptr<ArvCamera> find_first_available(void);
 
     //TODO: add iterative support to add all discovered cameras
 };

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 
 #include <string>
+#include <utility>
 #include <functional>
 
 namespace arv
@@ -40,12 +41,13 @@ template <class T>
 class min_max_property
 {
   public:
-    min_max_property() {}
-    min_max_property(T const min, T const max, T const val)
+    min_max_property() : _min(0), _max(0), _val(0), _incr(0) {}
+    min_max_property(T const min, T const max, T const val, T const incr = T(0))
     {
         this->_min = min;
         this->_max = max;
         this->_val = val;
+        this->_incr = incr;
     }
 
     void update(T const min, T const max)
@@ -54,8 +56,19 @@ class min_max_property
         this->_max = max;
     }
 
-    void set(T const new_val)
+    void set_increment(T const incr)
     {
+        this->_incr = incr;
+    }
+
+    /** Set a new value for the property, obeying max/min limits and following
+     * incremental restrictions if set (i.e. if not 0). */
+    void set(T new_val)
+    {
+        if (this->_incr != T(0))
+            // enforce alignment to increments
+            new_val = int((new_val - this->_min)/this->_incr) * this->_incr + this->_min;
+
         if (new_val > this->_max)
             this->_val = this->_max;
         else if (new_val < this->_min)
@@ -68,9 +81,10 @@ class min_max_property
     T val() { return this->_val; }
     T min() { return this->_min; }
     T max() { return this->_max; }
+    T incr() { return this->_incr; }
 
   private:
-    T _min, _max, _val;
+    T _min, _max, _val, _incr;
 };
 
 class ArvCamera
@@ -113,8 +127,15 @@ class ArvCamera
 
     /* Set geometry */
     virtual void set_bin(int const bin_x, int const bin_y)                        = 0;
+    /** update this class information of binning from the camera hardware.
+     * @return pair of binning values for x and y.
+     */
+    virtual std::pair<int,int> update_bin(void)                                   = 0;
     virtual void set_geometry(int const x, int const y, int const w, int const h) = 0;
-    virtual void update_geometry(void)                                            = 0;
+    /** update this class information of geometry from the camera hardware.
+     * @return tuple of (x, y, w, h).
+     */
+    virtual std::tuple<int,int,int,int> update_geometry(void)                     = 0;
 
     /* Set exposure */
     virtual void set_exposure_time(double const val) = 0;

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 #include <memory>
+#include <iterator>
 #include <functional>
 
 namespace arv
@@ -160,9 +161,83 @@ class ArvCamera
 class ArvFactory
 {
   public:
+    /** Find, instantiate, and return a unique_ptr of the first available
+     * ArvCamera.
+     */
     static std::unique_ptr<ArvCamera> find_first_available(void);
 
-    //TODO: add iterative support to add all discovered cameras
+    /** Camera device index, used by the camera iterator and to instantiate an
+     * ArvCamera.
+     */
+    class Index {
+        int index;
+      public:
+        Index(int index) : index(index) { }
+
+        /** Attempt to create a camera instance for the camera index.
+         * Does *not* update the device list.
+         */
+        std::unique_ptr<ArvCamera> instantiate() const;
+
+        Index & operator++() {
+          ++this->index;
+          return *this;
+        }
+        bool operator==(const Index & other) const {
+          return this->index == other.index;
+        }
+        bool operator!=(const Index & other) const {
+          return this->index != other.index;
+        }
+    };
+
+    /** Camera index iterator. */
+    class Iterator {
+        Index index;
+    public:
+        // 1. Mandatory STL iterator traits
+        using iterator_category = std::input_iterator_tag;
+        using value_type        = Index;
+        using difference_type   = std::ptrdiff_t;
+        using pointer           = const Index*;
+        using reference         = const Index&;
+
+        Iterator(Index index) : index(index) { }
+
+        /** Dereference operator. */
+        reference operator*() const {
+            return index;
+        }
+
+        /** Prefix increment operator. */
+        Iterator& operator++() {
+            ++this->index;
+            return *this;
+        }
+
+        // Postfix increment operator
+        Iterator operator++(int) {
+            Iterator temp = *this;
+            ++(*this);
+            return temp;
+        }
+
+        // Comparison operators
+        bool operator!=(const Iterator& other) const {
+            return this->index != other.index;
+        }
+
+        bool operator==(const Iterator& other) const {
+            return this->index == other.index;
+        }
+    };
+
+    /** Updates the list of devices and returns the iterator to the first. */
+    Iterator begin();
+    /** Returns an iterator to the currently known end.
+     * This function does *not* update the list of devices.
+     */
+    Iterator end();
 };
 
 } /* Namepsace */

--- a/indi-gige/src/ArvInterface.h
+++ b/indi-gige/src/ArvInterface.h
@@ -19,10 +19,11 @@
 #ifndef CPP_ARV_IFACE_H
 #define CPP_ARV_IFACE_H
 
-#include <stdint.h>
-#include <stddef.h>
+#include <cstdint>
+#include <cstddef>
 
 #include <string>
+#include <functional>
 
 namespace arv
 {
@@ -75,12 +76,21 @@ class min_max_property
 class ArvCamera
 {
   public:
-    ArvCamera([[maybe_unused]] std::string device_id, [[maybe_unused]] std::string model_name) {}
+    typedef std::function<void(uint8_t const *const, size_t)> HandleImgCB;
+
+    ArvCamera([[maybe_unused]] std::string device_id,
+              [[maybe_unused]] std::string model_name) {}
     virtual ~ArvCamera() = default;
-    virtual bool connect()      = 0;
-    virtual bool disconnect()   = 0;
-    virtual bool is_connected() = 0;
-    virtual bool is_exposing()  = 0;
+    virtual bool connect()            = 0;
+    virtual bool disconnect()         = 0;
+    virtual bool is_connected()       = 0;
+    /** Is a single-frame acquisition is underway? */
+    virtual bool is_exposing_single() = 0;
+    /** Is a multiple-frame acquisition (streaming) is underway? */
+    virtual bool is_streaming()       = 0;
+    bool is_acquiring() {
+      return this->is_exposing_single() || this->is_streaming();
+    }
 
     /* Get properties */
     virtual const char *vendor_name()                  = 0;
@@ -110,10 +120,19 @@ class ArvCamera
     virtual void set_exposure_time(double const val) = 0;
     virtual void set_gain(double const val)          = 0;
 
+    /** Start a single-frame acquisition. */
     virtual void exposure_start(void)                      = 0;
     virtual void exposure_abort(void)                      = 0;
-    virtual ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void *const, uint8_t const *const, size_t),
-                                              void *const) = 0;
+    virtual ARV_EXPOSURE_STATUS exposure_poll(HandleImgCB fn_image_callback) = 0;
+    virtual ARV_EXPOSURE_STATUS next_streaming_image(HandleImgCB fn_image_callback) = 0;
+    virtual void stop_streaming(void)                      = 0;
+    /** Start a multi-frame acquisition (i.e. streaming). */
+    void start_streaming(unsigned int n_buffers=10) {
+      this->start_streaming_impl(n_buffers);
+    }
+
+  protected:
+    virtual void start_streaming_impl(unsigned int n_buffers)   = 0;
 };
 
 class ArvFactory

--- a/indi-gige/src/BlackFly.cpp
+++ b/indi-gige/src/BlackFly.cpp
@@ -41,7 +41,6 @@ bool BlackFly::_custom_settings()
     }
 
     gboolean result;
-    guint32 val;
     GError *error = nullptr;
 
     int i;
@@ -94,7 +93,6 @@ void BlackFly::_fixup(void)
     }
 
     gboolean result;
-    guint32 val;
     GError *error = nullptr;
 
     int i;
@@ -133,11 +131,12 @@ bool BlackFly::_get_initial_config(void)
     /* Probably can find this somewhere in genicam, too, but it depends on framerate
      * and the maximum exposure is consequently not published */
     this->cam.exposure.update(5000, 11900000);
+    return true;
 }
 
 bool BlackFly::_set_initial_config(void)
 {
     printf("%s\n", __PRETTY_FUNCTION__);
     ArvGeneric::_set_initial_config();
-    this->_custom_settings();
+    return this->_custom_settings();
 }

--- a/indi-gige/src/BlackFly.cpp
+++ b/indi-gige/src/BlackFly.cpp
@@ -19,9 +19,12 @@
 #include "ArvGeneric.h"
 #include "BlackFly.h"
 
+#include <string>
+
 using namespace arv;
 
-BlackFly::BlackFly(void *camera_device) : ArvGeneric(camera_device)
+BlackFly::BlackFly(std::string device_id, std::string model_name)
+: ArvGeneric(device_id, model_name)
 {
     printf("%s\n", __PRETTY_FUNCTION__);
 }
@@ -68,17 +71,6 @@ error:
     return false;
 }
 
-bool BlackFly::connect(void)
-{
-    printf("%s\n", __PRETTY_FUNCTION__);
-    bool const ret = ArvGeneric::connect();
-    if (ret)
-    {
-        this->_configure();
-    }
-    return ret;
-}
-
 void BlackFly::_fixup(void)
 {
     ::ArvDevice *dev = this->dev;
@@ -111,13 +103,6 @@ void BlackFly::exposure_start(void)
     /* At some point in stream start, the endianness gets reset by the camera itself... why? genicam? */
     this->_fixup();
     ArvGeneric::exposure_start();
-}
-
-bool BlackFly::_configure(void)
-{
-    printf("%s\n", __PRETTY_FUNCTION__);
-    this->_set_initial_config();
-    return this->_get_initial_config();
 }
 
 bool BlackFly::_get_initial_config(void)

--- a/indi-gige/src/BlackFly.h
+++ b/indi-gige/src/BlackFly.h
@@ -19,17 +19,18 @@
 #ifndef CPP_ARV_BLACKFLY_H
 #define CPP_ARV_BLACKFLY_H
 
+#include <string>
+
 class BlackFly : public ArvGeneric
 {
   public:
-    BlackFly(void *camera_device);
-    bool connect();
-    void exposure_start(void);
+    BlackFly(std::string device_id, std::string model_name);
+    virtual ~BlackFly() = default;
+    virtual void exposure_start(void) override;
 
   protected:
-    bool _configure(void);
-    bool _get_initial_config();
-    bool _set_initial_config();
+    virtual bool _get_initial_config() override;
+    virtual bool _set_initial_config() override;
 
   private:
     bool _custom_settings();

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -76,10 +76,12 @@ static class Loader
 public:
     Loader()
     {
-        auto camera = arv::ArvFactory::find_first_available();
-        IDLog("Found Camera: %s\n", camera->device_id());
-        auto gigeccd = new GigECCD(std::move(camera));
-        cameras.push_back(std::unique_ptr<GigECCD>(gigeccd));
+        for (auto camera_index : arv::ArvFactory()) {
+            auto camera = camera_index.instantiate();
+            IDLog("Found Camera: %s\n", camera->device_id());
+            auto gigeccd = new GigECCD(std::move(camera));
+            cameras.push_back(std::unique_ptr<GigECCD>(gigeccd));
+        }
     }
 } loader;
 

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -123,6 +123,13 @@ void GigECCD::_update_indi_properties(void)
                    (double)this->camera->get_gain().val());
     GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
+    auto pitch = this->camera->get_pixel_pitch();
+    PixelSizeNP[0].fill("PIXEL_SIZE", "Size [μm]", "%.2f",
+                        pitch.min(), pitch.max(), .1, pitch.val());
+    PixelSizeNP.fill(getDeviceName(), "CCD_PIXEL_SIZE", "Pixel",
+                     IMAGE_SETTINGS_TAB,
+                     pitch.max() == pitch.min() ? IP_RO : IP_RW, 60, IPS_IDLE);
+
     IUFillText(&indiprop_info[0], "Vendor Name", "", this->camera->vendor_name());
     IUFillText(&indiprop_info[1], "Model Name", "", this->camera->model_name());
     IUFillText(&indiprop_info[2], "Device ID", "", this->camera->device_id());
@@ -131,6 +138,7 @@ void GigECCD::_update_indi_properties(void)
 
     defineProperty(&indiprop_info_prop);
     defineProperty(this->GainNP);
+    defineProperty(this->PixelSizeNP);
     if (this->camera->has_feature("DeviceTemperature")) {
       this->TemperatureNP.setPermission(IP_RO);
       defineProperty(this->TemperatureNP);
@@ -140,6 +148,7 @@ void GigECCD::_update_indi_properties(void)
 void GigECCD::_delete_indi_properties(void)
 {
     this->deleteProperty(this->GainNP);
+    this->deleteProperty(this->PixelSizeNP);
     this->deleteProperty(this->indiprop_info_prop.name);
     if (TemperatureNP.getPermission() == IP_RO) {
       this->TemperatureNP.setPermission(IP_RW);
@@ -314,6 +323,17 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
             this->GainNP[0].setValue(this->camera->get_gain().val());
 
             GainNP.apply();
+            return true;
+        }
+
+        if (PixelSizeNP.isNameMatch(name))
+        {
+            PixelSizeNP.update(values, names, n);
+            PixelSizeNP.setState(IPS_OK);
+            PixelSizeNP.apply();
+
+            auto dx = PixelSizeNP[0].getValue();
+            PrimaryCCD.setPixelSize(dx, dx);
             return true;
         }
     }

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -65,8 +65,7 @@ const char *GigECCD::getDefaultName()
 GigECCD::GigECCD(arv::ArvCamera *camera)
 {
     this->camera = camera;
-    snprintf(this->name, sizeof(this->name), "%s", this->camera->device_id());
-    setDeviceName(this->name);
+    setDeviceName(this->camera->device_id());
 }
 
 GigECCD::~GigECCD()

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -171,11 +171,7 @@ bool GigECCD::Connect()
 bool GigECCD::Disconnect()
 {
     LOGF_INFO("%s", __PRETTY_FUNCTION__);
-#if 0
-    //TODO: re-iterate and acquire proper camera from AvrFactory (based on ID?)
     return camera->disconnect();
-#endif
-    return true;
 }
 
 bool GigECCD::StartExposure(float duration)

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -93,8 +93,8 @@ bool GigECCD::_update_geometry(void)
                         this->camera->get_width().val(), this->camera->get_height().val());
 
     /* Sanity checks, reserve buffers */
-    int const width           = this->camera->get_width().val();
-    int const height          = this->camera->get_height().val();
+    [[maybe_unused]] int const width           = this->camera->get_width().val();
+    [[maybe_unused]] int const height          = this->camera->get_height().val();
     int const frame_byte_size = this->camera->get_frame_byte_size();
     int const indi_bufsize    = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * PrimaryCCD.getBPP() / 8;
 
@@ -109,6 +109,7 @@ bool GigECCD::_update_geometry(void)
         LOGF_INFO("Reserving INDI image buffer size %i bytes", indi_bufsize);
         PrimaryCCD.setFrameBufferSize(frame_byte_size);
     }
+    return true;
 }
 
 void GigECCD::_update_indi_properties(void)
@@ -207,7 +208,7 @@ void GigECCD::_update_image(uint8_t const *const data, size_t size)
     if ((size == frame_buf_size) && (data != nullptr))
     {
         uint8_t *const image = PrimaryCCD.getFrameBuffer();
-        memcpy(image, (void *const)data, frame_buf_size);
+        memcpy(image, (void const*)data, frame_buf_size);
         this->ExposureComplete(&PrimaryCCD);
     }
     else
@@ -220,7 +221,7 @@ void GigECCD::_update_image(uint8_t const *const data, size_t size)
 
 void GigECCD::_receive_image_hook(void *const class_ptr, uint8_t const *const data, size_t size)
 {
-    GigECCD *const cls = static_cast<GigECCD *const>(class_ptr);
+    GigECCD * cls = static_cast<GigECCD *>(class_ptr);
     cls->_update_image(data, size);
 }
 

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -45,6 +45,31 @@
 #define TIMER_US_TO_S  (1000000)
 #define CAPS           (CCD_CAN_ABORT | CCD_CAN_BIN | CCD_CAN_SUBFRAME | CCD_HAS_STREAMING)
 
+/* NOTE ABOUT BINNING:
+ * At least for FLIR GiGE cameras, changing binning changes the apparent size of
+ * the chip, such that the region of interest is configured using a smaller
+ * number of pixels.  This appears to be contrary to how INDI expects binning to
+ * be configured.  Following the CCD Simulator (if that is a decent example of
+ * implementing a INDI::CCD device, it rather appears that the region of
+ * interest is still expected to be set using the entire available Width/Height.
+ * It therefore appears necessary to mitigate this mismatch since (at least for
+ * ekos) the client appears to mess up the apparent image if binning is
+ * configured but a smaller region is selected, but in reality the entire
+ * avaialble sensor was binned.
+ *
+ * So, for now (as of 26 Feb 2026), even when binning is used, this driver will
+ * use the full MaxWidth and MaxHeight manually divided by the binning to select
+ * the region of interest.
+ *
+ * This means that any use of get_x_offset().val(), get_y_offset().val(),
+ * get_width().val(), or get_height().val() from the GigECCD::camera object must
+ * be manually multiplied or divided by the values from get_bin_x().val() and
+ * get_bin_y().val() as appropriate.  Similarly, camera->set_geometry(...) must
+ * be given values that are divided by the appropriate binning.
+ *
+ * TODO: verify this behavior on GiGE cameras from other vendors.
+ */
+
 static class Loader
 {
     std::deque<std::unique_ptr<GigECCD>> cameras;
@@ -85,18 +110,23 @@ bool GigECCD::_update_geometry(void)
 {
     std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     /* Get actual values */
-    this->camera->update_geometry();
+    auto [x, y, w, h] = this->camera->update_geometry();
+
+    /* As per note at begin of this file, we manually manage the region of
+     * interest conversion between the camera and INDI because the camera
+     * changes the apparent region of interest available depending on binning,
+     * while INDI does not. */
+    auto bin_x = this->camera->get_bin_x().val(),
+         bin_y = this->camera->get_bin_y().val();
 
     /* Sync these with INDI */
-    PrimaryCCD.setBin(this->camera->get_bin_x().val(), this->camera->get_bin_y().val());
-    PrimaryCCD.setFrame(this->camera->get_x_offset().val(), this->camera->get_y_offset().val(),
-                        this->camera->get_width().val(), this->camera->get_height().val());
+    INDI::CCD::UpdateCCDFrame(x*bin_x, y*bin_y, w*bin_x, h*bin_y);
 
     /* Sanity checks, reserve buffers */
-    [[maybe_unused]] int const width           = this->camera->get_width().val();
-    [[maybe_unused]] int const height          = this->camera->get_height().val();
     int const frame_byte_size = this->camera->get_frame_byte_size();
-    int const indi_bufsize    = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * PrimaryCCD.getBPP() / 8;
+    int const indi_bufsize    = (PrimaryCCD.getSubW() / PrimaryCCD.getBinX())
+                              * (PrimaryCCD.getSubH() / PrimaryCCD.getBinY())
+                              * PrimaryCCD.getBPP() / 8;
 
     if (indi_bufsize != frame_byte_size)
     {
@@ -111,7 +141,6 @@ bool GigECCD::_update_geometry(void)
     }
 
     this->Streamer->setPixelFormat(INDI_MONO, PrimaryCCD.getBPP());
-    this->Streamer->setSize(PrimaryCCD.getXRes(), PrimaryCCD.getYRes());
     return true;
 }
 
@@ -173,6 +202,7 @@ bool GigECCD::updateProperties()
                            this->camera->get_bpp().val(), this->camera->get_pixel_pitch().val(),
                            this->camera->get_pixel_pitch().val());
 
+        this->_update_bin();
         (void)this->_update_geometry();
         this->timer_id = this->SetTimer(this->getCurrentPollingPeriod());
     }
@@ -461,10 +491,19 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
 
 bool GigECCD::UpdateCCDFrame(int x, int y, int w, int h)
 {
-    LOGF_INFO("%s x=%i y=%i w=%i h=%i", __PRETTY_FUNCTION__, x, y, w, h);
-
     std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
-    this->camera->set_geometry(x, y, w, h);
+
+    /* As per note at begin of this file, we manually manage the region of
+     * interest conversion between the camera and INDI because the camera
+     * changes the apparent region of interest available depending on binning,
+     * while INDI does not. */
+    auto bin_x = this->camera->get_bin_x().val(),
+         bin_y = this->camera->get_bin_y().val();
+
+    LOGF_INFO("%s x=%i y=%i w=%i h=%i binx=%i biny=%i",
+              __PRETTY_FUNCTION__, x, y, w, h, bin_x, bin_y);
+
+    this->camera->set_geometry(x/bin_x, y/bin_y, w/bin_x, h/bin_y);
     return this->_update_geometry();
 }
 
@@ -473,7 +512,15 @@ bool GigECCD::UpdateCCDBin(int binx, int biny)
     LOGF_INFO("%s binx=%i biny=%i", __PRETTY_FUNCTION__, binx, biny);
     std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     camera->set_bin(binx, biny);
+    this->_update_bin();
     return UpdateCCDFrame(PrimaryCCD.getSubX(), PrimaryCCD.getSubY(), PrimaryCCD.getSubW(), PrimaryCCD.getSubH());
+}
+
+void GigECCD::_update_bin(void) {
+    auto [bx, by] = this->camera->update_bin(); /* Get actual values */
+
+    /* Sync actuals values to INDI */
+    INDI::CCD::UpdateCCDBin(bx, by);
 }
 
 bool GigECCD::UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType)

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -323,6 +323,7 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
             this->GainNP[0].setValue(this->camera->get_gain().val());
 
             GainNP.apply();
+            saveConfig(PixelSizeNP);
             return true;
         }
 
@@ -334,6 +335,7 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
 
             auto dx = PixelSizeNP[0].getValue();
             PrimaryCCD.setPixelSize(dx, dx);
+            saveConfig(PixelSizeNP);
             return true;
         }
     }
@@ -368,4 +370,12 @@ void GigECCD::addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSR
     INDI::CCD::addFITSKeywords(targetChip, fitsKeyword);
 
     fitsKeyword.push_back({"GAIN", GainNP[0].getValue(), 3, "Gain"});
+}
+
+bool GigECCD::saveConfigItems(FILE *fp)
+{
+    INDI::CCD::saveConfigItems(fp);
+    GainNP.save(fp);
+    PixelSizeNP.save(fp);
+    return true;
 }

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -53,7 +53,7 @@ public:
     {
         arv::ArvCamera *camera = arv::ArvFactory::find_first_available();
         cameras.push_back(std::unique_ptr<GigECCD>(new GigECCD(camera)));
-        IDLog("Found Camera: %s\n", camera->model_name());
+        IDLog("Found Camera: %s\n", camera->device_id());
     }
 } loader;
 
@@ -65,9 +65,7 @@ const char *GigECCD::getDefaultName()
 GigECCD::GigECCD(arv::ArvCamera *camera)
 {
     this->camera = camera;
-    snprintf(this->name, sizeof(this->name), "GigE CCD %s-%s",
-             this->camera->model_name(),
-             this->camera->device_id());
+    snprintf(this->name, sizeof(this->name), "%s", this->camera->device_id());
     setDeviceName(this->name);
 }
 

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -22,6 +22,7 @@
 #include <sys/time.h>
 #include <deque>
 #include <memory>
+#include <mutex>
 
 #include "indidevapi.h"
 #include "eventloop.h"
@@ -42,8 +43,7 @@
 
 #define TIMER_US_TO_MS (1000)
 #define TIMER_US_TO_S  (1000000)
-#define TIMER_TICK_MS  (100)
-#define CAPS           (CCD_CAN_ABORT | CCD_CAN_BIN | CCD_CAN_SUBFRAME)
+#define CAPS           (CCD_CAN_ABORT | CCD_CAN_BIN | CCD_CAN_SUBFRAME | CCD_HAS_STREAMING)
 
 static class Loader
 {
@@ -83,6 +83,7 @@ bool GigECCD::initProperties()
 
 bool GigECCD::_update_geometry(void)
 {
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     /* Get actual values */
     this->camera->update_geometry();
 
@@ -108,11 +109,15 @@ bool GigECCD::_update_geometry(void)
         LOGF_INFO("Reserving INDI image buffer size %i bytes", indi_bufsize);
         PrimaryCCD.setFrameBufferSize(frame_byte_size);
     }
+
+    this->Streamer->setPixelFormat(INDI_MONO, PrimaryCCD.getBPP());
+    this->Streamer->setSize(PrimaryCCD.getXRes(), PrimaryCCD.getYRes());
     return true;
 }
 
 void GigECCD::_update_indi_properties(void)
 {
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     LOG_INFO("update_indi_properties()");
 
     // Gain
@@ -160,6 +165,7 @@ bool GigECCD::updateProperties()
 {
     INDI::CCD::updateProperties();
 
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     if (this->camera->is_connected())
     {
         this->_update_indi_properties();
@@ -168,7 +174,7 @@ bool GigECCD::updateProperties()
                            this->camera->get_pixel_pitch().val());
 
         (void)this->_update_geometry();
-        this->timer_id = this->SetTimer(TIMER_TICK_MS);
+        this->timer_id = this->SetTimer(this->getCurrentPollingPeriod());
     }
     else
     {
@@ -181,14 +187,83 @@ bool GigECCD::updateProperties()
 
 bool GigECCD::Connect()
 {
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     IDLog("Connect to Camera: %s\n", camera->model_name());
+    this->start_streaming_thread();
     return camera->connect();
 }
 
 bool GigECCD::Disconnect()
 {
     LOGF_INFO("%s", __PRETTY_FUNCTION__);
+    this->stop_streaming_thread();
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     return camera->disconnect();
+}
+
+void GigECCD::start_streaming_thread()
+{
+    auto receive_image = [this](uint8_t const *const data, size_t size)
+    {
+        /* locked as per indiccd.h guidance. */
+        std::lock_guard<std::mutex> lock(this->ccdBufferLock);
+        this->Streamer->newFrame(data, size);
+        //LOG_DEBUG("injected image into stream manager");
+    };
+
+    auto streaming_worker = [this, receive_image]() {
+        while (!this->streaming_thread_stop_requested.load()) {
+            std::unique_lock<std::recursive_mutex> lock(this->camera_mutex);
+            if (!this->streaming_thread_active.load()) {
+                if (this->camera->is_streaming())
+                    // Have been streaming; have now been requested to stop
+                    this->camera->stop_streaming();
+
+                this->streaming_thread_condition.wait(lock);
+
+                if (!this->streaming_thread_active.load()) {
+                    LOG_INFO("Quit probably requested for streaming thread");
+                    // probably just requested to quit so go to while loop test
+                    continue;
+                }
+
+                /* While we *weren't* streaming, we are now requested to start
+                 * streaming.
+                 */
+                LOG_INFO("Starting streaming");
+                this->camera->start_streaming();
+            }
+
+            // camera_mutex should be locked at this point
+            auto status = camera->next_streaming_image(receive_image);
+            switch (status) {
+                case arv::ARV_EXPOSURE_UNKNOWN:
+                case arv::ARV_EXPOSURE_FAILED: {
+                    LOG_ERROR("Streaming acquisition had unknown failure");
+                    this->camera->exposure_abort();
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        LOG_INFO("Shutting down streaming thread");
+    };
+
+    this->streaming_thread = std::thread(streaming_worker);
+}
+
+void GigECCD::stop_streaming_thread()
+{
+    LOG_INFO("Requesting streaming stop");
+    {
+        std::lock_guard<std::mutex> lock(this->ccdBufferLock);
+        this->streaming_thread_active = false;
+        this->streaming_thread_stop_requested = true;
+    }
+    this->streaming_thread_condition.notify_all();
+    this->streaming_thread.join();
 }
 
 bool GigECCD::StartExposure(float duration)
@@ -198,6 +273,7 @@ bool GigECCD::StartExposure(float duration)
     if (PrimaryCCD.getFrameType() == INDI::CCDChip::BIAS_FRAME)
         duration = 0;
 
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     camera->set_exposure_time((double)(duration)*1000000.0);
     PrimaryCCD.setExposureDuration(duration); // to ensure FITS correct header
 
@@ -205,27 +281,57 @@ bool GigECCD::StartExposure(float duration)
     TIME_VAL_GET(&this->exposure_start_time);
 
     camera->exposure_start();
-    return camera->is_exposing();
+    return camera->is_exposing_single();
 }
 
 bool GigECCD::AbortExposure()
 {
     LOGF_INFO("%s", __PRETTY_FUNCTION__);
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     camera->exposure_abort();
+    return true;
+}
+
+bool GigECCD::StartStreaming()
+{
+    {
+        std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
+        if (this->camera->is_exposing_single()) {
+            LOG_ERROR("Invalid streaming request during single-frame acquisition");
+            return false;
+        }
+
+        this->camera->set_exposure_time(Streamer->getTargetExposure()*1000000.0);
+        LOG_INFO("Requesting streaming start");
+        this->streaming_thread_active = true;
+    }
+    this->streaming_thread_condition.notify_all();
+    return true;
+}
+
+bool GigECCD::StopStreaming()
+{
+    LOG_INFO("Requesting streaming stop");
+    this->streaming_thread_active = false;
+    this->streaming_thread_condition.notify_all();
     return true;
 }
 
 void GigECCD::_update_image(uint8_t const *const data, size_t size)
 {
-    LOGF_INFO("Receiving %i bytes image", size);
+    LOGF_INFO("Received %i bytes image", size);
 
     size_t const frame_buf_size = PrimaryCCD.getFrameBufferSize();
 
     if ((size == frame_buf_size) && (data != nullptr))
     {
-        uint8_t *const image = PrimaryCCD.getFrameBuffer();
-        memcpy(image, (void const*)data, frame_buf_size);
+        { /* locked as per indiccd.h guidance. */
+            std::lock_guard<std::mutex> lock(this->ccdBufferLock);
+            uint8_t *const image = PrimaryCCD.getFrameBuffer();
+            memcpy(image, (void const*)data, frame_buf_size);
+        }
         if (TemperatureNP.getPermission() == IP_RO) {
+            std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
             this->TemperatureNP[0].setValue(this->camera->get_float("DeviceTemperature"));
             this->TemperatureNP.setState(IPS_OK);
             this->TemperatureNP.apply();
@@ -240,23 +346,21 @@ void GigECCD::_update_image(uint8_t const *const data, size_t size)
     }
 }
 
-void GigECCD::_receive_image_hook(void *const class_ptr, uint8_t const *const data, size_t size)
-{
-    GigECCD * cls = static_cast<GigECCD *>(class_ptr);
-    cls->_update_image(data, size);
-}
-
 void GigECCD::_handle_failed(void)
 {
     LOG_ERROR("Failure occurred, filling image with black");
 
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     camera->exposure_abort();
 
     PrimaryCCD.setExposureLeft(0);
 
-    /* Fill with black */
-    uint8_t *const image = PrimaryCCD.getFrameBuffer();
-    memset(image, 0, PrimaryCCD.getFrameBufferSize());
+    { /* locked as per indiccd.h guidance. */
+        std::lock_guard<std::mutex> lock(this->ccdBufferLock);
+        /* Fill with black */
+        uint8_t *const image = PrimaryCCD.getFrameBuffer();
+        memset(image, 0, PrimaryCCD.getFrameBufferSize());
+    }
 
     this->ExposureComplete(&PrimaryCCD);
 }
@@ -269,6 +373,7 @@ void GigECCD::_handle_timeout(struct timeval *const tv, uint32_t timeout_us)
     struct timeval now;
     TIME_VAL_GET(&now);
 
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     uint32_t const elapsed       = ((TIME_VAL_US(&now)) - (TIME_VAL_US(tv)));
     uint32_t const exposure_time = (uint32_t)this->camera->get_exposure().val();
     uint32_t const time_left     = exposure_time - elapsed;
@@ -278,26 +383,37 @@ void GigECCD::_handle_timeout(struct timeval *const tv, uint32_t timeout_us)
     else
         PrimaryCCD.setExposureLeft((float)time_left / (float)TIMER_US_TO_S);
 
-    if (elapsed > timeout_us)
+    if (elapsed > timeout_us) {
+        LOGF_ERROR("Image acquisition timed out (>%d μs)", timeout_us);
         this->_handle_failed();
+    }
 }
 
 void GigECCD::TimerHit()
 {
-    this->timer_id = this->SetTimer(TIMER_TICK_MS);
-    if (!this->camera->is_connected() || !this->camera->is_exposing())
+    this->timer_id = this->SetTimer(this->getCurrentPollingPeriod());
+    if (!this->camera->is_connected() || !this->camera->is_exposing_single())
         return;
 
-    arv::ARV_EXPOSURE_STATUS const status = camera->exposure_poll(this->_receive_image_hook, this);
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
+    auto receive_image = [this](uint8_t const *const data, size_t size)
+    {
+        this->_update_image(data, size);
+    };
+
+
+    auto status = camera->exposure_poll(receive_image);
     switch (status)
     {
         case arv::ARV_EXPOSURE_FINISHED:
-            /* Nothing to do, ArvCamera automatically unsets is_exposing */
+            // Nothing to do, ArvCamera automatically unsets is_exposing_single
             break;
         case arv::ARV_EXPOSURE_UNKNOWN:
-        case arv::ARV_EXPOSURE_FAILED:
+        case arv::ARV_EXPOSURE_FAILED: {
+            LOG_ERROR("Image acquisition had unknown failure");
             this->_handle_failed();
             break;
+        }
         case arv::ARV_EXPOSURE_FILLING:
             this->_handle_timeout(&this->exposure_transfer_time, TIMER_TRANSFER_TIMEOUT_US);
             break;
@@ -317,6 +433,7 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
             GainNP.update(values, names, n);
             GainNP.setState(IPS_OK);
 
+            std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
             this->camera->set_gain(this->GainNP[0].getValue());
             /* Get-back from camera system */
             this->GainNP[0].setValue(this->camera->get_gain().val());
@@ -346,6 +463,7 @@ bool GigECCD::UpdateCCDFrame(int x, int y, int w, int h)
 {
     LOGF_INFO("%s x=%i y=%i w=%i h=%i", __PRETTY_FUNCTION__, x, y, w, h);
 
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     this->camera->set_geometry(x, y, w, h);
     return this->_update_geometry();
 }
@@ -353,6 +471,7 @@ bool GigECCD::UpdateCCDFrame(int x, int y, int w, int h)
 bool GigECCD::UpdateCCDBin(int binx, int biny)
 {
     LOGF_INFO("%s binx=%i biny=%i", __PRETTY_FUNCTION__, binx, biny);
+    std::lock_guard<std::recursive_mutex> lock(this->camera_mutex);
     camera->set_bin(binx, biny);
     return UpdateCCDFrame(PrimaryCCD.getSubX(), PrimaryCCD.getSubY(), PrimaryCCD.getSubW(), PrimaryCCD.getSubH());
 }

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -191,6 +191,7 @@ bool GigECCD::StartExposure(float duration)
         duration = 0;
 
     camera->set_exposure_time((double)(duration)*1000000.0);
+    PrimaryCCD.setExposureDuration(duration); // to ensure FITS correct header
 
     TIME_VAL_INIT(&this->exposure_transfer_time);
     TIME_VAL_GET(&this->exposure_start_time);

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -65,7 +65,9 @@ const char *GigECCD::getDefaultName()
 GigECCD::GigECCD(arv::ArvCamera *camera)
 {
     this->camera = camera;
-    snprintf(this->name, sizeof(this->name), "GigE CCD%s", this->camera->model_name());
+    snprintf(this->name, sizeof(this->name), "GigE CCD %s-%s",
+             this->camera->model_name(),
+             this->camera->device_id());
     setDeviceName(this->name);
 }
 

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -115,10 +115,13 @@ bool GigECCD::_update_geometry(void)
 void GigECCD::_update_indi_properties(void)
 {
     LOG_INFO("update_indi_properties()");
-    IUFillNumber(&this->indiprop_gain[0], "Range", "", "%g", (double)this->camera->get_gain().min(),
-                 (double)this->camera->get_gain().max(), 1., (double)this->camera->get_gain().val());
-    IUFillNumberVector(&this->indiprop_gain_prop, this->indiprop_gain, 1, getDeviceName(), "Gain", "", MAIN_CONTROL_TAB,
-                       IP_RW, 60, IPS_IDLE);
+
+    // Gain
+    GainNP[0].fill("GAIN", "value", "%.f",
+                   (double)this->camera->get_gain().min(),
+                   (double)this->camera->get_gain().max(), 1.,
+                   (double)this->camera->get_gain().val());
+    GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     IUFillText(&indiprop_info[0], "Vendor Name", "", this->camera->vendor_name());
     IUFillText(&indiprop_info[1], "Model Name", "", this->camera->model_name());
@@ -127,7 +130,7 @@ void GigECCD::_update_indi_properties(void)
                      0, IPS_IDLE);
 
     defineProperty(&indiprop_info_prop);
-    defineProperty(&this->indiprop_gain_prop);
+    defineProperty(this->GainNP);
     if (this->camera->has_feature("DeviceTemperature")) {
       this->TemperatureNP.setPermission(IP_RO);
       defineProperty(this->TemperatureNP);
@@ -136,7 +139,7 @@ void GigECCD::_update_indi_properties(void)
 
 void GigECCD::_delete_indi_properties(void)
 {
-    this->deleteProperty(this->indiprop_gain_prop.name);
+    this->deleteProperty(this->GainNP);
     this->deleteProperty(this->indiprop_info_prop.name);
     if (TemperatureNP.getPermission() == IP_RO) {
       this->TemperatureNP.setPermission(IP_RW);
@@ -300,16 +303,16 @@ bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], ch
 {
     if (!strcmp(dev, this->getDeviceName()))
     {
-        if (!strcmp(name, this->indiprop_gain_prop.name))
+        if (GainNP.isNameMatch(name))
         {
-            IUUpdateNumber(&this->indiprop_gain_prop, values, names, n);
-            this->camera->set_gain(this->indiprop_gain[0].value);
-            this->indiprop_gain_prop.s = IPS_OK;
+            GainNP.update(values, names, n);
+            GainNP.setState(IPS_OK);
 
+            this->camera->set_gain(this->GainNP[0].getValue());
             /* Get-back from camera system */
-            double actual_value = this->camera->get_gain().val();
-            IUUpdateNumber(&this->indiprop_gain_prop, &actual_value, names, n);
-            IDSetNumber(&this->indiprop_gain_prop, nullptr);
+            this->GainNP[0].setValue(this->camera->get_gain().val());
+
+            GainNP.apply();
             return true;
         }
     }
@@ -337,4 +340,11 @@ bool GigECCD::UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType)
     LOGF_INFO("%s", __PRETTY_FUNCTION__);
     PrimaryCCD.setFrameType(fType);
     return true;
+}
+
+void GigECCD::addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeyword)
+{
+    INDI::CCD::addFITSKeywords(targetChip, fitsKeyword);
+
+    fitsKeyword.push_back({"GAIN", GainNP[0].getValue(), 3, "Gain"});
 }

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -76,9 +76,10 @@ static class Loader
 public:
     Loader()
     {
-        arv::ArvCamera *camera = arv::ArvFactory::find_first_available();
-        cameras.push_back(std::unique_ptr<GigECCD>(new GigECCD(camera)));
+        auto camera = arv::ArvFactory::find_first_available();
         IDLog("Found Camera: %s\n", camera->device_id());
+        auto gigeccd = new GigECCD(std::move(camera));
+        cameras.push_back(std::unique_ptr<GigECCD>(gigeccd));
     }
 } loader;
 
@@ -87,9 +88,9 @@ const char *GigECCD::getDefaultName()
     return "GigE CCD";
 }
 
-GigECCD::GigECCD(arv::ArvCamera *camera)
+GigECCD::GigECCD(std::unique_ptr<arv::ArvCamera> camera)
+  : camera(std::move(camera))
 {
-    this->camera = camera;
     setDeviceName(this->camera->device_id());
 }
 

--- a/indi-gige/src/indi_gige.cpp
+++ b/indi-gige/src/indi_gige.cpp
@@ -128,12 +128,20 @@ void GigECCD::_update_indi_properties(void)
 
     defineProperty(&indiprop_info_prop);
     defineProperty(&this->indiprop_gain_prop);
+    if (this->camera->has_feature("DeviceTemperature")) {
+      this->TemperatureNP.setPermission(IP_RO);
+      defineProperty(this->TemperatureNP);
+    }
 }
 
 void GigECCD::_delete_indi_properties(void)
 {
     this->deleteProperty(this->indiprop_gain_prop.name);
     this->deleteProperty(this->indiprop_info_prop.name);
+    if (TemperatureNP.getPermission() == IP_RO) {
+      this->TemperatureNP.setPermission(IP_RW);
+      this->deleteProperty(this->TemperatureNP);
+    }
 }
 
 //Initial call
@@ -205,6 +213,11 @@ void GigECCD::_update_image(uint8_t const *const data, size_t size)
     {
         uint8_t *const image = PrimaryCCD.getFrameBuffer();
         memcpy(image, (void const*)data, frame_buf_size);
+        if (TemperatureNP.getPermission() == IP_RO) {
+            this->TemperatureNP[0].setValue(this->camera->get_float("DeviceTemperature"));
+            this->TemperatureNP.setState(IPS_OK);
+            this->TemperatureNP.apply();
+        }
         this->ExposureComplete(&PrimaryCCD);
     }
     else

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -49,6 +49,7 @@ class GigECCD : public INDI::CCD
     virtual bool UpdateCCDBin(int binx, int biny) override;
     virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;
     virtual void addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeyword) override;
+    virtual bool saveConfigItems(FILE *fp) override;
 
   private:
     void _delete_indi_properties(void);

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -69,6 +69,7 @@ class GigECCD : public INDI::CCD
     /* Indi properties */
 
     INDI::PropertyNumber GainNP {1};
+    INDI::PropertyNumber PixelSizeNP {1};
     IText indiprop_info[3] {};
     ITextVectorProperty indiprop_info_prop;
 

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -21,7 +21,6 @@
 #define GENERIC_CCD_H
 
 #include <indiccd.h>
-#include <iostream>
 
 #include "ArvInterface.h"
 
@@ -33,22 +32,22 @@ class GigECCD : public INDI::CCD
     GigECCD(arv::ArvCamera *camera);
     virtual ~GigECCD();
 
-    const char *getDefaultName();
+    virtual const char *getDefaultName() override;
 
-    bool initProperties();
-    bool updateProperties();
+    virtual bool initProperties() override;
+    virtual bool updateProperties() override;
 
-    bool Connect();
-    bool Disconnect();
+    virtual bool Connect() override;
+    virtual bool Disconnect() override;
 
-    bool StartExposure(float duration);
-    bool AbortExposure();
+    virtual bool StartExposure(float duration) override;
+    virtual bool AbortExposure() override;
 
   protected:
-    void TimerHit();
-    virtual bool UpdateCCDFrame(int x, int y, int w, int h);
-    virtual bool UpdateCCDBin(int binx, int biny);
-    virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType);
+    virtual void TimerHit() override;
+    virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
+    virtual bool UpdateCCDBin(int binx, int biny) override;
+    virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;
 
   private:
     void _delete_indi_properties(void);

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -62,7 +62,6 @@ class GigECCD : public INDI::CCD
     void _handle_timeout(struct timeval *const tv, uint32_t timeout_us);
 
     arv::ArvCamera *camera;
-    char name[32];
     int timer_id;
     struct timeval exposure_start_time;
     struct timeval exposure_transfer_time;

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -22,6 +22,11 @@
 
 #include <indiccd.h>
 
+#include <string>
+#include <thread>
+#include <atomic>
+#include <condition_variable>
+
 #include "ArvInterface.h"
 
 using namespace std;
@@ -42,6 +47,12 @@ class GigECCD : public INDI::CCD
 
     virtual bool StartExposure(float duration) override;
     virtual bool AbortExposure() override;
+    /** Request streaming to start.
+     * This should not be called with camera_mutex locked. */
+    virtual bool StartStreaming() override;
+    /** Request streaming to stop.
+     * This should not be called with camera_mutex locked. */
+    virtual bool StopStreaming() override;
 
   protected:
     virtual void TimerHit() override;
@@ -56,15 +67,24 @@ class GigECCD : public INDI::CCD
     void _update_indi_properties(void);
     bool _update_geometry(void);
     void _update_image(uint8_t const *const data, size_t size);
-    static void _receive_image_hook(void *const class_ptr, uint8_t const *const data, size_t size);
 
     void _handle_failed(void);
     void _handle_timeout(struct timeval *const tv, uint32_t timeout_us);
+    void start_streaming_thread();
+    /** Request streaming to stop and the streaming thread to quit.
+     * This should not be called with camera_mutex locked. */
+    void stop_streaming_thread();
 
     arv::ArvCamera *camera;
+    std::recursive_mutex camera_mutex;
     int timer_id;
     struct timeval exposure_start_time;
     struct timeval exposure_transfer_time;
+
+    std::thread streaming_thread;
+    std::atomic<bool> streaming_thread_stop_requested {false};
+    std::atomic<bool> streaming_thread_active {false};
+    std::condition_variable_any streaming_thread_condition;
 
     /* Indi properties */
 

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -65,7 +65,8 @@ class GigECCD : public INDI::CCD
   private:
     void _delete_indi_properties(void);
     void _update_indi_properties(void);
-    bool _update_geometry(void);
+    void _update_bin(void); /// update binning to INDI from hardware
+    bool _update_geometry(void); /// update geometry to INDI from hardware
     void _update_image(uint8_t const *const data, size_t size);
 
     void _handle_failed(void);

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -48,6 +48,7 @@ class GigECCD : public INDI::CCD
     virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
     virtual bool UpdateCCDBin(int binx, int biny) override;
     virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;
+    virtual void addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeyword) override;
 
   private:
     void _delete_indi_properties(void);
@@ -67,8 +68,7 @@ class GigECCD : public INDI::CCD
 
     /* Indi properties */
 
-    INumber indiprop_gain[1];
-    INumberVectorProperty indiprop_gain_prop;
+    INDI::PropertyNumber GainNP {1};
     IText indiprop_info[3] {};
     ITextVectorProperty indiprop_info_prop;
 

--- a/indi-gige/src/indi_gige.h
+++ b/indi-gige/src/indi_gige.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <thread>
 #include <atomic>
+#include <memory>
 #include <condition_variable>
 
 #include "ArvInterface.h"
@@ -34,7 +35,7 @@ using namespace std;
 class GigECCD : public INDI::CCD
 {
   public:
-    GigECCD(arv::ArvCamera *camera);
+    GigECCD(std::unique_ptr<arv::ArvCamera> camera);
     virtual ~GigECCD();
 
     virtual const char *getDefaultName() override;
@@ -76,7 +77,7 @@ class GigECCD : public INDI::CCD
      * This should not be called with camera_mutex locked. */
     void stop_streaming_thread();
 
-    arv::ArvCamera *camera;
+    std::unique_ptr<arv::ArvCamera> camera;
     std::recursive_mutex camera_mutex;
     int timer_id;
     struct timeval exposure_start_time;


### PR DESCRIPTION
Most of the code in the indi-gige driver was written specifically for at least one older version of a point-grey BlackFly camera using an older version of the Aravis library.  These patches update the indi-gige driver to use the more recent and common 0.8 version of the Aravis library.  These patches also greatly improve the driver to be more generically applicable to other cameras.  These patches also allow for streaming from an Aravis-supported camera (either GigE-Vision or USB-vision).  These patches provide the necessary changes that will also allow for multiple cameras to be used simultaneously.  Nevertheless, these patches do not implement the iterative enumeration that will be necessary to instantiate all available cameras (only the first is still instantiated)--it is left as a task for a future patch to implement this extended instantiation.