### PR TITLE
fix(test): use correct property name in firmware test

### DIFF
--- a/indi-celestronaux/tests/system/TEST_DESCRIPTION.md
+++ b/indi-celestronaux/tests/system/TEST_DESCRIPTION.md
@@ -8,7 +8,7 @@ Focus on low-level communication, driver stability, and raw motor control.
 ### `test_firmware_info`
 *   **Purpose:** Verifies that the driver correctly retrieves firmware versions from the AUX bus components.
 *   **Procedure:** Connects to the mount and checks the `Firmware Info` property.
-*   **Verification:** Confirms that `Ra/AZM version` starts with "7" (the version reported by `caux-sim`). It ignores the Mother Board version as it is often reported as `Unknown` in production.
+*   **Verification:** Confirms that `AZM` version starts with "7" (the version reported by `caux-sim`). It ignores the Mother Board version as it is often reported as `Unknown` in production.
 
 ### `test_manual_motion`
 *   **Purpose:** Validates the NSWE direction button logic and raw slewing.

--- a/indi-celestronaux/tests/system/test_basic.py
+++ b/indi-celestronaux/tests/system/test_basic.py
@@ -12,7 +12,7 @@ def test_firmware_info(indiserver_process):
             prop = await client.wait_for_condition(
                 DEVICE_NAME,
                 "Firmware Info",
-                lambda p: p["values"].get("Ra/AZM version", "").startswith("7"),
+                lambda p: p["values"].get("AZM", "").startswith("7"),
                 timeout=15,
             )
             assert prop is not None


### PR DESCRIPTION
The test was using the property label 'Ra/AZM version' instead of the property name 'AZM' to look up firmware version in the config.

INDI properties are keyed by name, not label. The Firmware Info property defines the AZM text field with name='AZM' and label='Ra/AZM version'.