### PR TITLE
CAUX: fix non-persistant cord wrap settings across driver restarts

### DIFF
--- a/debian/indi-celestronaux/changelog
+++ b/debian/indi-celestronaux/changelog
@@ -1,3 +1,14 @@
+indi-celestronaux (1.8) trixie; urgency=medium
+
+  * Fix non-persistent cord wrap settings across driver restarts
+  * Persist cord wrap toggle, position, and base mode to INDI config
+  * Fix hardcoded 270° in startupWithoutHC() with priority lookup
+    Mount -> Config -> North default
+  * Add error handling for cord wrap mount queries with config fallback
+  * Add 7 comprehensive cord wrap persistence tests
+
+ -- Paweł T. Jochym <jochym@gmail.com>  Wed, 22 Jul 2026 22:00:00 +0200
+
 indi-celestronaux (1.6) jammy; urgency=medium
 
   * Add comprehensive battery telemetry support for Evolution mounts

--- a/indi-celestronaux/CMakeLists.txt
+++ b/indi-celestronaux/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
 set(CAUX_VERSION_MAJOR 1)
-set(CAUX_VERSION_MINOR 7)
+set(CAUX_VERSION_MINOR 8)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_celestronaux.xml.cmake ${CMAKE_CURRENT_BINARY_DIR}/indi_celestronaux.xml )

--- a/indi-celestronaux/TEST_PLAN.md
+++ b/indi-celestronaux/TEST_PLAN.md
@@ -38,3 +38,11 @@ This plan outlines the step-by-step development of the system test suite for the
 - [x] **Long-duration Tracking:** Observed background tracking loop in simulator (Issue 14).
 - [ ] **Predictive Tracking (2nd Order):** Verify period guide rate updates in response to drift.
 - [x] **Reconnection:** Verified recovery from lost connection.
+
+## Phase 6: Cord Wrap Persistence
+- [x] **Toggle Persistence:** Enable/disable cord wrap persists across save.
+- [x] **Position Persistence:** Set position (NE/E/SE/S/SW/W/NW/N) persists across save.
+- [x] **Base Mode Persistence:** Encoder vs Sky/Alignment mode persists across save.
+- [x] **Full Config Persistence:** All cord wrap properties save together correctly.
+- [x] **Position Cycling:** All 8 positions can be set and verified in config.
+- [x] **Disable Preserves Position:** Disabling cord wrap doesn't change saved position.

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -599,20 +599,28 @@ bool CelestronAUX::updateProperties()
         // Cord wrap Enabled?
         if (m_MountType == ALT_AZ)
         {
+            defineProperty(CordWrapToggleSP);
+            defineProperty(CordWrapPositionSP);
+            defineProperty(CordWrapBaseSP);
+
+            // Load saved config as baseline for reliable restore on reconnect
+            loadConfig(true, CordWrapToggleSP.getName());
+            loadConfig(true, CordWrapPositionSP.getName());
+            loadConfig(true, CordWrapBaseSP.getName());
+
+            // Try to read from mount - override config if successful
             bool enabled = false;
             if (getCordWrapEnabled(enabled))
             {
                 CordWrapToggleSP[INDI_ENABLED].s   = enabled ? ISS_ON : ISS_OFF;
                 CordWrapToggleSP[INDI_DISABLED].s  = enabled ? ISS_OFF : ISS_ON;
+                LOGF_INFO("Cord Wrap is %s.", enabled ? "enabled" : "disabled");
             }
             else
             {
-                // Query failed - keep loaded config values (already set by loadConfig)
                 LOG_INFO("Using saved cord wrap config (mount query failed)");
             }
-            defineProperty(CordWrapToggleSP);
 
-            // Cord wrap Position?
             uint32_t position = 0;
             if (getCordWrapPosition(position))
             {
@@ -625,10 +633,13 @@ bool CelestronAUX::updateProperties()
             else
             {
                 LOG_INFO("Using saved cord wrap position config (mount query failed)");
-                // Config already loaded - properties already have correct values
             }
-            defineProperty(CordWrapPositionSP);
-            defineProperty(CordWrapBaseSP);
+
+            // Sync member variables from property state
+            m_CordWrapActive = CordWrapToggleSP[INDI_ENABLED].s == ISS_ON;
+            int onIdx = CordWrapPositionSP.findOnSwitchIndex();
+            if (onIdx >= 0)
+                m_RequestedCordwrapPos = onIdx * 45;
         }
 
         // Slew limits
@@ -2925,7 +2936,31 @@ bool CelestronAUX::startupWithoutHC()
             return false;
     }
 
-    data[0] = 0xc0;
+    // Set cord wrap position: Mount → Config → Default (North)
+    uint32_t cordWrapPos = 0;
+    if (getCordWrapPosition(cordWrapPos))
+    {
+        LOGF_INFO("startupWithoutHC: using mount cord wrap position %.0f°",
+                  cordWrapPos / STEPS_PER_DEGREE);
+    }
+    else
+    {
+        int configPosIdx = 0;
+        if (IUGetConfigOnSwitchIndex(getDeviceName(), CordWrapPositionSP.getName(), &configPosIdx) == 0)
+        {
+            cordWrapPos = static_cast<uint32_t>(configPosIdx * 45.0 * STEPS_PER_DEGREE);
+            LOGF_INFO("startupWithoutHC: using config cord wrap position %.0f°", configPosIdx * 45.0);
+        }
+        else
+        {
+            LOG_INFO("startupWithoutHC: using default cord wrap position 0° (North)");
+        }
+    }
+
+    data[0] = static_cast<uint8_t>((cordWrapPos >> 16) & 0xFF);
+    data[1] = static_cast<uint8_t>((cordWrapPos >> 8) & 0xFF);
+    data[2] = static_cast<uint8_t>(cordWrapPos & 0xFF);
+
     for (int i = 0; i < 2; i++)
     {
         command = AUXCommand(MC_SET_CORDWRAP_POS, APP, i == AXIS_AZ ? AZM : ALT, data);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -617,6 +617,7 @@ bool CelestronAUX::updateProperties()
             if (getCordWrapPosition(position))
             {
                 double cordWrapAngle = range360(position / STEPS_PER_DEGREE);
+                LOGF_INFO("Cord Wrap position angle %.2f", cordWrapAngle);
                 const int idx = static_cast<int>(std::floor(cordWrapAngle / 45)) % 8;
                 for (int i = 0; i < 8; ++i)
                     CordWrapPositionSP[i].s = (i == idx) ? ISS_ON : ISS_OFF;
@@ -1101,7 +1102,13 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
             }
 
             bool enabled = false;
-            getCordWrapEnabled(enabled);
+            if (!getCordWrapEnabled(enabled))
+            {
+                CordWrapToggleSP.setState(IPS_ALERT);
+                CordWrapToggleSP.apply();
+                return true;
+            }
+            LOGF_INFO("Cord Wrap is %s.", enabled ? "enabled" : "disabled");
             CordWrapToggleSP.setState(IPS_OK);
             CordWrapToggleSP.apply();
             saveConfig(CordWrapToggleSP);
@@ -1147,7 +1154,12 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
                     break;
             }
 
-            writeCordWrapToMount();
+            if (!writeCordWrapToMount())
+            {
+                CordWrapPositionSP.setState(IPS_ALERT);
+                CordWrapPositionSP.apply();
+                return true;
+            }
             saveConfig(CordWrapPositionSP);
             return true;
         }
@@ -1181,7 +1193,12 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
         {
             CordWrapBaseSP.update(states, names, n);
             // Write current position to mount using new mode convention
-            writeCordWrapToMount();
+            if (!writeCordWrapToMount())
+            {
+                CordWrapBaseSP.setState(IPS_ALERT);
+                CordWrapBaseSP.apply();
+                return true;
+            }
             CordWrapBaseSP.setState(IPS_OK);
             CordWrapBaseSP.apply();
             saveConfig(CordWrapBaseSP);

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -260,6 +260,18 @@ void CelestronAUX::ISGetProperties(const char *dev)
 {
     INDI::Telescope::ISGetProperties(dev);
     defineProperty(PortTypeSP);
+
+    // Load saved cord-wrap configuration before connection
+    loadConfig(true, CordWrapToggleSP.getName());
+    loadConfig(true, CordWrapPositionSP.getName());
+    loadConfig(true, CordWrapBaseSP.getName());
+
+    // Restore m_RequestedCordwrapPos from saved config
+    int configPosIdx = 0;
+    if (IUGetConfigOnSwitchIndex(getDeviceName(), CordWrapPositionSP.getName(), &configPosIdx) == 0)
+        m_RequestedCordwrapPos = configPosIdx * 45;
+    else
+        m_RequestedCordwrapPos = 0;  // Default to North
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -338,7 +350,7 @@ bool CelestronAUX::initProperties()
 
     // Cord Wrap Position
     CordWrapPositionSP[CORDWRAP_N].fill("CORDWRAP_N", "North", ISS_ON);
-    CordWrapPositionSP[CORDWRAP_NE].fill("CORDWRAP_NE", "North-East", ISS_ON);
+    CordWrapPositionSP[CORDWRAP_NE].fill("CORDWRAP_NE", "North-East", ISS_OFF);
     CordWrapPositionSP[CORDWRAP_E].fill("CORDWRAP_E", "East",  ISS_OFF);
     CordWrapPositionSP[CORDWRAP_SE].fill("CORDWRAP_SE", "South-East",  ISS_OFF);
     CordWrapPositionSP[CORDWRAP_S].fill("CORDWRAP_S", "South", ISS_OFF);
@@ -587,16 +599,32 @@ bool CelestronAUX::updateProperties()
         // Cord wrap Enabled?
         if (m_MountType == ALT_AZ)
         {
-            getCordWrapEnabled();
-            CordWrapToggleSP[INDI_ENABLED].s   = m_CordWrapActive ? ISS_ON : ISS_OFF;
-            CordWrapToggleSP[INDI_DISABLED].s  = m_CordWrapActive ? ISS_OFF : ISS_ON;
+            bool enabled = false;
+            if (getCordWrapEnabled(enabled))
+            {
+                CordWrapToggleSP[INDI_ENABLED].s   = enabled ? ISS_ON : ISS_OFF;
+                CordWrapToggleSP[INDI_DISABLED].s  = enabled ? ISS_OFF : ISS_ON;
+            }
+            else
+            {
+                // Query failed - keep loaded config values (already set by loadConfig)
+                LOG_INFO("Using saved cord wrap config (mount query failed)");
+            }
             defineProperty(CordWrapToggleSP);
 
             // Cord wrap Position?
-            getCordWrapPosition();
-            double cordWrapAngle = range360(m_CordWrapPosition / STEPS_PER_DEGREE);
-            LOGF_INFO("Cord Wrap position angle %.2f", cordWrapAngle);
-            CordWrapPositionSP[static_cast<int>(std::floor(cordWrapAngle / 45))].s = ISS_ON;
+            uint32_t position = 0;
+            if (getCordWrapPosition(position))
+            {
+                double cordWrapAngle = range360(position / STEPS_PER_DEGREE);
+                LOGF_INFO("Cord Wrap position angle %.2f", cordWrapAngle);
+                CordWrapPositionSP[static_cast<int>(std::floor(cordWrapAngle / 45))].s = ISS_ON;
+            }
+            else
+            {
+                LOG_INFO("Using saved cord wrap position config (mount query failed)");
+                // Config already loaded - properties already have correct values
+            }
             defineProperty(CordWrapPositionSP);
             defineProperty(CordWrapBaseSP);
         }
@@ -1043,10 +1071,39 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
             CordWrapToggleSP.update(states, names, n);
             const bool toEnable = CordWrapToggleSP[INDI_ENABLED].s == ISS_ON;
             LOGF_INFO("Cord Wrap is %s.", toEnable ? "enabled" : "disabled");
-            setCordWrapEnabled(toEnable);
-            getCordWrapEnabled();
+
+            if (toEnable)
+            {
+                // Enable and write current position
+                if (!setCordWrapEnabled(true))
+                {
+                    CordWrapToggleSP.setState(IPS_ALERT);
+                    CordWrapToggleSP.apply();
+                    return true;
+                }
+                if (!writeCordWrapToMount())
+                {
+                    CordWrapToggleSP.setState(IPS_ALERT);
+                    CordWrapToggleSP.apply();
+                    return true;
+                }
+            }
+            else
+            {
+                // Disable only - don't touch position
+                if (!setCordWrapEnabled(false))
+                {
+                    CordWrapToggleSP.setState(IPS_ALERT);
+                    CordWrapToggleSP.apply();
+                    return true;
+                }
+            }
+
+            bool enabled = false;
+            getCordWrapEnabled(enabled);
             CordWrapToggleSP.setState(IPS_OK);
             CordWrapToggleSP.apply();
+            saveConfig(CordWrapToggleSP);
 
             return true;
         }
@@ -1089,7 +1146,8 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
                     break;
             }
 
-            syncCoordWrapPosition();
+            writeCordWrapToMount();
+            saveConfig(CordWrapPositionSP);
             return true;
         }
 
@@ -1121,8 +1179,11 @@ bool CelestronAUX::ISNewSwitch(const char *dev, const char *name, ISState *state
         if (CordWrapBaseSP.isNameMatch(name))
         {
             CordWrapBaseSP.update(states, names, n);
+            // Write current position to mount using new mode convention
+            writeCordWrapToMount();
             CordWrapBaseSP.setState(IPS_OK);
             CordWrapBaseSP.apply();
+            saveConfig(CordWrapBaseSP);
             return true;
         }
 
@@ -1345,19 +1406,95 @@ double CelestronAUX::getNorthAz()
 /////////////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////////////
+bool CelestronAUX::readCordWrapFromMount()
+{
+    if (m_MountType != ALT_AZ)
+        return true;
+
+    bool enabled = false;
+    uint32_t position = 0;
+    bool ok = true;
+
+    if (!getCordWrapEnabled(enabled))
+    {
+        LOG_WARN("Failed to read cord wrap enabled status from mount");
+        ok = false;
+    }
+    if (!getCordWrapPosition(position))
+    {
+        LOG_WARN("Failed to read cord wrap position from mount");
+        ok = false;
+    }
+
+    if (ok)
+    {
+        m_CordWrapActive = enabled;
+        m_CordWrapPosition = position;
+
+        // Update INDI properties to match mount
+        CordWrapToggleSP[INDI_ENABLED].s   = enabled ? ISS_ON : ISS_OFF;
+        CordWrapToggleSP[INDI_DISABLED].s  = enabled ? ISS_OFF : ISS_ON;
+
+        double angle = range360(position / STEPS_PER_DEGREE);
+        int idx = static_cast<int>(std::floor(angle / 45)) % 8;
+        for (int i = 0; i < 8; ++i)
+            CordWrapPositionSP[i].s = (i == idx) ? ISS_ON : ISS_OFF;
+    }
+    return ok;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
+bool CelestronAUX::writeCordWrapToMount()
+{
+    if (m_MountType != ALT_AZ)
+        return true;
+
+    uint32_t encoderPos = 0;
+
+    if (CordWrapBaseSP[CW_BASE_SKY].s == ISS_ON)
+    {
+        // Sky mode: m_RequestedCordwrapPos is sky-relative (degrees from alignment north)
+        encoderPos = static_cast<uint32_t>(range360(m_RequestedCordwrapPos + getNorthAz()) * STEPS_PER_DEGREE);
+    }
+    else
+    {
+        // Encoder mode: m_RequestedCordwrapPos is encoder-relative (degrees from mount base)
+        encoderPos = static_cast<uint32_t>(range360(m_RequestedCordwrapPos) * STEPS_PER_DEGREE);
+    }
+
+    if (!setCordWrapPosition(encoderPos))
+    {
+        LOG_ERROR("Failed to write cord wrap position to mount");
+        return false;
+    }
+
+    // Read back to verify
+    uint32_t actualPos = 0;
+    if (!getCordWrapPosition(actualPos))
+    {
+        LOG_WARN("Failed to verify cord wrap position after write");
+        return false;
+    }
+
+    m_CordWrapPosition = actualPos;
+    return true;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////
 void CelestronAUX::syncCoordWrapPosition()
 {
     // No coord wrap for equatorial mounts.
     if (m_MountType != ALT_AZ)
         return;
 
-    uint32_t coordWrapPosition = 0;
-    if (CordWrapBaseSP[CW_BASE_SKY].s == ISS_ON)
-        coordWrapPosition = range360(m_RequestedCordwrapPos + getNorthAz()) * STEPS_PER_DEGREE;
+    if (isCordWrapSkyMode())
+        writeCordWrapToMount();
     else
-        coordWrapPosition = range360(m_RequestedCordwrapPos) * STEPS_PER_DEGREE;
-    setCordWrapPosition(coordWrapPosition);
-    getCordWrapPosition();
+        readCordWrapFromMount();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -2948,12 +3085,16 @@ bool CelestronAUX::setCordWrapEnabled(bool enable)
     return true;
 };
 
-bool CelestronAUX::getCordWrapEnabled()
+bool CelestronAUX::getCordWrapEnabled(bool &enabled)
 {
     AUXCommand command(MC_POLL_CORDWRAP, APP, AZM);
-    sendAUXCommand(command);
-    readAUXResponse(command);
-    return m_CordWrapActive;
+    if (!sendAUXCommand(command) || !readAUXResponse(command))
+    {
+        LOG_DEBUG("getCordWrapEnabled: communication failed");
+        return false;
+    }
+    enabled = m_CordWrapActive;
+    return true;
 };
 
 
@@ -2972,12 +3113,16 @@ bool CelestronAUX::setCordWrapPosition(uint32_t steps)
 /////////////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////////////
-uint32_t CelestronAUX::getCordWrapPosition()
+bool CelestronAUX::getCordWrapPosition(uint32_t &position)
 {
     AUXCommand command(MC_GET_CORDWRAP_POS, APP, AZM);
-    sendAUXCommand(command);
-    readAUXResponse(command);
-    return m_CordWrapPosition;
+    if (!sendAUXCommand(command) || !readAUXResponse(command))
+    {
+        LOG_DEBUG("getCordWrapPosition: communication failed");
+        return false;
+    }
+    position = m_CordWrapPosition;
+    return true;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/indi-celestronaux/celestronaux.cpp
+++ b/indi-celestronaux/celestronaux.cpp
@@ -617,8 +617,9 @@ bool CelestronAUX::updateProperties()
             if (getCordWrapPosition(position))
             {
                 double cordWrapAngle = range360(position / STEPS_PER_DEGREE);
-                LOGF_INFO("Cord Wrap position angle %.2f", cordWrapAngle);
-                CordWrapPositionSP[static_cast<int>(std::floor(cordWrapAngle / 45))].s = ISS_ON;
+                const int idx = static_cast<int>(std::floor(cordWrapAngle / 45)) % 8;
+                for (int i = 0; i < 8; ++i)
+                    CordWrapPositionSP[i].s = (i == idx) ? ISS_ON : ISS_OFF;
             }
             else
             {

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -127,6 +127,9 @@ class CelestronAUX :
 
         // Public to enable setting from ISSnoop
         void syncCoordWrapPosition();
+        bool readCordWrapFromMount();
+        bool writeCordWrapToMount();
+        bool isCordWrapSkyMode() const { return CordWrapBaseSP[CW_BASE_SKY].s == ISS_ON; }
 
     protected:
         virtual void ISGetProperties(const char *dev) override;
@@ -237,9 +240,9 @@ class CelestronAUX :
         /// Coord Wrap
         /////////////////////////////////////////////////////////////////////////////////////
         bool setCordWrapEnabled(bool enable);
-        bool getCordWrapEnabled();
+        bool getCordWrapEnabled(bool &enabled);
         bool setCordWrapPosition(uint32_t steps);
-        uint32_t getCordWrapPosition();
+        bool getCordWrapPosition(uint32_t &position);
 
         /////////////////////////////////////////////////////////////////////////////////////
         /// Focus

--- a/indi-celestronaux/celestronaux.h
+++ b/indi-celestronaux/celestronaux.h
@@ -363,7 +363,7 @@ class CelestronAUX :
         // Coord Wrap
         bool m_CordWrapActive {false};
         int32_t m_CordWrapPosition {0};
-        uint32_t m_RequestedCordwrapPos;
+        uint32_t m_RequestedCordwrapPos {0};
 
         // Focus
         bool m_FocusEnabled {false};

--- a/indi-celestronaux/simulator/nse_simulator.py
+++ b/indi-celestronaux/simulator/nse_simulator.py
@@ -257,7 +257,7 @@ def main(stdscr):
     #loop.run_until_complete(asyncio.wait([broadcast(), timer(0.2), scope]))
     loop.close()
 
-if len(sys.argv) > 1 and sys.argv[1] == 't':
+if len(sys.argv) > 1 and sys.argv[1] in ('t', '-t'):
     main(None)
 else:
     curses.wrapper(main)

--- a/indi-celestronaux/simulator/nse_simulator.py
+++ b/indi-celestronaux/simulator/nse_simulator.py
@@ -257,4 +257,7 @@ def main(stdscr):
     #loop.run_until_complete(asyncio.wait([broadcast(), timer(0.2), scope]))
     loop.close()
 
-curses.wrapper(main)
+if len(sys.argv) > 1 and sys.argv[1] == 't':
+    main(None)
+else:
+    curses.wrapper(main)

--- a/indi-celestronaux/tests/system/conftest.py
+++ b/indi-celestronaux/tests/system/conftest.py
@@ -3,6 +3,7 @@ import asyncio
 import subprocess
 import time
 import os
+import shutil
 import socket
 import sys
 from .indi_client import INDIClient
@@ -31,6 +32,27 @@ def is_port_open(port):
     """Check if a local port is already in use."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0
+
+
+CONFIG_PATH = os.path.expanduser("~/.indi/Celestron AUX_config.xml")
+
+
+@pytest.fixture(autouse=True)
+def backup_config():
+    """Backup and restore INDI config file around each test."""
+    backup_path = CONFIG_PATH + ".test_backup"
+    has_backup = False
+
+    if os.path.exists(CONFIG_PATH):
+        shutil.copy2(CONFIG_PATH, backup_path)
+        has_backup = True
+
+    yield
+
+    if has_backup and os.path.exists(backup_path):
+        shutil.move(backup_path, CONFIG_PATH)
+    elif not has_backup and os.path.exists(CONFIG_PATH):
+        os.remove(CONFIG_PATH)
 
 
 @pytest.fixture(scope="session")

--- a/indi-celestronaux/tests/system/test_cordwrap.py
+++ b/indi-celestronaux/tests/system/test_cordwrap.py
@@ -1,0 +1,239 @@
+import pytest
+import asyncio
+import os
+import xml.etree.ElementTree as ET
+from .conftest import DEVICE_NAME, driver_client_context
+
+
+def get_config_value(property_name, switch_name=None):
+    """Read a property value from the config file."""
+    config_path = os.path.expanduser("~/.indi/Celestron AUX_config.xml")
+    if not os.path.exists(config_path):
+        return None
+
+    tree = ET.parse(config_path)
+    root = tree.getroot()
+
+    for elem in root:
+        if elem.get("name") == property_name:
+            if switch_name:
+                for sw in elem:
+                    if sw.get("name") == switch_name:
+                        return sw.text.strip() if sw.text else None
+            else:
+                values = {}
+                for sw in elem:
+                    values[sw.get("name")] = sw.text.strip() if sw.text else None
+                return values
+    return None
+
+
+def test_cordwrap_toggle_persistence(indiserver_process):
+    """Enable cord wrap and verify it persists after save."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # Enable cord wrap
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_ENABLED"])
+            await asyncio.sleep(1)
+
+            # Verify it's enabled
+            prop = client.get_property(DEVICE_NAME, "CORDWRAP")
+            assert prop["values"].get("INDI_ENABLED") == "On"
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(2)
+
+            # Verify config file has the correct value
+            enabled = get_config_value("CORDWRAP", "INDI_ENABLED")
+            assert enabled == "On", f"Config file shows CORDWRAP INDI_ENABLED={enabled}, expected On"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_toggle_disable_persistence(indiserver_process):
+    """Disable cord wrap and verify it persists after save."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # First enable, then disable
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_ENABLED"])
+            await asyncio.sleep(1)
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_DISABLED"])
+            await asyncio.sleep(1)
+
+            # Verify it's disabled
+            prop = client.get_property(DEVICE_NAME, "CORDWRAP")
+            assert prop["values"].get("INDI_DISABLED") == "On"
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(2)
+
+            # Verify config file
+            disabled = get_config_value("CORDWRAP", "INDI_DISABLED")
+            assert disabled == "On", f"Config file shows CORDWRAP INDI_DISABLED={disabled}, expected On"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_position_persistence(indiserver_process):
+    """Set cord wrap position to SE and verify it persists after save."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # Set position to SE
+            await client.set_switch(DEVICE_NAME, "CORDWRAP_POS", ["CORDWRAP_SE"])
+            await asyncio.sleep(1)
+
+            # Verify it's set
+            prop = client.get_property(DEVICE_NAME, "CORDWRAP_POS")
+            assert prop["values"].get("CORDWRAP_SE") == "On"
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(2)
+
+            # Verify config file
+            se_on = get_config_value("CORDWRAP_POS", "CORDWRAP_SE")
+            n_off = get_config_value("CORDWRAP_POS", "CORDWRAP_N")
+            assert se_on == "On", f"Config file shows CORDWRAP_SE={se_on}, expected On"
+            assert n_off == "Off", f"Config file shows CORDWRAP_N={n_off}, expected Off"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_base_persistence(indiserver_process):
+    """Set cord wrap base to Sky/Alignment and verify it persists after save."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # Set base to Sky/Alignment
+            await client.set_switch(DEVICE_NAME, "CW_BASE", ["CW_BASE_SKY"])
+            await asyncio.sleep(1)
+
+            # Verify it's set
+            prop = client.get_property(DEVICE_NAME, "CW_BASE")
+            assert prop["values"].get("CW_BASE_SKY") == "On"
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(2)
+
+            # Verify config file
+            sky_on = get_config_value("CW_BASE", "CW_BASE_SKY")
+            enc_off = get_config_value("CW_BASE", "CW_BASE_ENC")
+            assert sky_on == "On", f"Config file shows CW_BASE_SKY={sky_on}, expected On"
+            assert enc_off == "Off", f"Config file shows CW_BASE_ENC={enc_off}, expected Off"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_full_config_persistence(indiserver_process):
+    """Set all cord wrap properties and verify they persist together after save."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # Set all cord wrap properties
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_ENABLED"])
+            await asyncio.sleep(0.5)
+            await client.set_switch(DEVICE_NAME, "CORDWRAP_POS", ["CORDWRAP_SE"])
+            await asyncio.sleep(0.5)
+            await client.set_switch(DEVICE_NAME, "CW_BASE", ["CW_BASE_SKY"])
+            await asyncio.sleep(1)
+
+            # Verify all properties
+            toggle = client.get_property(DEVICE_NAME, "CORDWRAP")
+            pos = client.get_property(DEVICE_NAME, "CORDWRAP_POS")
+            base = client.get_property(DEVICE_NAME, "CW_BASE")
+
+            assert toggle["values"].get("INDI_ENABLED") == "On"
+            assert pos["values"].get("CORDWRAP_SE") == "On"
+            assert base["values"].get("CW_BASE_SKY") == "On"
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(2)
+
+            # Verify config file has all values
+            assert get_config_value("CORDWRAP", "INDI_ENABLED") == "On"
+            assert get_config_value("CORDWRAP_POS", "CORDWRAP_SE") == "On"
+            assert get_config_value("CORDWRAP_POS", "CORDWRAP_N") == "Off"
+            assert get_config_value("CW_BASE", "CW_BASE_SKY") == "On"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_position_multiple(indiserver_process):
+    """Test setting different positions and verify each persists."""
+
+    positions = [
+        ("CORDWRAP_NE", "CORDWRAP_N"),
+        ("CORDWRAP_E", "CORDWRAP_NE"),
+        ("CORDWRAP_S", "CORDWRAP_E"),
+        ("CORDWRAP_SW", "CORDWRAP_S"),
+        ("CORDWRAP_W", "CORDWRAP_SW"),
+        ("CORDWRAP_NW", "CORDWRAP_W"),
+        ("CORDWRAP_N", "CORDWRAP_NW"),
+    ]
+
+    async def run():
+        async with driver_client_context() as client:
+            for target, previous in positions:
+                # Set position
+                await client.set_switch(DEVICE_NAME, "CORDWRAP_POS", [target])
+                await asyncio.sleep(0.5)
+
+                # Verify
+                prop = client.get_property(DEVICE_NAME, "CORDWRAP_POS")
+                assert prop["values"].get(target) == "On", f"{target} not set"
+                assert prop["values"].get(previous) == "Off", f"{previous} still on"
+
+                # Save config
+                await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+                await asyncio.sleep(1)
+
+                # Verify config
+                target_val = get_config_value("CORDWRAP_POS", target)
+                previous_val = get_config_value("CORDWRAP_POS", previous)
+                assert target_val == "On", f"Config: {target}={target_val}, expected On"
+                assert previous_val == "Off", f"Config: {previous}={previous_val}, expected Off"
+
+    asyncio.run(run())
+
+
+def test_cordwrap_disable_does_not_affect_position(indiserver_process):
+    """Verify that disabling cord wrap does not change the position setting."""
+
+    async def run():
+        async with driver_client_context() as client:
+            # Set position to SE
+            await client.set_switch(DEVICE_NAME, "CORDWRAP_POS", ["CORDWRAP_SE"])
+            await asyncio.sleep(0.5)
+
+            # Enable cord wrap
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_ENABLED"])
+            await asyncio.sleep(0.5)
+
+            # Save config
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(1)
+
+            # Disable cord wrap
+            await client.set_switch(DEVICE_NAME, "CORDWRAP", ["INDI_DISABLED"])
+            await asyncio.sleep(0.5)
+
+            # Verify position is still SE
+            pos = client.get_property(DEVICE_NAME, "CORDWRAP_POS")
+            assert pos["values"].get("CORDWRAP_SE") == "On"
+
+            # Save config again
+            await client.set_switch(DEVICE_NAME, "CONFIG_PROCESS", ["CONFIG_SAVE"])
+            await asyncio.sleep(1)
+
+            # Verify config still has SE
+            se_val = get_config_value("CORDWRAP_POS", "CORDWRAP_SE")
+            assert se_val == "On", f"After disable, CORDWRAP_SE={se_val}, expected On"
+
+    asyncio.run(run())


### PR DESCRIPTION
Cord wrap properties (toggle, position, base mode) were not being saved to config when changed via the UI. This caused settings to be lost on driver restart.

Root cause: ISNewSwitch handlers for CORDWRAP, CORDWRAP_POS, and CW_BASE were missing saveConfig() calls after updating properties.

Changes:
- Add saveConfig() calls to all three cord wrap ISNewSwitch handlers
- Add loadConfig() calls in ISGetProperties() to restore settings
- Fix CORDWRAP_NE default from ISS_ON to ISS_OFF in initProperties()
- Add error handling for getCordWrapEnabled/getCordWrapPosition
- Update updateProperties() to fallback to config on mount query failure
- Add isCordWrapSkyMode() helper method
- Add comprehensive cord wrap persistence tests (7 tests)

Follows the same pattern as ApproachDirectionSP, PortTypeSP, and GuidePulseMode which already call saveConfig() in their handlers.

Tested in simulation and on real mount with HC and HBG3 and over network.