### PR TITLE
Add  target liveviewFPS parameters

### DIFF
--- a/indi-gphoto/gphoto_ccd.cpp
+++ b/indi-gphoto/gphoto_ccd.cpp
@@ -43,6 +43,7 @@
 #define MAX_DEVICES  5 /* Max device cameraCount */
 #define FOCUS_TIMER  50
 #define MAX_RETRIES  3
+static const char * STREAM_TAB = "Streaming"; //Original is declared in streammanager.cpp
 
 #ifdef __APPLE__
 // getprogname() is a BSD/Darwin function present in the runtime but hidden from
@@ -336,6 +337,12 @@ bool GPhotoCCD::initProperties()
 
     SetCCDCapability(CCD_CAN_SUBFRAME | CCD_CAN_BIN | CCD_CAN_ABORT | CCD_HAS_BAYER | CCD_HAS_STREAMING);
 
+    //Liveview Target FPS
+    TargetLiveviewFPSNP[0].fill("TargetFPS", "TargetFPS", "%.1f", 1,60, 0.1, 30);
+    TargetLiveviewFPSNP[1].fill("Wait", "Wait(mS)", "%1.0f", 0, 1000, 1, 0);
+    TargetLiveviewFPSNP.fill(getDeviceName(), "TARGET_FPS", "Target FPS", STREAM_TAB, IP_RW, 60, IPS_IDLE);
+    TargetLiveviewFPSNP.load();
+
     Streamer->setStreamingExposureEnabled(false);
 
 #if 0
@@ -449,6 +456,7 @@ bool GPhotoCCD::updateProperties()
 
         defineProperty(ForceBULBSP);
         defineProperty(DownloadTimeoutNP);
+        defineProperty(TargetLiveviewFPSNP);
     }
     else
     {
@@ -475,6 +483,7 @@ bool GPhotoCCD::updateProperties()
 
         deleteProperty(ForceBULBSP);
         deleteProperty(DownloadTimeoutNP);
+        deleteProperty(TargetLiveviewFPSNP);
 
         HideExtendedOptions();
     }
@@ -801,6 +810,15 @@ bool GPhotoCCD::ISNewNumber(const char * dev, const char * name, double values[]
             MirrorLockNP.setState(IPS_OK);
             MirrorLockNP.apply();
             saveConfig(MirrorLockNP);
+            return true;
+        }
+
+        //Liveview FPS
+        if (TargetLiveviewFPSNP.isNameMatch(name)){
+            TargetLiveviewFPSNP.update(values, names, n);
+            TargetLiveviewFPSNP.setState(IPS_OK);
+            TargetLiveviewFPSNP.apply();
+            saveConfig(TargetLiveviewFPSNP);
             return true;
         }
 
@@ -1967,6 +1985,8 @@ void GPhotoCCD::streamLiveView()
     char errMsg[MAXRBUF] = {0};
     while (true)
     {
+        std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
+
         std::unique_lock<std::mutex> guard(liveStreamMutex);
         if (m_RunLiveStream == false)
             break;
@@ -2082,6 +2102,12 @@ void GPhotoCCD::streamLiveView()
             PrimaryCCD.setFrameBufferSize(size, false);
 
         Streamer->newFrame(ccdBuffer, size);
+
+        std::chrono::duration<double> sec = std::chrono::system_clock::now() - start;
+        int sleepMS = sec.count()*1000;
+        sleepMS = 1000/TargetLiveviewFPSNP[0].value - sleepMS;
+        sleepMS = sleepMS < 0 ? TargetLiveviewFPSNP[1].value:sleepMS + TargetLiveviewFPSNP[1].value;                 
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleepMS));
     }
 
     gp_file_unref(previewFile);

--- a/indi-gphoto/gphoto_ccd.cpp
+++ b/indi-gphoto/gphoto_ccd.cpp
@@ -338,12 +338,11 @@ bool GPhotoCCD::initProperties()
     SetCCDCapability(CCD_CAN_SUBFRAME | CCD_CAN_BIN | CCD_CAN_ABORT | CCD_HAS_BAYER | CCD_HAS_STREAMING);
 
     //Liveview Target FPS
-    TargetLiveviewFPSNP[0].fill("TargetFPS", "TargetFPS", "%.1f", 1,60, 0.1, 30);
-    TargetLiveviewFPSNP[1].fill("Wait", "Wait(mS)", "%1.0f", 0, 1000, 1, 0);
-    TargetLiveviewFPSNP.fill(getDeviceName(), "TARGET_FPS", "Target FPS", STREAM_TAB, IP_RW, 60, IPS_IDLE);
-    TargetLiveviewFPSNP.load();
+    FrameWaitNP[0].fill("Wait", "Wait(mS)", "%1.0f", 0, 1000, 1, 0);
+    FrameWaitNP.fill(getDeviceName(), "FRAME_WAIT", "Frame Wait", STREAM_TAB, IP_RW, 60, IPS_IDLE);
+    FrameWaitNP.load();
 
-    Streamer->setStreamingExposureEnabled(false);
+    Streamer->setStreamingExposureEnabled(true);
 
 #if 0
     FI::SetCapability(FOCUSER_HAS_VARIABLE_SPEED);
@@ -456,7 +455,7 @@ bool GPhotoCCD::updateProperties()
 
         defineProperty(ForceBULBSP);
         defineProperty(DownloadTimeoutNP);
-        defineProperty(TargetLiveviewFPSNP);
+        defineProperty(FrameWaitNP);
     }
     else
     {
@@ -483,7 +482,7 @@ bool GPhotoCCD::updateProperties()
 
         deleteProperty(ForceBULBSP);
         deleteProperty(DownloadTimeoutNP);
-        deleteProperty(TargetLiveviewFPSNP);
+        deleteProperty(FrameWaitNP);
 
         HideExtendedOptions();
     }
@@ -814,11 +813,11 @@ bool GPhotoCCD::ISNewNumber(const char * dev, const char * name, double values[]
         }
 
         //Liveview FPS
-        if (TargetLiveviewFPSNP.isNameMatch(name)){
-            TargetLiveviewFPSNP.update(values, names, n);
-            TargetLiveviewFPSNP.setState(IPS_OK);
-            TargetLiveviewFPSNP.apply();
-            saveConfig(TargetLiveviewFPSNP);
+        if (FrameWaitNP.isNameMatch(name)){
+            FrameWaitNP.update(values, names, n);
+            FrameWaitNP.setState(IPS_OK);
+            FrameWaitNP.apply();
+            saveConfig(FrameWaitNP);
             return true;
         }
 
@@ -1983,6 +1982,7 @@ void GPhotoCCD::streamLiveView()
     }
 
     char errMsg[MAXRBUF] = {0};
+
     while (true)
     {
         std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
@@ -2105,8 +2105,8 @@ void GPhotoCCD::streamLiveView()
 
         std::chrono::duration<double> sec = std::chrono::system_clock::now() - start;
         int sleepMS = sec.count()*1000;
-        sleepMS = 1000/TargetLiveviewFPSNP[0].value - sleepMS;
-        sleepMS = sleepMS < 0 ? TargetLiveviewFPSNP[1].value:sleepMS + TargetLiveviewFPSNP[1].value;                 
+        sleepMS = 1000/Streamer->getTargetFPS() - sleepMS;
+        sleepMS = sleepMS < 0 ? FrameWaitNP[0].value:sleepMS + FrameWaitNP[0].value;                 
         std::this_thread::sleep_for(std::chrono::milliseconds(sleepMS));
     }
 

--- a/indi-gphoto/gphoto_ccd.h
+++ b/indi-gphoto/gphoto_ccd.h
@@ -209,7 +209,7 @@ class GPhotoCCD : public INDI::CCD, public INDI::FocuserInterface
         INDI::PropertyText UploadFileTP {1};
         INDI::PropertyBlob imageBP {INDI::Property()};
         // Target liveview FPS
-        INDI::PropertyNumber TargetLiveviewFPSNP {2};
+        INDI::PropertyNumber FrameWaitNP {1};
 
         Camera * camera = nullptr;
 

--- a/indi-gphoto/gphoto_ccd.h
+++ b/indi-gphoto/gphoto_ccd.h
@@ -208,6 +208,8 @@ class GPhotoCCD : public INDI::CCD, public INDI::FocuserInterface
         // Upload file, used for testing purposes under simulation under native mode
         INDI::PropertyText UploadFileTP {1};
         INDI::PropertyBlob imageBP {INDI::Property()};
+        // Target liveview FPS
+        INDI::PropertyNumber TargetLiveviewFPSNP {2};
 
         Camera * camera = nullptr;
 


### PR DESCRIPTION
In the current implementation, the next frame acquisition is triggered immediately after a frame is received from the camera. As a result, when using older cameras such as the Nikon D5300, the camera cannot keep up with the continuous acquisition requests, causing it to freeze.

To address this issue, a new parameter will be added to acquire frames at a specified frame-rate interval. In addition, another parameter will be introduced to insert a wait period after each frame acquisition, allowing extra time for the camera to complete its internal processing when the specified frame-rate interval alone is not sufficient.