### PR TITLE
indi-libcamera: use negotiated stream size for CCD geometry

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -621,6 +621,10 @@ RpiCamProperties INDILibCamera::getAvailableCamProperties()
     
     config->validate();
     cam->configure(config.get());
+    // Save the negotiated StillCapture stream size.
+    // This is used to initialize the CCD geometry during Connect().
+    m_CaptureWidth = config->at(0).size.width;
+    m_CaptureHeight = config->at(0).size.height;
     
     const auto &controls = cam->controls();
     
@@ -926,10 +930,30 @@ void INDILibCamera::default_signal_handler(int signal_number)
 bool INDILibCamera::Connect()
 {
     LOGF_INFO("Connecting to %s", getDeviceName());
-    auto pas = m_ControlList.get(properties::PixelArraySize);
-    // no idea why the IMX290 returns an uneven number of pixels, so just round down
-    auto width = 2.0 * (pas->width / 2);
-    auto height = pas->height;
+
+    // Use the negotiated StillCapture stream size when available.
+    // PixelArraySize describes the sensor array and may differ from
+    // the actual capture stream dimensions on some cameras.
+    uint32_t width = m_CaptureWidth;
+    uint32_t height = m_CaptureHeight;
+
+    if (width == 0 || height == 0)
+    {
+        auto pas = m_ControlList.get(properties::PixelArraySize);
+
+        if (pas)
+        {
+            // no idea why the IMX290 returns an uneven number of pixels, so just round down
+            width = 2 * (pas->width / 2);
+            height = pas->height;
+            LOG_WARN("Negotiated stream size unavailable, falling back to PixelArraySize.");
+        }
+        else
+        {
+            LOG_ERROR("Unable to determine CCD size.");
+            return false;
+        }
+    }
 
     PrimaryCCD.setResolution(width, height);
     UpdateCCDFrame(0, 0, width, height);

--- a/indi-libcamera/indi_libcamera.h
+++ b/indi-libcamera/indi_libcamera.h
@@ -45,7 +45,7 @@ struct RpiCamProperties
         T max;
         T def;
     };
-    
+
     ControlRange<float> brightness    = {-1.0f, 1.0f, 0.0f};
     ControlRange<float> contrast      = {0.0f, 15.99f, 1.0f};
     ControlRange<float> saturation    = {0.0f, 15.99f, 1.0f};
@@ -167,6 +167,10 @@ class INDILibCamera : public INDI::CCD
         int m_black_levels[4] {0, 0, 0, 0};
         int m_LiveVideoWidth {-1}, m_LiveVideoHeight {-1};
         uint8_t m_CameraIndex;
+
+        uint32_t m_CaptureWidth = 0;
+        uint32_t m_CaptureHeight = 0;
+
         libcamera::ControlList m_ControlList;
 
         RpiCamProperties getAvailableCamProperties();


### PR DESCRIPTION
## Summary

Use the negotiated libcamera StillCapture stream size to initialize the INDI CCD geometry instead of `properties::PixelArraySize`.

## Background

While testing an IMX462 camera on Raspberry Pi OS Bookworm (64-bit) with libcamera 0.5.2, I noticed the driver reported a CCD/ROI size of 1944×1097, while libcamera negotiated a 1920×1080 StillCapture stream.

The driver initialized the CCD geometry from `properties::PixelArraySize`, which describes the sensor array and may differ from the negotiated capture stream on some cameras.

This patch stores the negotiated StillCapture stream dimensions after camera configuration and uses them to initialize the CCD geometry.

If the negotiated stream size is unavailable, the driver falls back to `PixelArraySize` to preserve compatibility.

## Tested on

* Raspberry Pi Zero 2 W
* Raspberry Pi OS Bookworm 64-bit
* libcamera 0.5.2
* Sony IMX462

Verified using:

* `rpicam-hello --list-cameras`
* `rpicam-still`
* INDI Control Panel
* Ekos-KStars

After this change the driver reports:

* CCD: 1920×1080
* Frame ROI: 1920×1080

matching the negotiated libcamera capture stream.

This is my first contribution to the project. If there is a preferred way to implement this or any coding style changes you'd like, I'd be happy to update the patch.
