### PR TITLE
Fix CP210x DTR/RTS reset on ESP32 (HBG3 adapter) in indi-celestronaux

### DIFF
--- a/indi-celestronaux/CHANGELOG.md
+++ b/indi-celestronaux/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - indi-celestronaux System Tests
 
+## [2026-07-20 20:15] - Version 1.7.0 - CP210x DTR/RTS Reset Fix
+- **Fixed CP210x microcontroller reset issue** on ESP32-based mounts (HBG3 adapter)
+- Added `configureSerialPort()` method to set `CLOCAL` (no DTR/RTS assert on open), `~HUPCL` (no DTR/RTS drop on close), and conditional `CRTSCTS`
+- **AUX/PC port (19200 baud)**: Hardware flow control (RTS/CTS half-duplex) preserved
+- **HC/USB port (9600 baud)**: No flow control, prevents spurious resets
+- Flags preserved in `tty_set_speed()` during baud rate changes
+- Eliminates hard ESP32 reset on connect/disconnect/reconnect cycles
+
 ## [2026-01-30 11:45] - Test Stabilization & Bug Fixes
 - **Corrected Switch Elements**: Fixed all tests to use correct element names for `TELESCOPE_SLEW_RATE` (`8x` instead of `9`) and `ALIGNMENT_SUBSYSTEM_ACTIVE` (`ALIGNMENT SUBSYSTEM ACTIVE` instead of `On`).
 - **Enhanced 1-Star Precision Test**: Implemented dynamic RA/Dec calculation based on current LST/Horizon position. Increased precision requirement to 60 seconds.

--- a/indi-celestronaux/CMakeLists.txt
+++ b/indi-celestronaux/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
 set(CAUX_VERSION_MAJOR 1)
-set(CAUX_VERSION_MINOR 6)
+set(CAUX_VERSION_MINOR 7)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_celestronaux.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_celestronaux.xml )

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -4051,21 +4051,8 @@ bool CelestronAUX::configureSerialPort(bool useFlowControl)
     else
         tty_setting.c_cflag &= ~CRTSCTS;
 
-    // Ensure 8N1 settings
-    tty_setting.c_cflag &= ~PARENB;
-    tty_setting.c_cflag &= ~CSTOPB;
-    tty_setting.c_cflag &= ~CSIZE;
-    tty_setting.c_cflag |= CS8;
-
-    // Raw mode
-    tty_setting.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-    tty_setting.c_oflag &= ~OPOST;
-    tty_setting.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-    tty_setting.c_cflag |= CREAD | CLOCAL;
-
-    // Read timeout handled by tty_read (VMIN=0, VTIME=10 -> 1 sec)
-    tty_setting.c_cc[VMIN] = 0;
-    tty_setting.c_cc[VTIME] = 10;
+    // Preserve all other settings (baud rate, parity, data bits, VMIN/VTIME, etc.)
+    // set by INDI base class. Only modify the specific flags above.
 
     if (tcsetattr(PortFD, TCSANOW, &tty_setting))
     {

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -126,6 +126,13 @@ bool CelestronAUX::Handshake()
     {
         if (getActiveConnection() == serialConnection)
         {
+            // Configure serial port to prevent CP210x DTR/RTS reset on open
+            // AUX/PC port (19200 baud) uses hardware flow control (RTS/CTS)
+            // HC/USB port (9600 baud) does not use flow control
+            bool useFlowControl = (PortTypeSP[PORT_AUX_PC].getState() == ISS_ON);
+            if (!configureSerialPort(useFlowControl))
+                return false;
+
             if (PortTypeSP[PORT_AUX_PC].getState() == ISS_ON)
             {
                 serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
@@ -4003,9 +4010,66 @@ bool CelestronAUX::tty_set_speed(speed_t speed)
         return false;
     }
 
+    // Preserve port configuration flags (CLOCAL, HUPCL, CRTSCTS) after baud rate change
+    // AUX/PC port (19200 baud) uses hardware flow control, HC/USB port (9600 baud) does not
+    bool useFlowControl = (PortTypeSP[PORT_AUX_PC].getState() == ISS_ON);
+    tty_setting.c_cflag |= CLOCAL;     // Don't assert DTR/RTS on open
+    tty_setting.c_cflag &= ~HUPCL;     // Don't drop DTR/RTS on close
+    if (useFlowControl)
+        tty_setting.c_cflag |= CRTSCTS;  // AUX/PC needs hardware flow control
+    else
+        tty_setting.c_cflag &= ~CRTSCTS; // HC/USB no flow control
+
     if (tcsetattr(PortFD, TCSANOW, &tty_setting))
     {
         LOGF_ERROR("Error setting tty attributes %s(%d).", strerror(errno), errno);
+        return false;
+    }
+return true;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+/// Configure serial port to prevent CP210x DTR/RTS reset on open/close
+/////////////////////////////////////////////////////////////////////////////////////
+bool CelestronAUX::configureSerialPort(bool useFlowControl)
+{
+    struct termios tty_setting;
+
+    if (tcgetattr(PortFD, &tty_setting))
+    {
+        LOGF_ERROR("Error getting tty attributes for port config: %s(%d).", strerror(errno), errno);
+        return false;
+    }
+
+    // Ignore modem control lines - prevents DTR/RTS assertion on open
+    tty_setting.c_cflag |= CLOCAL;
+    // Don't drop DTR/RTS on close
+    tty_setting.c_cflag &= ~HUPCL;
+    // Hardware flow control: AUX/PC port needs it, HC/USB does not
+    if (useFlowControl)
+        tty_setting.c_cflag |= CRTSCTS;
+    else
+        tty_setting.c_cflag &= ~CRTSCTS;
+
+    // Ensure 8N1 settings
+    tty_setting.c_cflag &= ~PARENB;
+    tty_setting.c_cflag &= ~CSTOPB;
+    tty_setting.c_cflag &= ~CSIZE;
+    tty_setting.c_cflag |= CS8;
+
+    // Raw mode
+    tty_setting.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+    tty_setting.c_oflag &= ~OPOST;
+    tty_setting.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+    tty_setting.c_cflag |= CREAD | CLOCAL;
+
+    // Read timeout handled by tty_read (VMIN=0, VTIME=10 -> 1 sec)
+    tty_setting.c_cc[VMIN] = 0;
+    tty_setting.c_cc[VTIME] = 10;
+
+    if (tcsetattr(PortFD, TCSANOW, &tty_setting))
+    {
+        LOGF_ERROR("Error setting tty attributes for port config: %s(%d).", strerror(errno), errno);
         return false;
     }
 
@@ -4014,6 +4078,7 @@ bool CelestronAUX::tty_set_speed(speed_t speed)
 
 /////////////////////////////////////////////////////////////////////////////////////
 ///
+
 /////////////////////////////////////////////////////////////////////////////////////
 void CelestronAUX::hex_dump(char *buf, AUXBuffer data, size_t size)
 {

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -4025,7 +4025,7 @@ bool CelestronAUX::tty_set_speed(speed_t speed)
         LOGF_ERROR("Error setting tty attributes %s(%d).", strerror(errno), errno);
         return false;
     }
-return true;
+    return true;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -389,6 +389,7 @@ class CelestronAUX :
         int aux_tty_read(char *buf, int bufsiz, int timeout, int *n);
         int aux_tty_write (char *buf, int bufsiz, float timeout, int *n);
         bool tty_set_speed(speed_t speed);
+        bool configureSerialPort(bool useFlowControl);
 
         // connection
         bool m_IsRTSCTS {false};


### PR DESCRIPTION

## Summary
Fixes periodic microcontroller reset issue when using Celestron AUX driver with Silicon Labs CP210x USB-UART bridges (e.g., HBG3 adapter) connected to ESP32-based devices.

## Root Cause
The CP210x kernel driver forces DTR/RTS lines LOW (active) on port open. On hardware with auto-reset circuits (DTR→EN, RTS→GPIO0), this causes a hard ESP32 reset on every connection/reconnection.

## Solution
Added  method that sets termios flags immediately after port open:
-  - prevents DTR/RTS assertion on open
-  - prevents DTR/RTS drop on close  
- Conditional  - enabled only for AUX/PC port (19200 baud, RTS/CTS half-duplex), disabled for HC/USB port (9600 baud)

Flags preserved in  during baud rate changes.

## Changes
- : +1 line (method declaration)
- : +73 lines (implementation + Handshake/tty_set_speed integration)

## Testing
- AUX/PC port (19200 baud): RTS/CTS half-duplex preserved
- HC/USB port (9600 baud): No flow control, no reset
- Both modes verified working on HBG3 adapter hardware and HC/serial connection.
