### PR TITLE
gphoto: fix range type manual focusing

### DIFF
--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -2328,7 +2328,7 @@ int gphoto_manual_focus(gphoto_driver *gphoto, int speed, char *errMsg)
         }
         case GP_WIDGET_RANGE:
         {
-            int rval = speed;
+            float rval = speed;
 
             /* Range is on Nikon from -32768 <-> 32768 */
             if (strstr(device, "Nikon"))
@@ -2358,6 +2358,11 @@ int gphoto_manual_focus(gphoto_driver *gphoto, int speed, char *errMsg)
                         break;
                 }
             }
+
+            /* Reset to 0 first so the camera registers a change on repeated calls */
+            const float zero = 0;
+            gp_widget_set_value(gphoto->focus_widget->widget, &zero);
+            gphoto_set_config(gphoto->camera, gphoto->config, gphoto->context);
 
             rc = gp_widget_set_value(gphoto->focus_widget->widget, &rval);
             if (rc < GP_OK)


### PR DESCRIPTION
 - `gp_widget_set_value` expects float value for RANGE type widgets
 - reset the value to 0 before performing the focusing (similar way to RADIO type widget) otherwise the action is not performed by the camera if the same value is used repeatedly

Tested with a Sony a6400