### PR TITLE
indi-asi: Implement gradual warm-up when turning the cooler off

### DIFF
--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -41,6 +41,9 @@
 #define VERBOSE_EXPOSURE        3
 #define TEMP_TIMER_MS           1000 /* Temperature polling time (ms) */
 #define TEMP_THRESHOLD          .25  /* Differential temperature threshold (C)*/
+#define TEMP_AMBIENT_DEFAULT    25.0  /* Default warm-up target on cooler off (C), ASI SDK has no ambient sensor */
+#define WARMUP_STABLE_MS        60000 /* Temperature must be stable this long before warm-up is considered done */
+#define WARMUP_STABLE_DELTA     0.5   /* Maximum temperature change (C) that counts as "stable" */
 
 #define CONTROL_TAB "Controls"
 
@@ -403,6 +406,9 @@ bool ASIBase::initProperties()
     CoolerNP[0].fill("CCD_COOLER_VALUE", "Cooling Power (%)", "%+06.2f", 0., 1., .2, 0.0);
     CoolerNP.fill(getDeviceName(), "CCD_COOLER_POWER", "Cooling Power", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
+    WarmupTargetNP[0].fill("TEMPERATURE", "Temperature (C)", "%.1f", -50., 50., 1., TEMP_AMBIENT_DEFAULT);
+    WarmupTargetNP.fill(getDeviceName(), "CCD_WARMUP_TARGET", "Warm Up Target", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     ControlNP.fill(getDeviceName(), "CCD_CONTROLS",      "Controls", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
     ControlSP.fill(getDeviceName(), "CCD_CONTROLS_MODE", "Set Auto", CONTROL_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
@@ -505,6 +511,8 @@ bool ASIBase::updateProperties()
             loadConfig(true, CoolerNP.getName());
             defineProperty(CoolerSP);
             loadConfig(true, CoolerSP.getName());
+            defineProperty(WarmupTargetNP);
+            loadConfig(true, WarmupTargetNP.getName());
         }
         // Even if there is no cooler, we define temperature property as READ ONLY
         else
@@ -566,6 +574,7 @@ bool ASIBase::updateProperties()
         {
             deleteProperty(CoolerNP);
             deleteProperty(CoolerSP);
+            deleteProperty(WarmupTargetNP);
         }
         else
             deleteProperty(TemperatureNP);
@@ -865,6 +874,19 @@ bool ASIBase::ISNewNumber(const char *dev, const char *name, double values[], ch
             saveConfig(BlinkNP);
             return true;
         }
+
+        if (WarmupTargetNP.isNameMatch(name))
+        {
+            WarmupTargetNP.update(values, names, n);
+            WarmupTargetNP.setState(IPS_OK);
+            WarmupTargetNP.apply();
+            saveConfig(WarmupTargetNP);
+            return true;
+        }
+
+        // An explicit temperature request supersedes any warm-up-on-cooler-off in progress.
+        if (TemperatureNP.isNameMatch(name))
+            cancelCoolerWarmup();
     }
 
     return INDI::CCD::ISNewNumber(dev, name, values, names, n);
@@ -958,7 +980,14 @@ bool ASIBase::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 return true;
             }
 
-            activateCooler(CoolerSP[0].getState() == ISS_ON);
+            if (CoolerSP[0].getState() == ISS_ON)
+            {
+                cancelCoolerWarmup();
+                activateCooler(true);
+                resumeCooling();
+            }
+            else
+                beginCoolerWarmup();
 
             return true;
         }
@@ -1078,11 +1107,13 @@ bool ASIBase::setVideoFormat(uint8_t index)
 int ASIBase::SetTemperature(double temperature)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
-    // #PS: how will it warm up?
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (activateCooler(true) == false)
+    // While warming up towards ambient, keep the TEC engaged without flipping CoolerSP back to ON -
+    // activateCooler() would otherwise re-apply ISS_ON on every ~60s ramp step.
+    bool coolerOk = mCoolerWarmingUp ? setCoolerPower(true) : activateCooler(true);
+    if (!coolerOk)
     {
         LOG_ERROR("Failed to activate cooler.");
         return -1;
@@ -1103,14 +1134,20 @@ int ASIBase::SetTemperature(double temperature)
     return 0;
 }
 
-bool ASIBase::activateCooler(bool enable)
+bool ASIBase::setCoolerPower(bool enable)
 {
     ASI_ERROR_CODE ret = ASISetControlValue(mCameraInfo.CameraID, ASI_COOLER_ON, enable ? ASI_TRUE : ASI_FALSE, ASI_FALSE);
     if (ret != ASI_SUCCESS)
-    {
-        CoolerSP.setState(IPS_ALERT);
         LOGF_ERROR("Failed to activate cooler (%s).", Helpers::toString(ret));
-    }
+
+    return (ret == ASI_SUCCESS);
+}
+
+bool ASIBase::activateCooler(bool enable)
+{
+    bool success = setCoolerPower(enable);
+    if (!success)
+        CoolerSP.setState(IPS_ALERT);
     else
     {
         CoolerSP[0].setState(enable ? ISS_ON  : ISS_OFF);
@@ -1119,7 +1156,142 @@ bool ASIBase::activateCooler(bool enable)
     }
     CoolerSP.apply();
 
-    return (ret == ASI_SUCCESS);
+    return success;
+}
+
+void ASIBase::beginCoolerWarmup()
+{
+    // Gradual warm-up only makes sense when temperature ramping is enabled; otherwise cut power immediately.
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() == 0)
+    {
+        activateCooler(false);
+        return;
+    }
+
+    // Save before we overwrite m_TargetTemperature with the ambient value below.
+    // m_TargetTemperature (base class) holds the user's original cooling setpoint as set via
+    // ISNewNumber; mTargetTemperature (our own member) only holds the last ramp step.
+    mSavedCoolingTarget = m_TargetTemperature;
+
+    double ambientTemperature = WarmupTargetNP[0].getValue();
+    double currentTemperature = TemperatureNP[0].getValue();
+
+    // Already close enough to ambient, just cut power immediately.
+    if (std::abs(ambientTemperature - currentTemperature) <= TemperatureRampNP[RAMP_THRESHOLD].getValue())
+    {
+        activateCooler(false);
+        return;
+    }
+
+    // Reflect the OFF request on the switch right away, but keep it busy until ambient is reached.
+    CoolerSP[0].setState(ISS_OFF);
+    CoolerSP[1].setState(ISS_ON);
+    CoolerSP.setState(IPS_BUSY);
+    CoolerSP.apply();
+
+    mCoolerWarmingUp = true;
+    mWarmupLastTemperature = mCurrentTemperature;
+    mCoolerZeroPowerTimer.start();
+
+    double nextTemperature = (ambientTemperature < currentTemperature)
+                              ? std::max(ambientTemperature, currentTemperature - TemperatureRampNP[RAMP_SLOPE].getValue())
+                              : std::min(ambientTemperature, currentTemperature + TemperatureRampNP[RAMP_SLOPE].getValue());
+
+    int rc = SetTemperature(nextTemperature);
+    if (rc == -1)
+    {
+        LOG_ERROR("Failed to initiate cooler warm-up, turning cooler off immediately.");
+        mCoolerWarmingUp = false;
+        activateCooler(false);
+        return;
+    }
+
+    if (rc == 1)
+    {
+        // SetTemperature() considered us already at the next step, we're effectively at ambient.
+        mCoolerWarmingUp = false;
+        activateCooler(false);
+        return;
+    }
+
+    m_TemperatureElapsedTimer.start();
+    m_TargetTemperature = ambientTemperature;
+    m_TemperatureCheckTimer.start();
+    TemperatureNP.setState(IPS_BUSY);
+    TemperatureNP.apply();
+
+    LOGF_INFO("Cooler is warming up to ambient temperature (%.1f C)...", ambientTemperature);
+}
+
+void ASIBase::cancelCoolerWarmup()
+{
+    if (!mCoolerWarmingUp)
+        return;
+
+    mCoolerWarmingUp = false;
+    m_TemperatureCheckTimer.stop();
+
+    if (TemperatureNP.getState() == IPS_BUSY)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+}
+
+void ASIBase::finishCoolerWarmup(const char *reason)
+{
+    if (!mCoolerWarmingUp)
+        return;
+
+    mCoolerWarmingUp = false;
+    m_TemperatureCheckTimer.stop();
+
+    if (TemperatureNP.getState() == IPS_BUSY)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+
+    activateCooler(false);
+    LOGF_INFO("Cooler is now off, %s.", reason);
+}
+
+void ASIBase::resumeCooling()
+{
+    // Nothing saved yet (cooler activated for the first time, never warmed up before)
+    // or saved target is not actually below the current temperature – nothing to do.
+    if (mSavedCoolingTarget >= TemperatureNP[0].getValue())
+        return;
+
+    double nextTemperature = mSavedCoolingTarget;
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+        nextTemperature = std::max(mSavedCoolingTarget,
+                                   TemperatureNP[0].getValue() - TemperatureRampNP[RAMP_SLOPE].getValue());
+
+    int rc = SetTemperature(nextTemperature);
+    if (rc == 0)
+    {
+        if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+            m_TemperatureElapsedTimer.start();
+        m_TargetTemperature = mSavedCoolingTarget;
+        m_TemperatureCheckTimer.start();
+        TemperatureNP.setState(IPS_BUSY);
+        TemperatureNP.apply();
+        LOGF_INFO("Resuming cooling to %.2f C.", mSavedCoolingTarget);
+    }
+    else if (rc == 1)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+}
+
+void ASIBase::checkTemperatureTarget()
+{
+    INDI::CCD::checkTemperatureTarget();
+
+    if (mCoolerWarmingUp && TemperatureNP.getState() != IPS_BUSY)
+        finishCoolerWarmup("ambient temperature reached");
 }
 
 bool ASIBase::StartExposure(float duration)
@@ -1433,6 +1605,23 @@ void ASIBase::temperatureTimerTimeout()
         {
             CoolerNP[0].setValue(value);
             CoolerNP.setState(value > 0 ? IPS_BUSY : IPS_IDLE);
+
+            // Secondary completion check: ASI TECs are unidirectional — they cannot heat,
+            // so power stays at 0% for the entire warm-up ramp regardless of progress.
+            // A sustained 0% therefore tells us nothing useful during warm-up.
+            // Instead check temperature stability: once the reading stops changing the camera
+            // has reached thermal equilibrium with its environment (which may be below the
+            // configured warm-up target if room temperature is cooler than 25 °C).
+            if (mCoolerWarmingUp)
+            {
+                if (std::abs(mCurrentTemperature - mWarmupLastTemperature) > WARMUP_STABLE_DELTA)
+                {
+                    mWarmupLastTemperature = mCurrentTemperature;
+                    mCoolerZeroPowerTimer.start();
+                }
+                else if (mCoolerZeroPowerTimer.hasExpired(WARMUP_STABLE_MS))
+                    finishCoolerWarmup("temperature has stabilized");
+            }
         }
         CoolerNP.apply();
     }
@@ -1702,7 +1891,10 @@ bool ASIBase::saveConfigItems(FILE *fp)
     INDI::CCD::saveConfigItems(fp);
 
     if (HasCooler())
+    {
         CoolerSP.save(fp);
+        WarmupTargetNP.save(fp);
+    }
 
     if (!ControlNP.isEmpty())
         ControlNP.save(fp);

--- a/indi-asi/asi_base.h
+++ b/indi-asi/asi_base.h
@@ -34,6 +34,7 @@
 
 #include <indiccd.h>
 #include <inditimer.h>
+#include <indielapsedtimer.h>
 
 class SingleWorker;
 class ASIBase : public INDI::CCD
@@ -57,6 +58,8 @@ class ASIBase : public INDI::CCD
         virtual bool AbortExposure() override;
 
     protected:
+
+        virtual void checkTemperatureTarget() override;
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
@@ -99,6 +102,10 @@ class ASIBase : public INDI::CCD
     protected:
         double mTargetTemperature;
         double mCurrentTemperature;
+        bool mCoolerWarmingUp {false};
+        double mWarmupLastTemperature {0};
+        double mSavedCoolingTarget {100.0}; // sentinel: no valid target saved yet
+        INDI::ElapsedTimer mCoolerZeroPowerTimer; // measures how long temperature has been stable
         INDI::Timer mTimerTemperature;
         void temperatureTimerTimeout();
 
@@ -124,8 +131,23 @@ class ASIBase : public INDI::CCD
         /** Update SER recorder video format */
         void updateRecorderFormat();
 
-        /** Control cooler */
+        /** Control cooler, updates CoolerSP switch/state */
         bool activateCooler(bool enable);
+
+        /** Raw TEC power toggle, does not touch CoolerSP so callers can control the switch presentation */
+        bool setCoolerPower(bool enable);
+
+        /** Ramp temperature toward ambient, keeping the Cooler switch busy, then switch the cooler off */
+        void beginCoolerWarmup();
+
+        /** Cancel an in-progress cooler warm-up, e.g. because the cooler was switched back on */
+        void cancelCoolerWarmup();
+
+        /** Finish an in-progress cooler warm-up by switching the cooler off for good */
+        void finishCoolerWarmup(const char *reason);
+
+        /** After re-enabling the cooler, ramp back to the previously saved target temperature */
+        void resumeCooling();
 
         /** Set Video Format */
         bool setVideoFormat(uint8_t index);
@@ -142,6 +164,7 @@ class ASIBase : public INDI::CCD
         /** Additional Properties to INDI::CCD */
         INDI::PropertyNumber  CoolerNP {1};
         INDI::PropertySwitch  CoolerSP {2};
+        INDI::PropertyNumber  WarmupTargetNP {1};
 
         INDI::PropertyNumber  ControlNP {0};
         INDI::PropertySwitch  ControlSP {0};


### PR DESCRIPTION
Previously, switching the Cooler OFF immediately cut TEC power and set CoolerSP to IPS_IDLE, bypassing the temperature-ramp machinery entirely. This could cause thermal shock on sensors that were significantly below ambient temperature.

This commit introduces a full warm-up state machine that mirrors the existing cooling ramp (driven by TemperatureRampNP RAMP_SLOPE / RAMP_THRESHOLD in the INDI::CCD base class) and keeps the Cooler switch in IPS_BUSY until the camera has safely returned to near-ambient temperature.

New behaviour
─────────────
• Cooler OFF with RAMP_SLOPE = 0 (ramping disabled): unchanged, TEC
  cuts immediately.
• Cooler OFF with RAMP_SLOPE > 0: begins a gradual warm-up toward the
  configurable "Warm Up Target" temperature (CCD_WARMUP_TARGET, default
  25 °C, persisted in the driver config).  CoolerSP stays IPS_BUSY
  (switch shows OFF) until complete.
• Warm-up completion is detected by two independent criteria, whichever
  fires first:
    1. Temperature reading reaches within RAMP_THRESHOLD of the warm-up target — handled by the existing INDI::CCD::checkTemperatureTarget() override.
    2. Temperature has been stable (changed less than 0.5 °C) for 60 s — catches the case where the actual room temperature is below the configured warm-up target, so the camera equilibrates below 25 °C and would otherwise never cross the threshold. • Cooler ON during an active warm-up: cancels the warm-up immediately
  and resumes cooling toward the previously set target temperature,
  respecting the ramp slope.
• An explicit temperature request (TemperatureNP) while warming up also
  cancels the warm-up and hands control back to the standard ramp path.

Key implementation details
──────────────────────────
• Split activateCooler() into setCoolerPower() (raw TEC toggle, no UI
  update) and activateCooler() (TEC toggle + CoolerSP state update).
  SetTemperature() calls setCoolerPower() during warm-up so that the
  ~60 s ramp steps driven by m_TemperatureCheckTimer do not flip
  CoolerSP back to ISS_ON/IPS_BUSY on every iteration.
• mSavedCoolingTarget captures m_TargetTemperature (the base-class
  member set by ISNewNumber, holding the user's final cooling setpoint)
  at the start of beginCoolerWarmup(), before it is overwritten with the
  warm-up target.  mTargetTemperature (ASIBase's own member) was
  intentionally not used here because it only tracks the last ramp step,
  not the user's original request.
• ASI TECs are unidirectional (cooling only); TEC power reads 0 % for
  the entire warm-up ramp, so a raw "power idle" check is not a useful
  completion signal.  The stability-based secondary check avoids this
  pitfall.

New property
────────────
CCD_WARMUP_TARGET ("Warm Up Target") — configurable warm-up target temperature in °C, shown in the main control tab for cooled cameras. Saved to and restored from the driver configuration file.