### PR TITLE
Fix for A7RIV timeout & capturing a single frame only

### DIFF
--- a/indi-gphoto/gphoto_driver.cpp
+++ b/indi-gphoto/gphoto_driver.cpp
@@ -1391,7 +1391,9 @@ int gphoto_read_exposure_fd(gphoto_driver *gphoto, int fd)
         //reset_settings(gphoto);
 
         // A ptp reset is needed by Sony A7II and A7III
-        if (strstr(gphoto->manufacturer, "Sony") && strstr(gphoto->model, "ILCE"))
+        // However, this session reset wrecks the A7RIV, preventing capture of successive frames
+        if (strstr(gphoto->manufacturer, "Sony") && strstr(gphoto->model, "ILCE")
+                && !strstr(gphoto->model, "7RM4"))
             gp_camera_exit(gphoto->camera, gphoto->context);
 
         return result;


### PR DESCRIPTION
When attempting to use the Sony A7RIV, I encountered a timeout failure which caused an extensive delay and eventual timeout, with the result that of any 1..N frames, frames 2..N failed to capture.   

I traced it to this ptp session reset between each frame.   The change attached to this PR prevents this session reset for ILCE-7RM4, the only A7R model for which I can confirm the reset is destructive to sequence captures.   However, I will say that to me at least, if feels highly unlikely that the reset operation is useful on any model, given how long it takes to complete.

This is the driver code I have been running for my last 4-5 sessions, and it is working reliably for hundreds of frames in sequence.