### PR TITLE
indi-libcamera:  Add Gain Conversion control for IMX290-family sensors

### DIFF
--- a/indi-libcamera/README.md
+++ b/indi-libcamera/README.md
@@ -28,6 +28,34 @@ The Driver can run multiple devices if required, to run the driver:
 
 AVAILABLE CONTROLS
 
+## Gain Conversion (HCG/LCG)
+
+The Gain Conversion control is available for IMX290-family sensors when the
+kernel exposes the following sysfs interface:
+
+    /sys/module/imx290/parameters/hcg_mode
+
+When this interface is available, indi-libcamera exposes a "Gain Conversion"
+property that allows switching between:
+
+- Dynamic Range (LCG)
+- Low Noise (HCG)
+
+If the sysfs interface is not present, the property is hidden.
+
+By default, the sysfs interface is typically writable only by root.
+
+One way to allow a non-root `indiserver` to control Gain Conversion is to
+change the group ownership to a group that the `indiserver` user belongs to,
+for example:
+
+```bash
+sudo chgrp video /sys/module/imx290/parameters/hcg_mode
+```
+
+For a permanent configuration, use a udev rule or another system-specific
+mechanism to assign the desired group automatically.
+
 TODO 
 
 You can also start video stream.

--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -43,8 +43,17 @@
 #include <libraw.h>
 #include <jpeglib.h>
 
+#include <fstream>
+#include <cerrno>
+#include <cstring>
 
 #define CONTROL_TAB "Controls"
+
+namespace
+{
+constexpr const char *HCG_SYSFS =
+    "/sys/module/imx290/parameters/hcg_mode";
+}
 
 static class Loader
 {
@@ -773,6 +782,10 @@ bool INDILibCamera::initProperties()
     GainNP[0].fill("GAIN", "Gain", "%.2f", props.gain.min, props.gain.max, 1.00, props.gain.def);
     GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", IMAGE_CONTROLS_TAB, IP_RW, 60, IPS_IDLE);
 
+    GainConversionSP[0].fill("LCG", "Dynamic Range (LCG)", ISS_ON);
+    GainConversionSP[1].fill("HCG", "Low Noise (HCG)", ISS_OFF);
+    GainConversionSP.fill(getDeviceName(), "GAIN_CONVERSION", "Gain Conversion", IMAGE_CONTROLS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+
     uint32_t cap = 0;
     cap |= CCD_HAS_BAYER;
     cap |= CCD_HAS_STREAMING;
@@ -810,6 +823,14 @@ bool INDILibCamera::updateProperties()
         defineProperty(TemperatureNP);
         defineProperty(AdjustmentNP);
         defineProperty(GainNP);
+
+        GainConversionMode currentMode;
+        if (readGainConversionMode(currentMode))
+        {
+            defineProperty(GainConversionSP);
+            updateGainConversionUI();
+        }
+
         defineProperty(AdjustExposureModeSP);
         defineProperty(AdjustAwbModeSP);
         defineProperty(AdjustMeteringModeSP);
@@ -820,6 +841,7 @@ bool INDILibCamera::updateProperties()
         deleteProperty(TemperatureNP);
         deleteProperty(AdjustmentNP);
         deleteProperty(GainNP);
+        deleteProperty(GainConversionSP);
         deleteProperty(AdjustExposureModeSP);
         deleteProperty(AdjustAwbModeSP);
         deleteProperty(AdjustMeteringModeSP);
@@ -1062,6 +1084,28 @@ bool INDILibCamera::ISNewSwitch(const char *dev, const char *name, ISState * sta
             }, true);
             return true;
         }
+
+        // Gain Conversion
+        if (GainConversionSP.isNameMatch(name))
+        {
+            updateProperty(GainConversionSP, states, names, n, [this, names]()
+            {
+                GainConversionMode mode =
+                    (strcmp(names[0], "HCG") == 0)
+                        ? GainConversionMode::LowNoise
+                        : GainConversionMode::DynamicRange;
+
+                if (!writeGainConversionMode(mode))
+                    return false;
+
+                updateGainConversionUI();
+
+                return true;
+            }, true);
+
+            return true;
+        }
+
     }
 
     return INDI::CCD::ISNewSwitch(dev, name, states, names, n);
@@ -1574,3 +1618,79 @@ INDI_PIXEL_FORMAT INDILibCamera::bayerToPixelFormat(const char *bayer)
 
     return INDI_MONO;
 }
+/////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////
+bool INDILibCamera::readGainConversionMode(GainConversionMode &mode) const
+{
+    std::ifstream file(HCG_SYSFS);
+
+    if (!file)
+        return false;
+
+    std::string value;
+    file >> value;
+
+    if (!value.empty() &&
+        (value[0] == 'Y' || value[0] == 'y'))
+    {
+        mode = GainConversionMode::LowNoise;
+    }
+    else
+    {
+        mode = GainConversionMode::DynamicRange;
+    }
+
+    return true;
+}
+
+void INDILibCamera::updateGainConversionUI()
+{
+    GainConversionMode mode;
+
+    if (!readGainConversionMode(mode))
+        return;
+
+    GainConversionSP.reset();
+
+    if (mode == GainConversionMode::LowNoise)
+        GainConversionSP[1].setState(ISS_ON);
+    else
+        GainConversionSP[0].setState(ISS_ON);
+
+    GainConversionSP.setState(IPS_OK);
+    GainConversionSP.apply();
+}
+
+bool INDILibCamera::writeGainConversionMode(GainConversionMode mode)
+{
+    std::ofstream file(HCG_SYSFS);
+
+    if (!file)
+    {
+        LOGF_ERROR("No write permission for %s. Configure write permissions or run indiserver with appropriate privileges.",
+                    HCG_SYSFS);
+        return false;
+    }
+
+    if (mode == GainConversionMode::LowNoise)
+        file << '1';
+    else
+        file << '0';
+
+    file.flush();
+
+    if (!file.good())
+    {
+        LOGF_ERROR("Failed writing to %s: %s",
+                    HCG_SYSFS,
+                    strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////

--- a/indi-libcamera/indi_libcamera.h
+++ b/indi-libcamera/indi_libcamera.h
@@ -157,6 +157,7 @@ class INDILibCamera : public INDI::CCD
         INDI::PropertySwitch AdjustExposureModeSP {0}, AdjustAwbModeSP {0}, AdjustMeteringModeSP {0}, AdjustDenoiseModeSP {0} ;
         INDI::PropertyNumber AdjustmentNP {AdjustAwbBlue + 1};
         INDI::PropertyNumber GainNP {1};
+        INDI::PropertySwitch GainConversionSP {2};
 
         // std::unique_ptr<RPiCamApp> m_CameraApp;
         // std::unique_ptr<RPiCamEncoder> m_CameraEncoder;
@@ -168,6 +169,16 @@ class INDILibCamera : public INDI::CCD
         int m_LiveVideoWidth {-1}, m_LiveVideoHeight {-1};
         uint8_t m_CameraIndex;
         libcamera::ControlList m_ControlList;
+
+        enum class GainConversionMode
+        {
+            DynamicRange,
+            LowNoise
+        };
+
+        bool readGainConversionMode(GainConversionMode &mode) const;
+        bool writeGainConversionMode(GainConversionMode mode);
+        void updateGainConversionUI();
 
         RpiCamProperties getAvailableCamProperties();
 };


### PR DESCRIPTION
## Summary

This PR adds a **Gain Conversion** property to the `indi-libcamera` driver for Sony IMX290-family image sensors.

The property allows switching between:

* **Dynamic Range (LCG)**
* **Low Noise (HCG)**

The driver reads the current gain conversion mode when the camera connects, updates the INDI property accordingly, and writes the selected mode through the existing kernel interface.

## Supported sensors

This feature is intended for Sony IMX290-family sensors, such as:

* IMX290
* IMX327
* IMX462

## Motivation

These sensors support two analog gain conversion modes.

* **LCG (Low Conversion Gain)** provides higher dynamic range.
* **HCG (High Conversion Gain)** provides lower read noise, which is especially useful for astrophotography.

Until now this functionality was not available through the INDI LibCamera driver.

## Notes

The current implementation uses the existing kernel parameter:

`/sys/module/imx290/parameters/hcg_mode`

Writing this parameter requires appropriate system permissions. If writing fails, the driver reports an informative error message.

A future improvement would be exposing Gain Conversion as a standard V4L2/libcamera control, removing the need for direct sysfs access.

## Tested

Tested successfully on:

* Raspberry Pi
* Sony IMX462
* Raspberry Pi `imx290` kernel driver
* INDI Control Panel

Verified:

* Current mode is read correctly on connection.
* Switching between Dynamic Range (LCG) and Low Noise (HCG) updates the kernel parameter.
* The INDI property stays synchronized with the actual hardware state.
