### PR TITLE
indi-asi: Implement gradual warm-up when turning the cooler off

### DIFF
--- a/indi-apogee/apogee_ccd.cpp
+++ b/indi-apogee/apogee_ccd.cpp
@@ -322,13 +322,13 @@ bool ApogeeCCD::getCameraParams()
     return true;
 }
 
-int ApogeeCCD::SetTemperature(double temperature)
+int ApogeeCCD::SetTemperature(double temperature, bool enableCooler)
 {
     // If less than 0.1 of a degree, let's just return OK
     if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
         return 1;
 
-    if (!m_CoolerWarmingUp)
+    if (enableCooler)
         activateCooler(true);
 
     try

--- a/indi-apogee/apogee_ccd.cpp
+++ b/indi-apogee/apogee_ccd.cpp
@@ -328,7 +328,8 @@ int ApogeeCCD::SetTemperature(double temperature)
     if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
         return 1;
 
-    activateCooler(true);
+    if (!m_CoolerWarmingUp)
+        activateCooler(true);
 
     try
     {
@@ -437,9 +438,17 @@ bool ApogeeCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                 return false;
 
             if (CoolerS[0].s == ISS_ON)
+            {
+                cancelCoolerWarmup();
                 activateCooler(true);
+                resumeCoolingAfterWarmup();
+            }
             else
-                activateCooler(false);
+            {
+                CoolerSP.s = IPS_BUSY;
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                IDSetSwitch(&CoolerSP, nullptr);
+            }
 
             return true;
         }
@@ -1255,6 +1264,42 @@ void ApogeeCCD::activateCooler(bool enable)
     IDSetSwitch(&CoolerSP, nullptr);
 }
 
+bool ApogeeCCD::SetCoolerEnabled(bool enable)
+{
+    if (isSimulation())
+    {
+        CoolerS[0].s = enable ? ISS_ON : ISS_OFF;
+        CoolerS[1].s = enable ? ISS_OFF : ISS_ON;
+        if (!enable)
+        {
+            CoolerSP.s = IPS_IDLE;
+            IDSetSwitch(&CoolerSP, nullptr);
+        }
+        return true;
+    }
+
+    try
+    {
+        bool coolerOn = ApgCam->IsCoolerOn();
+        if ((enable && !coolerOn) || (!enable && coolerOn))
+            ApgCam->SetCooler(enable);
+    }
+    catch (std::runtime_error &err)
+    {
+        LOGF_ERROR("SetCooler failed. %s.", err.what());
+        return false;
+    }
+
+    CoolerS[0].s = enable ? ISS_ON : ISS_OFF;
+    CoolerS[1].s = enable ? ISS_OFF : ISS_ON;
+    if (!enable)
+    {
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
+    return true;
+}
+
 void ApogeeCCD::TimerHit()
 {
     long timeleft;
@@ -1320,6 +1365,7 @@ void ApogeeCCD::TimerHit()
                 TemperatureNP[0].setValue(ccdTemp);
                 TemperatureNP.apply();
             }
+            coolerWarmupTick(ccdTemp);
             break;
 
         case IPS_BUSY:
@@ -1344,6 +1390,7 @@ void ApogeeCCD::TimerHit()
 
             TemperatureNP[0].setValue(ccdTemp);
             TemperatureNP.apply();
+            coolerWarmupTick(ccdTemp);
             break;
 
         case IPS_ALERT:

--- a/indi-apogee/apogee_ccd.h
+++ b/indi-apogee/apogee_ccd.h
@@ -50,7 +50,7 @@ class ApogeeCCD : public INDI::CCD, public INDI::FilterInterface
         bool Connect() override;
         bool Disconnect() override;
 
-        int SetTemperature(double temperature) override;
+        int SetTemperature(double temperature, bool enableCooler = false) override;
         bool SetCoolerEnabled(bool enable) override;
         bool StartExposure(float duration) override;
         bool AbortExposure() override;

--- a/indi-apogee/apogee_ccd.h
+++ b/indi-apogee/apogee_ccd.h
@@ -51,6 +51,7 @@ class ApogeeCCD : public INDI::CCD, public INDI::FilterInterface
         bool Disconnect() override;
 
         int SetTemperature(double temperature) override;
+        bool SetCoolerEnabled(bool enable) override;
         bool StartExposure(float duration) override;
         bool AbortExposure() override;
 

--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -1092,25 +1092,26 @@ bool ASIBase::setVideoFormat(uint8_t index)
     return true;
 }
 
-int ASIBase::SetTemperature(double temperature)
+int ASIBase::SetTemperature(double temperature, bool enableCooler)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (!SetCoolerEnabled(true))
+    if (enableCooler)
     {
-        LOG_ERROR("Failed to activate cooler.");
-        return -1;
-    }
-
-    // Update CoolerSP display if not already showing an active/warmup state
-    if (CoolerSP.getState() == IPS_IDLE)
-    {
-        CoolerSP[0].setState(ISS_ON);
-        CoolerSP[1].setState(ISS_OFF);
-        CoolerSP.setState(IPS_BUSY);
-        CoolerSP.apply();
+        if (!SetCoolerEnabled(true))
+        {
+            LOG_ERROR("Failed to activate cooler.");
+            return -1;
+        }
+        if (CoolerSP[0].getState() == ISS_OFF)
+        {
+            CoolerSP[0].setState(ISS_ON);
+            CoolerSP[1].setState(ISS_OFF);
+            CoolerSP.setState(IPS_BUSY);
+            CoolerSP.apply();
+        }
     }
 
     ASI_ERROR_CODE ret;

--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -41,9 +41,6 @@
 #define VERBOSE_EXPOSURE        3
 #define TEMP_TIMER_MS           1000 /* Temperature polling time (ms) */
 #define TEMP_THRESHOLD          .25  /* Differential temperature threshold (C)*/
-#define TEMP_AMBIENT_DEFAULT    25.0  /* Default warm-up target on cooler off (C), ASI SDK has no ambient sensor */
-#define WARMUP_STABLE_MS        60000 /* Temperature must be stable this long before warm-up is considered done */
-#define WARMUP_STABLE_DELTA     0.5   /* Maximum temperature change (C) that counts as "stable" */
 
 #define CONTROL_TAB "Controls"
 
@@ -406,9 +403,6 @@ bool ASIBase::initProperties()
     CoolerNP[0].fill("CCD_COOLER_VALUE", "Cooling Power (%)", "%+06.2f", 0., 1., .2, 0.0);
     CoolerNP.fill(getDeviceName(), "CCD_COOLER_POWER", "Cooling Power", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
-    WarmupTargetNP[0].fill("TEMPERATURE", "Temperature (C)", "%.1f", -50., 50., 1., TEMP_AMBIENT_DEFAULT);
-    WarmupTargetNP.fill(getDeviceName(), "CCD_WARMUP_TARGET", "Warm Up Target", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
-
     ControlNP.fill(getDeviceName(), "CCD_CONTROLS",      "Controls", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
     ControlSP.fill(getDeviceName(), "CCD_CONTROLS_MODE", "Set Auto", CONTROL_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
@@ -511,8 +505,6 @@ bool ASIBase::updateProperties()
             loadConfig(true, CoolerNP.getName());
             defineProperty(CoolerSP);
             loadConfig(true, CoolerSP.getName());
-            defineProperty(WarmupTargetNP);
-            loadConfig(true, WarmupTargetNP.getName());
         }
         // Even if there is no cooler, we define temperature property as READ ONLY
         else
@@ -574,7 +566,6 @@ bool ASIBase::updateProperties()
         {
             deleteProperty(CoolerNP);
             deleteProperty(CoolerSP);
-            deleteProperty(WarmupTargetNP);
         }
         else
             deleteProperty(TemperatureNP);
@@ -875,15 +866,6 @@ bool ASIBase::ISNewNumber(const char *dev, const char *name, double values[], ch
             return true;
         }
 
-        if (WarmupTargetNP.isNameMatch(name))
-        {
-            WarmupTargetNP.update(values, names, n);
-            WarmupTargetNP.setState(IPS_OK);
-            WarmupTargetNP.apply();
-            saveConfig(WarmupTargetNP);
-            return true;
-        }
-
         // An explicit temperature request supersedes any warm-up-on-cooler-off in progress.
         if (TemperatureNP.isNameMatch(name))
             cancelCoolerWarmup();
@@ -983,11 +965,17 @@ bool ASIBase::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
             if (CoolerSP[0].getState() == ISS_ON)
             {
                 cancelCoolerWarmup();
-                activateCooler(true);
-                resumeCooling();
+                CoolerSP.setState(IPS_BUSY);
+                CoolerSP.apply();
+                if (SetCoolerEnabled(true))
+                    resumeCoolingAfterWarmup();
             }
             else
-                beginCoolerWarmup();
+            {
+                CoolerSP.setState(IPS_BUSY);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                CoolerSP.apply();
+            }
 
             return true;
         }
@@ -1110,13 +1098,19 @@ int ASIBase::SetTemperature(double temperature)
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    // While warming up towards ambient, keep the TEC engaged without flipping CoolerSP back to ON -
-    // activateCooler() would otherwise re-apply ISS_ON on every ~60s ramp step.
-    bool coolerOk = mCoolerWarmingUp ? setCoolerPower(true) : activateCooler(true);
-    if (!coolerOk)
+    if (!SetCoolerEnabled(true))
     {
         LOG_ERROR("Failed to activate cooler.");
         return -1;
+    }
+
+    // Update CoolerSP display if not already showing an active/warmup state
+    if (CoolerSP.getState() == IPS_IDLE)
+    {
+        CoolerSP[0].setState(ISS_ON);
+        CoolerSP[1].setState(ISS_OFF);
+        CoolerSP.setState(IPS_BUSY);
+        CoolerSP.apply();
     }
 
     ASI_ERROR_CODE ret;
@@ -1134,164 +1128,26 @@ int ASIBase::SetTemperature(double temperature)
     return 0;
 }
 
-bool ASIBase::setCoolerPower(bool enable)
+bool ASIBase::SetCoolerEnabled(bool enable)
 {
     ASI_ERROR_CODE ret = ASISetControlValue(mCameraInfo.CameraID, ASI_COOLER_ON, enable ? ASI_TRUE : ASI_FALSE, ASI_FALSE);
     if (ret != ASI_SUCCESS)
-        LOGF_ERROR("Failed to activate cooler (%s).", Helpers::toString(ret));
-
-    return (ret == ASI_SUCCESS);
-}
-
-bool ASIBase::activateCooler(bool enable)
-{
-    bool success = setCoolerPower(enable);
-    if (!success)
+    {
+        LOGF_ERROR("Failed to set cooler power (%s).", Helpers::toString(ret));
         CoolerSP.setState(IPS_ALERT);
-    else
-    {
-        CoolerSP[0].setState(enable ? ISS_ON  : ISS_OFF);
-        CoolerSP[1].setState(enable ? ISS_OFF : ISS_ON);
-        CoolerSP.setState(enable ? IPS_BUSY : IPS_IDLE);
-    }
-    CoolerSP.apply();
-
-    return success;
-}
-
-void ASIBase::beginCoolerWarmup()
-{
-    // Gradual warm-up only makes sense when temperature ramping is enabled; otherwise cut power immediately.
-    if (TemperatureRampNP[RAMP_SLOPE].getValue() == 0)
-    {
-        activateCooler(false);
-        return;
+        CoolerSP.apply();
+        return false;
     }
 
-    // Save before we overwrite m_TargetTemperature with the ambient value below.
-    // m_TargetTemperature (base class) holds the user's original cooling setpoint as set via
-    // ISNewNumber; mTargetTemperature (our own member) only holds the last ramp step.
-    mSavedCoolingTarget = m_TargetTemperature;
-
-    double ambientTemperature = WarmupTargetNP[0].getValue();
-    double currentTemperature = TemperatureNP[0].getValue();
-
-    // Already close enough to ambient, just cut power immediately.
-    if (std::abs(ambientTemperature - currentTemperature) <= TemperatureRampNP[RAMP_THRESHOLD].getValue())
+    if (!enable)
     {
-        activateCooler(false);
-        return;
+        CoolerSP[0].setState(ISS_OFF);
+        CoolerSP[1].setState(ISS_ON);
+        CoolerSP.setState(IPS_IDLE);
+        CoolerSP.apply();
     }
 
-    // Reflect the OFF request on the switch right away, but keep it busy until ambient is reached.
-    CoolerSP[0].setState(ISS_OFF);
-    CoolerSP[1].setState(ISS_ON);
-    CoolerSP.setState(IPS_BUSY);
-    CoolerSP.apply();
-
-    mCoolerWarmingUp = true;
-    mWarmupLastTemperature = mCurrentTemperature;
-    mCoolerZeroPowerTimer.start();
-
-    double nextTemperature = (ambientTemperature < currentTemperature)
-                              ? std::max(ambientTemperature, currentTemperature - TemperatureRampNP[RAMP_SLOPE].getValue())
-                              : std::min(ambientTemperature, currentTemperature + TemperatureRampNP[RAMP_SLOPE].getValue());
-
-    int rc = SetTemperature(nextTemperature);
-    if (rc == -1)
-    {
-        LOG_ERROR("Failed to initiate cooler warm-up, turning cooler off immediately.");
-        mCoolerWarmingUp = false;
-        activateCooler(false);
-        return;
-    }
-
-    if (rc == 1)
-    {
-        // SetTemperature() considered us already at the next step, we're effectively at ambient.
-        mCoolerWarmingUp = false;
-        activateCooler(false);
-        return;
-    }
-
-    m_TemperatureElapsedTimer.start();
-    m_TargetTemperature = ambientTemperature;
-    m_TemperatureCheckTimer.start();
-    TemperatureNP.setState(IPS_BUSY);
-    TemperatureNP.apply();
-
-    LOGF_INFO("Cooler is warming up to ambient temperature (%.1f C)...", ambientTemperature);
-}
-
-void ASIBase::cancelCoolerWarmup()
-{
-    if (!mCoolerWarmingUp)
-        return;
-
-    mCoolerWarmingUp = false;
-    m_TemperatureCheckTimer.stop();
-
-    if (TemperatureNP.getState() == IPS_BUSY)
-    {
-        TemperatureNP.setState(IPS_OK);
-        TemperatureNP.apply();
-    }
-}
-
-void ASIBase::finishCoolerWarmup(const char *reason)
-{
-    if (!mCoolerWarmingUp)
-        return;
-
-    mCoolerWarmingUp = false;
-    m_TemperatureCheckTimer.stop();
-
-    if (TemperatureNP.getState() == IPS_BUSY)
-    {
-        TemperatureNP.setState(IPS_OK);
-        TemperatureNP.apply();
-    }
-
-    activateCooler(false);
-    LOGF_INFO("Cooler is now off, %s.", reason);
-}
-
-void ASIBase::resumeCooling()
-{
-    // Nothing saved yet (cooler activated for the first time, never warmed up before)
-    // or saved target is not actually below the current temperature – nothing to do.
-    if (mSavedCoolingTarget >= TemperatureNP[0].getValue())
-        return;
-
-    double nextTemperature = mSavedCoolingTarget;
-    if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
-        nextTemperature = std::max(mSavedCoolingTarget,
-                                   TemperatureNP[0].getValue() - TemperatureRampNP[RAMP_SLOPE].getValue());
-
-    int rc = SetTemperature(nextTemperature);
-    if (rc == 0)
-    {
-        if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
-            m_TemperatureElapsedTimer.start();
-        m_TargetTemperature = mSavedCoolingTarget;
-        m_TemperatureCheckTimer.start();
-        TemperatureNP.setState(IPS_BUSY);
-        TemperatureNP.apply();
-        LOGF_INFO("Resuming cooling to %.2f C.", mSavedCoolingTarget);
-    }
-    else if (rc == 1)
-    {
-        TemperatureNP.setState(IPS_OK);
-        TemperatureNP.apply();
-    }
-}
-
-void ASIBase::checkTemperatureTarget()
-{
-    INDI::CCD::checkTemperatureTarget();
-
-    if (mCoolerWarmingUp && TemperatureNP.getState() != IPS_BUSY)
-        finishCoolerWarmup("ambient temperature reached");
+    return true;
 }
 
 bool ASIBase::StartExposure(float duration)
@@ -1593,6 +1449,8 @@ void ASIBase::temperatureTimerTimeout()
         TemperatureNP.apply();
     }
 
+    coolerWarmupTick(mCurrentTemperature);
+
     if (HasCooler())
     {
         ret = ASIGetControlValue(mCameraInfo.CameraID, ASI_COOLER_POWER_PERC, &value, &isAuto);
@@ -1605,23 +1463,6 @@ void ASIBase::temperatureTimerTimeout()
         {
             CoolerNP[0].setValue(value);
             CoolerNP.setState(value > 0 ? IPS_BUSY : IPS_IDLE);
-
-            // Secondary completion check: ASI TECs are unidirectional — they cannot heat,
-            // so power stays at 0% for the entire warm-up ramp regardless of progress.
-            // A sustained 0% therefore tells us nothing useful during warm-up.
-            // Instead check temperature stability: once the reading stops changing the camera
-            // has reached thermal equilibrium with its environment (which may be below the
-            // configured warm-up target if room temperature is cooler than 25 °C).
-            if (mCoolerWarmingUp)
-            {
-                if (std::abs(mCurrentTemperature - mWarmupLastTemperature) > WARMUP_STABLE_DELTA)
-                {
-                    mWarmupLastTemperature = mCurrentTemperature;
-                    mCoolerZeroPowerTimer.start();
-                }
-                else if (mCoolerZeroPowerTimer.hasExpired(WARMUP_STABLE_MS))
-                    finishCoolerWarmup("temperature has stabilized");
-            }
         }
         CoolerNP.apply();
     }
@@ -1893,7 +1734,6 @@ bool ASIBase::saveConfigItems(FILE *fp)
     if (HasCooler())
     {
         CoolerSP.save(fp);
-        WarmupTargetNP.save(fp);
     }
 
     if (!ControlNP.isEmpty())

--- a/indi-asi/asi_base.cpp
+++ b/indi-asi/asi_base.cpp
@@ -41,6 +41,9 @@
 #define VERBOSE_EXPOSURE        3
 #define TEMP_TIMER_MS           1000 /* Temperature polling time (ms) */
 #define TEMP_THRESHOLD          .25  /* Differential temperature threshold (C)*/
+#define TEMP_AMBIENT_DEFAULT    25.0  /* Default warm-up target on cooler off (C), ASI SDK has no ambient sensor */
+#define WARMUP_STABLE_MS        60000 /* Temperature must be stable this long before warm-up is considered done */
+#define WARMUP_STABLE_DELTA     0.5   /* Maximum temperature change (C) that counts as "stable" */
 
 #define CONTROL_TAB "Controls"
 
@@ -403,6 +406,9 @@ bool ASIBase::initProperties()
     CoolerNP[0].fill("CCD_COOLER_VALUE", "Cooling Power (%)", "%+06.2f", 0., 1., .2, 0.0);
     CoolerNP.fill(getDeviceName(), "CCD_COOLER_POWER", "Cooling Power", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
+    WarmupTargetNP[0].fill("TEMPERATURE", "Temperature (C)", "%.1f", -50., 50., 1., TEMP_AMBIENT_DEFAULT);
+    WarmupTargetNP.fill(getDeviceName(), "CCD_WARMUP_TARGET", "Warm Up Target", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     ControlNP.fill(getDeviceName(), "CCD_CONTROLS",      "Controls", CONTROL_TAB, IP_RW, 60, IPS_IDLE);
     ControlSP.fill(getDeviceName(), "CCD_CONTROLS_MODE", "Set Auto", CONTROL_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
@@ -505,6 +511,8 @@ bool ASIBase::updateProperties()
             loadConfig(true, CoolerNP.getName());
             defineProperty(CoolerSP);
             loadConfig(true, CoolerSP.getName());
+            defineProperty(WarmupTargetNP);
+            loadConfig(true, WarmupTargetNP.getName());
         }
         // Even if there is no cooler, we define temperature property as READ ONLY
         else
@@ -566,6 +574,7 @@ bool ASIBase::updateProperties()
         {
             deleteProperty(CoolerNP);
             deleteProperty(CoolerSP);
+            deleteProperty(WarmupTargetNP);
         }
         else
             deleteProperty(TemperatureNP);
@@ -865,6 +874,19 @@ bool ASIBase::ISNewNumber(const char *dev, const char *name, double values[], ch
             saveConfig(BlinkNP);
             return true;
         }
+
+        if (WarmupTargetNP.isNameMatch(name))
+        {
+            WarmupTargetNP.update(values, names, n);
+            WarmupTargetNP.setState(IPS_OK);
+            WarmupTargetNP.apply();
+            saveConfig(WarmupTargetNP);
+            return true;
+        }
+
+        // An explicit temperature request supersedes any warm-up-on-cooler-off in progress.
+        if (TemperatureNP.isNameMatch(name))
+            cancelCoolerWarmup();
     }
 
     return INDI::CCD::ISNewNumber(dev, name, values, names, n);
@@ -958,7 +980,14 @@ bool ASIBase::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 return true;
             }
 
-            activateCooler(CoolerSP[0].getState() == ISS_ON);
+            if (CoolerSP[0].getState() == ISS_ON)
+            {
+                cancelCoolerWarmup();
+                activateCooler(true);
+                resumeCooling();
+            }
+            else
+                beginCoolerWarmup();
 
             return true;
         }
@@ -1078,11 +1107,13 @@ bool ASIBase::setVideoFormat(uint8_t index)
 int ASIBase::SetTemperature(double temperature)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
-    // #PS: how will it warm up?
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (activateCooler(true) == false)
+    // While warming up towards ambient, keep the TEC engaged without flipping CoolerSP back to ON -
+    // activateCooler() would otherwise re-apply ISS_ON on every ~60s ramp step.
+    bool coolerOk = mCoolerWarmingUp ? setCoolerPower(true) : activateCooler(true);
+    if (!coolerOk)
     {
         LOG_ERROR("Failed to activate cooler.");
         return -1;
@@ -1103,14 +1134,20 @@ int ASIBase::SetTemperature(double temperature)
     return 0;
 }
 
-bool ASIBase::activateCooler(bool enable)
+bool ASIBase::setCoolerPower(bool enable)
 {
     ASI_ERROR_CODE ret = ASISetControlValue(mCameraInfo.CameraID, ASI_COOLER_ON, enable ? ASI_TRUE : ASI_FALSE, ASI_FALSE);
     if (ret != ASI_SUCCESS)
-    {
-        CoolerSP.setState(IPS_ALERT);
         LOGF_ERROR("Failed to activate cooler (%s).", Helpers::toString(ret));
-    }
+
+    return (ret == ASI_SUCCESS);
+}
+
+bool ASIBase::activateCooler(bool enable)
+{
+    bool success = setCoolerPower(enable);
+    if (!success)
+        CoolerSP.setState(IPS_ALERT);
     else
     {
         CoolerSP[0].setState(enable ? ISS_ON  : ISS_OFF);
@@ -1119,7 +1156,142 @@ bool ASIBase::activateCooler(bool enable)
     }
     CoolerSP.apply();
 
-    return (ret == ASI_SUCCESS);
+    return success;
+}
+
+void ASIBase::beginCoolerWarmup()
+{
+    // Gradual warm-up only makes sense when temperature ramping is enabled; otherwise cut power immediately.
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() == 0)
+    {
+        activateCooler(false);
+        return;
+    }
+
+    // Save before we overwrite m_TargetTemperature with the ambient value below.
+    // m_TargetTemperature (base class) holds the user's original cooling setpoint as set via
+    // ISNewNumber; mTargetTemperature (our own member) only holds the last ramp step.
+    mSavedCoolingTarget = m_TargetTemperature;
+
+    double ambientTemperature = WarmupTargetNP[0].getValue();
+    double currentTemperature = TemperatureNP[0].getValue();
+
+    // Already close enough to ambient, just cut power immediately.
+    if (std::abs(ambientTemperature - currentTemperature) <= TemperatureRampNP[RAMP_THRESHOLD].getValue())
+    {
+        activateCooler(false);
+        return;
+    }
+
+    // Reflect the OFF request on the switch right away, but keep it busy until ambient is reached.
+    CoolerSP[0].setState(ISS_OFF);
+    CoolerSP[1].setState(ISS_ON);
+    CoolerSP.setState(IPS_BUSY);
+    CoolerSP.apply();
+
+    mCoolerWarmingUp = true;
+    mWarmupLastTemperature = mCurrentTemperature;
+    mCoolerZeroPowerTimer.start();
+
+    double nextTemperature = (ambientTemperature < currentTemperature)
+                              ? std::max(ambientTemperature, currentTemperature - TemperatureRampNP[RAMP_SLOPE].getValue())
+                              : std::min(ambientTemperature, currentTemperature + TemperatureRampNP[RAMP_SLOPE].getValue());
+
+    int rc = SetTemperature(nextTemperature);
+    if (rc == -1)
+    {
+        LOG_ERROR("Failed to initiate cooler warm-up, turning cooler off immediately.");
+        mCoolerWarmingUp = false;
+        activateCooler(false);
+        return;
+    }
+
+    if (rc == 1)
+    {
+        // SetTemperature() considered us already at the next step, we're effectively at ambient.
+        mCoolerWarmingUp = false;
+        activateCooler(false);
+        return;
+    }
+
+    m_TemperatureElapsedTimer.start();
+    m_TargetTemperature = ambientTemperature;
+    m_TemperatureCheckTimer.start();
+    TemperatureNP.setState(IPS_BUSY);
+    TemperatureNP.apply();
+
+    LOGF_INFO("Cooler is warming up to ambient temperature (%.1f C)...", ambientTemperature);
+}
+
+void ASIBase::cancelCoolerWarmup()
+{
+    if (!mCoolerWarmingUp)
+        return;
+
+    mCoolerWarmingUp = false;
+    m_TemperatureCheckTimer.stop();
+
+    if (TemperatureNP.getState() == IPS_BUSY)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+}
+
+void ASIBase::finishCoolerWarmup(const char *reason)
+{
+    if (!mCoolerWarmingUp)
+        return;
+
+    mCoolerWarmingUp = false;
+    m_TemperatureCheckTimer.stop();
+
+    if (TemperatureNP.getState() == IPS_BUSY)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+
+    activateCooler(false);
+    LOGF_INFO("Cooler is now off, %s.", reason);
+}
+
+void ASIBase::resumeCooling()
+{
+    // Nothing saved yet (cooler activated for the first time, never warmed up before)
+    // or saved target is not actually below the current temperature – nothing to do.
+    if (mSavedCoolingTarget >= TemperatureNP[0].getValue())
+        return;
+
+    double nextTemperature = mSavedCoolingTarget;
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+        nextTemperature = std::max(mSavedCoolingTarget,
+                                   TemperatureNP[0].getValue() - TemperatureRampNP[RAMP_SLOPE].getValue());
+
+    int rc = SetTemperature(nextTemperature);
+    if (rc == 0)
+    {
+        if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+            m_TemperatureElapsedTimer.start();
+        m_TargetTemperature = mSavedCoolingTarget;
+        m_TemperatureCheckTimer.start();
+        TemperatureNP.setState(IPS_BUSY);
+        TemperatureNP.apply();
+        LOGF_INFO("Resuming cooling to %.2f C.", mSavedCoolingTarget);
+    }
+    else if (rc == 1)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+}
+
+void ASIBase::checkTemperatureTarget()
+{
+    INDI::CCD::checkTemperatureTarget();
+
+    if (mCoolerWarmingUp && TemperatureNP.getState() != IPS_BUSY)
+        finishCoolerWarmup("ambient temperature reached");
 }
 
 bool ASIBase::StartExposure(float duration)
@@ -1433,6 +1605,23 @@ void ASIBase::temperatureTimerTimeout()
         {
             CoolerNP[0].setValue(value);
             CoolerNP.setState(value > 0 ? IPS_BUSY : IPS_IDLE);
+
+            // Secondary completion check: ASI TECs are unidirectional — they cannot heat,
+            // so power stays at 0% for the entire warm-up ramp regardless of progress.
+            // A sustained 0% therefore tells us nothing useful during warm-up.
+            // Instead check temperature stability: once the reading stops changing the camera
+            // has reached thermal equilibrium with its environment (which may be below the
+            // configured warm-up target if room temperature is cooler than 25 °C).
+            if (mCoolerWarmingUp)
+            {
+                if (std::abs(mCurrentTemperature - mWarmupLastTemperature) > WARMUP_STABLE_DELTA)
+                {
+                    mWarmupLastTemperature = mCurrentTemperature;
+                    mCoolerZeroPowerTimer.start();
+                }
+                else if (mCoolerZeroPowerTimer.hasExpired(WARMUP_STABLE_MS))
+                    finishCoolerWarmup("temperature has stabilized");
+            }
         }
         CoolerNP.apply();
     }
@@ -1702,7 +1891,10 @@ bool ASIBase::saveConfigItems(FILE *fp)
     INDI::CCD::saveConfigItems(fp);
 
     if (HasCooler())
+    {
         CoolerSP.save(fp);
+        WarmupTargetNP.save(fp);
+    }
 
     if (!ControlNP.isEmpty())
         ControlNP.save(fp);

--- a/indi-asi/asi_base.h
+++ b/indi-asi/asi_base.h
@@ -53,7 +53,7 @@ class ASIBase : public INDI::CCD
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;

--- a/indi-asi/asi_base.h
+++ b/indi-asi/asi_base.h
@@ -34,6 +34,7 @@
 
 #include <indiccd.h>
 #include <inditimer.h>
+#include <indielapsedtimer.h>
 
 class SingleWorker;
 class ASIBase : public INDI::CCD
@@ -57,6 +58,8 @@ class ASIBase : public INDI::CCD
         virtual bool AbortExposure() override;
 
     protected:
+
+        virtual void checkTemperatureTarget() override;
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
@@ -99,6 +102,10 @@ class ASIBase : public INDI::CCD
     protected:
         double mTargetTemperature;
         double mCurrentTemperature;
+        bool mCoolerWarmingUp {false};
+        double mWarmupLastTemperature {0};
+        double mSavedCoolingTarget {100.0}; // sentinel: no valid target saved yet
+        INDI::ElapsedTimer mCoolerZeroPowerTimer; // measures how long temperature has been stable
         INDI::Timer mTimerTemperature;
         void temperatureTimerTimeout();
 
@@ -124,8 +131,23 @@ class ASIBase : public INDI::CCD
         /** Update SER recorder video format */
         void updateRecorderFormat();
 
-        /** Control cooler */
+        /** Control cooler, updates CoolerSP switch/state */
         bool activateCooler(bool enable);
+
+        /** Raw TEC power toggle, does not touch CoolerSP so callers can control the switch presentation */
+        bool setCoolerPower(bool enable);
+
+        /** Ramp temperature toward ambient, keeping the Cooler switch busy, then switch the cooler off */
+        void beginCoolerWarmup();
+
+        /** Cancel an in-progress cooler warm-up, e.g. because the cooler was switched back on */
+        void cancelCoolerWarmup();
+
+        /** Finish an in-progress cooler warm-up by switching the cooler off for good */
+        void finishCoolerWarmup(const char *reason);
+
+        /** After re-enabling the cooler, ramp back to the previously saved target temperature */
+        void resumeCooling();
 
         /** Set Video Format */
         bool setVideoFormat(uint8_t index);
@@ -142,6 +164,7 @@ class ASIBase : public INDI::CCD
         /** Additional Properties to INDI::CCD */
         INDI::PropertyNumber  CoolerNP {1};
         INDI::PropertySwitch  CoolerSP {2};
+        INDI::PropertyNumber  WarmupTargetNP {1};
 
         INDI::PropertyNumber  ControlNP {0};
         INDI::PropertySwitch  ControlSP {0};

--- a/indi-asi/asi_base.h
+++ b/indi-asi/asi_base.h
@@ -54,12 +54,11 @@ class ASIBase : public INDI::CCD
         virtual bool Disconnect() override;
 
         virtual int SetTemperature(double temperature) override;
+        virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
 
     protected:
-
-        virtual void checkTemperatureTarget() override;
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
@@ -102,10 +101,6 @@ class ASIBase : public INDI::CCD
     protected:
         double mTargetTemperature;
         double mCurrentTemperature;
-        bool mCoolerWarmingUp {false};
-        double mWarmupLastTemperature {0};
-        double mSavedCoolingTarget {100.0}; // sentinel: no valid target saved yet
-        INDI::ElapsedTimer mCoolerZeroPowerTimer; // measures how long temperature has been stable
         INDI::Timer mTimerTemperature;
         void temperatureTimerTimeout();
 
@@ -131,24 +126,6 @@ class ASIBase : public INDI::CCD
         /** Update SER recorder video format */
         void updateRecorderFormat();
 
-        /** Control cooler, updates CoolerSP switch/state */
-        bool activateCooler(bool enable);
-
-        /** Raw TEC power toggle, does not touch CoolerSP so callers can control the switch presentation */
-        bool setCoolerPower(bool enable);
-
-        /** Ramp temperature toward ambient, keeping the Cooler switch busy, then switch the cooler off */
-        void beginCoolerWarmup();
-
-        /** Cancel an in-progress cooler warm-up, e.g. because the cooler was switched back on */
-        void cancelCoolerWarmup();
-
-        /** Finish an in-progress cooler warm-up by switching the cooler off for good */
-        void finishCoolerWarmup(const char *reason);
-
-        /** After re-enabling the cooler, ramp back to the previously saved target temperature */
-        void resumeCooling();
-
         /** Set Video Format */
         bool setVideoFormat(uint8_t index);
 
@@ -164,7 +141,6 @@ class ASIBase : public INDI::CCD
         /** Additional Properties to INDI::CCD */
         INDI::PropertyNumber  CoolerNP {1};
         INDI::PropertySwitch  CoolerSP {2};
-        INDI::PropertyNumber  WarmupTargetNP {1};
 
         INDI::PropertyNumber  ControlNP {0};
         INDI::PropertySwitch  ControlSP {0};

--- a/indi-atik/atik_ccd.cpp
+++ b/indi-atik/atik_ccd.cpp
@@ -1047,7 +1047,7 @@ bool ATIKCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
     return INDI::CCD::ISNewSwitch(dev, name, states, names, n);
 }
 
-int ATIKCCD::SetTemperature(double temperature)
+int ATIKCCD::SetTemperature(double temperature, bool enableCooler)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
     if (fabs(temperature - TemperatureNP[0].getValue()) < TEMP_THRESHOLD)
@@ -1069,7 +1069,7 @@ int ATIKCCD::SetTemperature(double temperature)
 
     // Skip the CoolerSP display update during a warm-up sequence — the switch stays BUSY with
     // OFF selected until SetCoolerEnabled(false) finalises the ramp.
-    if (!m_CoolerWarmingUp)
+    if (enableCooler)
         activateCooler(true);
 
     return 0;

--- a/indi-atik/atik_ccd.cpp
+++ b/indi-atik/atik_ccd.cpp
@@ -887,7 +887,7 @@ bool ATIKCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
 
             return true;
         }
-        // Cooler controler
+        // Cooler controller
         else if (!strcmp(name, CoolerSP.name))
         {
             if (IUUpdateSwitch(&CoolerSP, states, names, n) < 0)
@@ -899,10 +899,24 @@ bool ATIKCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
 
             bool enabled = (CoolerS[COOLER_ON].s == ISS_ON);
 
+            if (!enabled)
+            {
+                // Cooler OFF: initiate gradual warm-up via base class helpers.
+                // beginCoolerWarmup() will call SetCoolerEnabled(false) itself when the
+                // temperature has stabilised (or immediately if no ramp is configured).
+                CoolerSP.s = IPS_BUSY;
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                IDSetSwitch(&CoolerSP, nullptr);
+                return true;
+            }
+
+            // Cooler ON: cancel any ongoing warmup first
+            cancelCoolerWarmup();
+
             // If user turns on cooler, but the requested temperature is higher than current temperature by more
             // than five degrees, then we consider this endangers the device and we alter the temperature target.
             // The five degrees tolerance is there to adapt to cooling overshoot.
-            if (enabled && TemperatureNP[0].getValue() + 5.0f < TemperatureRequest)
+            if (TemperatureNP[0].getValue() + 5.0f < TemperatureRequest)
             {
                 LOGF_WARN("Current temperature is %.2f, refusing to set %.2f (5 degrees warming tolerance). "
                           "To control cooler, request a lower temperature or let the device warm above %.2f.",
@@ -930,7 +944,13 @@ bool ATIKCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 }
             }
 
-            return activateCooler(enabled);
+            bool ok = activateCooler(true);
+            if (ok)
+            {
+                SetCoolerEnabled(true);
+                resumeCoolingAfterWarmup();
+            }
+            return ok;
         }
         else if (!strcmp(name, EvenIlluminationSP.name))
         {
@@ -1047,7 +1067,10 @@ int ATIKCCD::SetTemperature(double temperature)
     TemperatureRequest = temperature;
     LOGF_INFO("Setting CCD temperature to %+06.2f C", temperature);
 
-    activateCooler(true);
+    // Skip the CoolerSP display update during a warm-up sequence — the switch stays BUSY with
+    // OFF selected until SetCoolerEnabled(false) finalises the ramp.
+    if (!m_CoolerWarmingUp)
+        activateCooler(true);
 
     return 0;
 }
@@ -1096,6 +1119,39 @@ bool ATIKCCD::activateCooler(bool enable)
     }
 
     IDSetSwitch(&CoolerSP, nullptr);
+    return true;
+}
+
+bool ATIKCCD::SetCoolerEnabled(bool enable)
+{
+    if (enable)
+    {
+        // Re-apply the cooling setpoint to restart the TEC.
+        // Guard against calling before a valid setpoint has been established.
+        if (TemperatureRequest > 1e5)
+            return true;
+        int setpoint = static_cast<int>(TemperatureRequest * 100);
+        int rc = ArtemisSetCooling(hCam, setpoint);
+        if (rc != ARTEMIS_OK)
+        {
+            LOGF_ERROR("Failed to enable cooling (%d).", rc);
+            return false;
+        }
+        // CoolerSP stays at IPS_BUSY as set by the caller.
+    }
+    else
+    {
+        int rc = ArtemisCoolerWarmUp(hCam);
+        if (rc != ARTEMIS_OK)
+        {
+            LOGF_ERROR("Failed to initiate camera warm-up (%d).", rc);
+            return false;
+        }
+        CoolerS[COOLER_ON].s = ISS_OFF;
+        CoolerS[COOLER_OFF].s = ISS_ON;
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
     return true;
 }
 
@@ -1271,6 +1327,7 @@ void ATIKCCD::TimerHit()
     rc = ArtemisTemperatureSensorInfo(hCam, 1, &temperature);
     pthread_mutex_unlock(&accessMutex);
     TemperatureNP[0].setValue(temperature / 100.0);
+    coolerWarmupTick(TemperatureNP[0].getValue());
 
     switch (TemperatureNP.getState())
     {

--- a/indi-atik/atik_ccd.h
+++ b/indi-atik/atik_ccd.h
@@ -43,6 +43,7 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         virtual int SetTemperature(double temperature) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
+        virtual bool SetCoolerEnabled(bool enable) override;
 
         static void debugCallbackHelper(void *context, const char *message);
 

--- a/indi-atik/atik_ccd.h
+++ b/indi-atik/atik_ccd.h
@@ -40,7 +40,7 @@ class ATIKCCD : public INDI::CCD, public INDI::FilterInterface
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
         virtual bool SetCoolerEnabled(bool enable) override;

--- a/indi-fishcamp/indi_fishcamp.cpp
+++ b/indi-fishcamp/indi_fishcamp.cpp
@@ -206,8 +206,9 @@ bool FishCampCCD::setGain(double gain)
     return true;
 }
 
-int FishCampCCD::SetTemperature(double temperature)
+int FishCampCCD::SetTemperature(double temperature, bool enableCooler)
 {
+    INDI_UNUSED(enableCooler);
     TemperatureRequest = temperature;
 
     int rc = fcUsb_cmd_setTemperature(cameraNum, TemperatureRequest);

--- a/indi-fishcamp/indi_fishcamp.h
+++ b/indi-fishcamp/indi_fishcamp.h
@@ -54,7 +54,7 @@ class FishCampCCD : public INDI::CCD
     virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
     virtual bool UpdateCCDBin(int binx, int biny) override;
     virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;
-    virtual int SetTemperature(double temperature) override;
+    virtual int SetTemperature(double temperature, bool enableCooler = false) override;
 
     virtual void simulationTriggered(bool enable) override;
 

--- a/indi-fli/fli_ccd.cpp
+++ b/indi-fli/fli_ccd.cpp
@@ -489,8 +489,9 @@ bool FLICCD::setupParams()
     return true;
 }
 
-int FLICCD::SetTemperature(double temperature)
+int FLICCD::SetTemperature(double temperature, bool enableCooler )
 {
+    INDI_UNUSED(enableCooler);
     int err = 0;
 
     if (!sim && (err = FLISetTemperature(fli_dev, temperature)))

--- a/indi-fli/fli_ccd.h
+++ b/indi-fli/fli_ccd.h
@@ -52,7 +52,7 @@ class FLICCD : public INDI::CCD
 
     protected:
         virtual void TimerHit() override;
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int binx, int biny) override;
         virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;

--- a/indi-fli/kepler.cpp
+++ b/indi-fli/kepler.cpp
@@ -968,8 +968,9 @@ void Kepler::prepareUnpacked()
 /********************************************************************************
 *
 ********************************************************************************/
-int Kepler::SetTemperature(double temperature)
+int Kepler::SetTemperature(double temperature, bool enableCooler)
 {
+    INDI_UNUSED(enableCooler);
     // Return OK for
     if (std::abs(temperature - TemperatureNP[0].getValue()) < TEMPERATURE_THRESHOLD)
         return 1;

--- a/indi-fli/kepler.h
+++ b/indi-fli/kepler.h
@@ -52,7 +52,7 @@ class Kepler : public INDI::CCD
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
 
     protected:
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int binx, int biny) override;
         virtual bool UpdateCCDFrameType(INDI::CCDChip::CCD_FRAME fType) override;

--- a/indi-mi/mi_ccd.cpp
+++ b/indi-mi/mi_ccd.cpp
@@ -477,8 +477,9 @@ bool MICCD::setupParams()
     return true;
 }
 
-int MICCD::SetTemperature(double temperature)
+int MICCD::SetTemperature(double temperature, bool enableCooler)
 {
+    INDI_UNUSED(enableCooler);
     // If there difference, for example, is less than TEMP_THRESHOLD degrees, let's immediately return OK.
     if (fabs(temperature - TemperatureNP[0].getValue()) < TEMP_THRESHOLD)
         return 1;

--- a/indi-mi/mi_ccd.cpp
+++ b/indi-mi/mi_ccd.cpp
@@ -496,6 +496,35 @@ int MICCD::SetTemperature(double temperature)
     return 0;
 }
 
+bool MICCD::SetCoolerEnabled(bool enable)
+{
+    if (isSimulation())
+    {
+        if (!enable)
+        {
+            CoolerSP.s = IPS_IDLE;
+            IDSetSwitch(&CoolerSP, nullptr);
+        }
+        return true;
+    }
+
+    double temp = enable ? TemperatureRequest : TEMP_COOLER_OFF;
+    if (gxccd_set_temperature(cameraHandle, temp) < 0)
+    {
+        char errorStr[MAX_ERROR_LEN];
+        gxccd_get_last_error(cameraHandle, errorStr, sizeof(errorStr));
+        LOGF_ERROR("Setting temperature failed: %s.", errorStr);
+        return false;
+    }
+
+    if (!enable)
+    {
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
+    return true;
+}
+
 bool MICCD::StartExposure(float duration)
 {
     imageFrameType = PrimaryCCD.getFrameType();
@@ -791,21 +820,25 @@ bool MICCD::ISNewSwitch(const char *dev, const char *name, ISState *states, char
         }
         else if (!strcmp(name, CoolerSP.name))
         {
-
             IUUpdateSwitch(&CoolerSP, states, names, n);
-            CoolerSP.s = IPS_OK;
 
-            if (HasCooler() && !isSimulation())
+            if (HasCooler())
             {
                 bool on = !IUFindOnSwitchIndex(&CoolerSP);
-                double temp = on ? TemperatureRequest : TEMP_COOLER_OFF;
 
-                if (gxccd_set_temperature(cameraHandle, temp) < 0)
+                if (on)
                 {
-                    char errorStr[MAX_ERROR_LEN];
-                    gxccd_get_last_error(cameraHandle, errorStr, sizeof(errorStr));
-                    LOGF_ERROR("Setting temperature failed: %s.", errorStr);
-                    CoolerSP.s = IPS_ALERT;
+                    cancelCoolerWarmup();
+                    CoolerSP.s = IPS_OK;
+                    if (SetCoolerEnabled(true))
+                        resumeCoolingAfterWarmup();
+                    else
+                        CoolerSP.s = IPS_ALERT;
+                }
+                else
+                {
+                    CoolerSP.s = IPS_BUSY;
+                    beginCoolerWarmup(TemperatureNP[0].getValue());
                 }
             }
 
@@ -966,6 +999,7 @@ void MICCD::updateTemperature()
     }
 
     TemperatureNP[0].setValue(ccdtemp);
+    coolerWarmupTick(ccdtemp);
     CoolerN[0].value      = ccdpower * 100.0;
 
     //    if (TemperatureNP.s == IPS_BUSY && fabs(TemperatureN[0].value - TemperatureRequest) <= TEMP_THRESHOLD)

--- a/indi-mi/mi_ccd.h
+++ b/indi-mi/mi_ccd.h
@@ -41,7 +41,7 @@ class MICCD : public INDI::CCD, public INDI::FilterInterface
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;

--- a/indi-mi/mi_ccd.h
+++ b/indi-mi/mi_ccd.h
@@ -42,6 +42,7 @@ class MICCD : public INDI::CCD, public INDI::FilterInterface
         virtual bool Disconnect() override;
 
         virtual int SetTemperature(double temperature) override;
+        virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
 

--- a/indi-nightscape/nightscape.cpp
+++ b/indi-nightscape/nightscape.cpp
@@ -399,8 +399,9 @@ bool NightscapeCCD::AbortExposure()
 /**************************************************************************************
 ** Client is asking us to set a new temperature
 ***************************************************************************************/
-int NightscapeCCD::SetTemperature(double temperature)
+int NightscapeCCD::SetTemperature(double temperature, bool enableCooler)
 {
+    INDI_UNUSED(enableCooler);
     setTemp = TemperatureRequest = temperature;
     m->sendtemp(setTemp, cooler);
     dn->setSetTemp(setTemp);

--- a/indi-nightscape/nightscape.cpp
+++ b/indi-nightscape/nightscape.cpp
@@ -411,6 +411,25 @@ int NightscapeCCD::SetTemperature(double temperature)
 }
 
 /**************************************************************************************
+** Base class requests hardware cooler enable/disable (called by warm-up machinery)
+***************************************************************************************/
+bool NightscapeCCD::SetCoolerEnabled(bool enable)
+{
+    cooler = enable;
+    LOGF_INFO("Cooler is now %s", enable ? "ON" : "OFF");
+    m->sendtemp(setTemp, cooler);
+    dn->setActTemp(currentCCDTemperature.getValue());
+    if (!enable)
+    {
+        IUResetSwitch(&CoolerSP);
+        CoolerS[1].s = ISS_ON; // COOLER_OFF switch active
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
+    return true;
+}
+
+/**************************************************************************************
 ** How much longer until exposure is done?
 ***************************************************************************************/
 float NightscapeCCD::CalcTimeLeft(timeval start, float req)
@@ -521,6 +540,7 @@ void NightscapeCCD::TimerHit()
             }
             ntemps++;
             dn->setActTemp(currentCCDTemperature.getValue());
+            coolerWarmupTick(currentCCDTemperature.getValue());
 
             /* If target temperature is higher, then increase current CCD temperature */
             //            if (fabs(currentCCDTemperature - TemperatureRequest)  < 0.1)
@@ -624,12 +644,23 @@ bool NightscapeCCD::ISNewSwitch (const char *dev, const char *name, ISState *sta
                 return true;
             }
             IUUpdateSwitch(&CoolerSP, states, names, n);
-            cooler = !IUFindOnSwitchIndex(&CoolerSP);
-            LOGF_INFO( "Cooler is now %s", CoolerS[!cooler].label);
-            CoolerSP.s = IPS_OK;
-            IDSetSwitch(&CoolerSP, nullptr);
-            m->sendtemp(setTemp, cooler);
-            dn->setActTemp(currentCCDTemperature.getValue());
+            bool turningOn = !strcmp(actionName, CoolerS[0].name); // CoolerS[0] = COOLER_ON
+            if (turningOn)
+            {
+                cancelCoolerWarmup();
+                CoolerSP.s = IPS_BUSY;
+                IDSetSwitch(&CoolerSP, nullptr);
+                if (SetCoolerEnabled(true))
+                {
+                    resumeCoolingAfterWarmup();
+                }
+            }
+            else
+            {
+                CoolerSP.s = IPS_BUSY;
+                beginCoolerWarmup(currentCCDTemperature.getValue());
+                IDSetSwitch(&CoolerSP, nullptr);
+            }
             return true;
 
         }

--- a/indi-nightscape/nightscape.h
+++ b/indi-nightscape/nightscape.h
@@ -53,7 +53,7 @@ class NightscapeCCD : public INDI::CCD
     // CCD specific functions
     bool StartExposure(float duration) override;
     bool AbortExposure() override;
-    int SetTemperature(double temperature) override;
+    int SetTemperature(double temperature, bool enableCooler = false) override;
     bool SetCoolerEnabled(bool enable) override;
     void TimerHit() override;
     bool saveConfigItems(FILE *fp) override;

--- a/indi-nightscape/nightscape.h
+++ b/indi-nightscape/nightscape.h
@@ -54,6 +54,7 @@ class NightscapeCCD : public INDI::CCD
     bool StartExposure(float duration) override;
     bool AbortExposure() override;
     int SetTemperature(double temperature) override;
+    bool SetCoolerEnabled(bool enable) override;
     void TimerHit() override;
     bool saveConfigItems(FILE *fp) override;
 

--- a/indi-orion-ssg3/orion_ssg3_ccd.cpp
+++ b/indi-orion-ssg3/orion_ssg3_ccd.cpp
@@ -342,17 +342,22 @@ bool SSG3CCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 CoolerSP.apply();
                 return true;
             }
-            CoolerSP.update(states, names, n);
-            CoolerSP.setState(IPS_OK);
-            CoolerSP.apply();
 
             if (CoolerSP[0].getState() == ISS_OFF)
             {
-                activateCooler(false);
+                // Cooler is being turned off – begin gradual warm-up
+                CoolerSP.setState(IPS_BUSY);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                CoolerSP.apply();
             }
             else
             {
-                activateCooler(true);
+                // Cooler is being turned on – cancel any ongoing warm-up
+                cancelCoolerWarmup();
+                if (SetCoolerEnabled(true))
+                {
+                    resumeCoolingAfterWarmup();
+                }
             }
 
             return true;
@@ -440,7 +445,7 @@ int SSG3CCD::SetTemperature(double temperature)
     if (std::abs(temperature - TemperatureNP[0].getValue()) < TEMP_THRESHOLD)
         return 1;
 
-    if (!activateCooler(true))
+    if (!SetCoolerEnabled(true))
     {
         return -1;
     }
@@ -448,11 +453,10 @@ int SSG3CCD::SetTemperature(double temperature)
     return 0;
 }
 
-bool SSG3CCD::activateCooler(bool enable)
+bool SSG3CCD::SetCoolerEnabled(bool enable)
 {
     int rc;
 
-    CoolerSP.reset();
     if (enable)
     {
         rc = orion_ssg3_set_temperature(&ssg3, TemperatureRequest);
@@ -464,9 +468,15 @@ bool SSG3CCD::activateCooler(bool enable)
             return false;
         }
 
-        CoolerSP[COOLER_ON].setState(ISS_ON);
-        CoolerSP[COOLER_OFF].setState(ISS_OFF);
-        CoolerSP.setState(IPS_OK);
+        // Only flip the switch to ON when not in a warm-up sequence.  During warm-up the switch
+        // stays BUSY+OFF until SetCoolerEnabled(false) finishes the ramp.
+        if (!m_CoolerWarmingUp)
+        {
+            CoolerSP.reset();
+            CoolerSP[COOLER_ON].setState(ISS_ON);
+            CoolerSP.setState(IPS_BUSY);
+            CoolerSP.apply();
+        }
     }
     else
     {
@@ -479,12 +489,11 @@ bool SSG3CCD::activateCooler(bool enable)
             return false;
         }
 
-        CoolerSP[COOLER_ON].setState(ISS_OFF);
+        CoolerSP.reset();
         CoolerSP[COOLER_OFF].setState(ISS_ON);
         CoolerSP.setState(IPS_IDLE);
+        CoolerSP.apply();
     }
-
-    CoolerSP.apply();
     return true;
 }
 
@@ -505,6 +514,8 @@ void SSG3CCD::updateTemperature(void)
         TemperatureNP.setState(IPS_OK);
     }
     TemperatureNP.apply();
+
+    coolerWarmupTick(TemperatureNP[0].getValue());
 
     if (CoolerSP[COOLER_ON].getState() == ISS_ON)
     {

--- a/indi-orion-ssg3/orion_ssg3_ccd.cpp
+++ b/indi-orion-ssg3/orion_ssg3_ccd.cpp
@@ -436,7 +436,7 @@ void SSG3CCD::grabImage()
 /**
  * Set the CCD temperature
  */
-int SSG3CCD::SetTemperature(double temperature)
+int SSG3CCD::SetTemperature(double temperature, bool enableCooler)
 {
     LOGF_INFO("Setting temperature to %.2f C.", temperature);
 
@@ -445,7 +445,7 @@ int SSG3CCD::SetTemperature(double temperature)
     if (std::abs(temperature - TemperatureNP[0].getValue()) < TEMP_THRESHOLD)
         return 1;
 
-    if (!SetCoolerEnabled(true))
+    if (enableCooler && !SetCoolerEnabled(true))
     {
         return -1;
     }

--- a/indi-orion-ssg3/orion_ssg3_ccd.h
+++ b/indi-orion-ssg3/orion_ssg3_ccd.h
@@ -54,6 +54,7 @@ class SSG3CCD : public INDI::CCD
     virtual bool AbortExposure() override;
     virtual void TimerHit() override;
     virtual int SetTemperature(double temperature) override;
+    virtual bool SetCoolerEnabled(bool enable) override;
     // Guide Port
     virtual IPState GuideNorth(uint32_t ms) override;
     virtual IPState GuideSouth(uint32_t ms) override;
@@ -69,7 +70,6 @@ class SSG3CCD : public INDI::CCD
     // Utility functions
     void setupParams();
     void grabImage();
-    bool activateCooler(bool enable);
     void updateTemperature(void);
 
 

--- a/indi-orion-ssg3/orion_ssg3_ccd.h
+++ b/indi-orion-ssg3/orion_ssg3_ccd.h
@@ -53,7 +53,7 @@ class SSG3CCD : public INDI::CCD
     virtual bool StartExposure(float duration) override;
     virtual bool AbortExposure() override;
     virtual void TimerHit() override;
-    virtual int SetTemperature(double temperature) override;
+    virtual int SetTemperature(double temperature, bool enableCooler = false) override;
     virtual bool SetCoolerEnabled(bool enable) override;
     // Guide Port
     virtual IPState GuideNorth(uint32_t ms) override;

--- a/indi-playerone/playerone_base.cpp
+++ b/indi-playerone/playerone_base.cpp
@@ -1094,27 +1094,26 @@ bool POABase::setVideoFormat(uint8_t index)
     return true;
 }
 
-int POABase::SetTemperature(double temperature)
+int POABase::SetTemperature(double temperature, bool enableCooler)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
-    // #PS: how will it warm up?
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (!SetCoolerEnabled(true))
+    if (enableCooler)
     {
-        LOG_ERROR("Failed to activate cooler.");
-        return -1;
-    }
-
-    // Only update the switch display when not in a warm-up sequence (during warm-up, CoolerSP
-    // stays BUSY with OFF selected until SetCoolerEnabled(false) finalises the sequence).
-    if (!m_CoolerWarmingUp && CoolerSP.getState() != IPS_BUSY)
-    {
-        CoolerSP[0].setState(ISS_ON);
-        CoolerSP[1].setState(ISS_OFF);
-        CoolerSP.setState(IPS_BUSY);
-        CoolerSP.apply();
+        if (!SetCoolerEnabled(true))
+        {
+            LOG_ERROR("Failed to activate cooler.");
+            return -1;
+        }
+        if (CoolerSP[0].getState() == ISS_OFF)
+        {
+            CoolerSP[0].setState(ISS_ON);
+            CoolerSP[1].setState(ISS_OFF);
+            CoolerSP.setState(IPS_BUSY);
+            CoolerSP.apply();
+        }
     }
 
     POAErrors ret;

--- a/indi-playerone/playerone_base.cpp
+++ b/indi-playerone/playerone_base.cpp
@@ -991,7 +991,24 @@ bool POABase::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 return true;
             }
 
-            activateCooler(CoolerSP[0].getState() == ISS_ON);
+            if (CoolerSP[0].getState() == ISS_ON)
+            {
+                // User wants cooler ON: cancel any ongoing warm-up, enable hardware,
+                // then resume cooling toward the previously saved target.
+                cancelCoolerWarmup();
+                CoolerSP.setState(IPS_BUSY);
+                if (SetCoolerEnabled(true))
+                    resumeCoolingAfterWarmup();
+                CoolerSP.apply();
+            }
+            else
+            {
+                // User wants cooler OFF: begin gradual warm-up.
+                // beginCoolerWarmup() will call SetCoolerEnabled(false) when done.
+                CoolerSP.setState(IPS_BUSY);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                CoolerSP.apply();
+            }
 
             return true;
         }
@@ -1084,10 +1101,20 @@ int POABase::SetTemperature(double temperature)
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (activateCooler(true) == false)
+    if (!SetCoolerEnabled(true))
     {
         LOG_ERROR("Failed to activate cooler.");
         return -1;
+    }
+
+    // Only update the switch display when not in a warm-up sequence (during warm-up, CoolerSP
+    // stays BUSY with OFF selected until SetCoolerEnabled(false) finalises the sequence).
+    if (!m_CoolerWarmingUp && CoolerSP.getState() != IPS_BUSY)
+    {
+        CoolerSP[0].setState(ISS_ON);
+        CoolerSP[1].setState(ISS_OFF);
+        CoolerSP.setState(IPS_BUSY);
+        CoolerSP.apply();
     }
 
     POAErrors ret;
@@ -1127,6 +1154,30 @@ bool POABase::activateCooler(bool enable)
     CoolerSP.apply();
 
     return (ret == POA_OK);
+}
+
+bool POABase::SetCoolerEnabled(bool enable)
+{
+    POAConfigValue confVal;
+    confVal.boolValue = enable ? POA_TRUE : POA_FALSE;
+    POAErrors ret = POASetConfig(mCameraInfo.cameraID, POA_COOLER, confVal, POA_FALSE);
+    if (ret != POA_OK)
+    {
+        CoolerSP.setState(IPS_ALERT);
+        LOGF_ERROR("Failed to set cooler (%s).", Helpers::toString(ret));
+        CoolerSP.apply();
+        return false;
+    }
+
+    if (!enable)
+    {
+        CoolerSP[0].setState(ISS_OFF);
+        CoolerSP[1].setState(ISS_ON);
+        CoolerSP.setState(IPS_IDLE);
+        CoolerSP.apply();
+    }
+
+    return true;
 }
 
 bool POABase::StartExposure(float duration)
@@ -1403,6 +1454,8 @@ void POABase::temperatureTimerTimeout()
     else
     {
         mCurrentTemperature = value;
+        // Drive the base-class warm-up ramp (no-op when not warming up).
+        coolerWarmupTick(mCurrentTemperature);
         // If cooling is active, show goal status
         //        if (CoolerSP[0].getState() == ISS_ON)
         //        {

--- a/indi-playerone/playerone_base.h
+++ b/indi-playerone/playerone_base.h
@@ -53,7 +53,7 @@ class POABase : public INDI::CCD
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
         virtual bool SetCoolerEnabled(bool enable) override;

--- a/indi-playerone/playerone_base.h
+++ b/indi-playerone/playerone_base.h
@@ -56,6 +56,7 @@ class POABase : public INDI::CCD
         virtual int SetTemperature(double temperature) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
+        virtual bool SetCoolerEnabled(bool enable) override;
 
     protected:
 

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -1243,7 +1243,7 @@ bool QHYCCD::setupParams()
     return true;
 }
 
-int QHYCCD::SetTemperature(double temperature)
+int QHYCCD::SetTemperature(double temperature, bool enableCooler)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
     if (fabs(temperature - TemperatureNP[0].getValue()) < UPDATE_THRESHOLD)
@@ -1256,8 +1256,11 @@ int QHYCCD::SetTemperature(double temperature)
 
     SetQHYCCDParam(m_CameraHandle, CONTROL_COOLER, m_TemperatureRequest);
 
-    setCoolerEnabled(m_TemperatureRequest <= TemperatureNP[0].getValue());
-    setCoolerMode(COOLER_AUTOMATIC);
+    if (enableCooler)
+    {
+        setCoolerEnabled(m_TemperatureRequest <= TemperatureNP[0].getValue());
+        setCoolerMode(COOLER_AUTOMATIC);
+    }
     return 0;
 }
 

--- a/indi-qhy/qhy_ccd.cpp
+++ b/indi-qhy/qhy_ccd.cpp
@@ -1656,19 +1656,16 @@ bool QHYCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
 
             bool enabled = (CoolerS[COOLER_ON].s == ISS_ON);
 
-            // If explicitly enabled, we always set temperature to 0
+            // If explicitly enabled, cancel any in-progress warm-up then resume cooling.
             if (enabled)
             {
+                cancelCoolerWarmup();
                 if (HasCoolerAutoMode)
                 {
-                    double targetTemperature = TemperatureNP[0].getValue();
-                    if (targetTemperature > 0)
-                        targetTemperature = 0;
-                    if (SetTemperature(targetTemperature) == 0)
-                    {
-                        TemperatureNP.setState(IPS_BUSY);
-                        TemperatureNP.apply();
-                    }
+                    CoolerSP.s = IPS_BUSY;
+                    IDSetSwitch(&CoolerSP, nullptr);
+                    if (SetCoolerEnabled(true))
+                        resumeCoolingAfterWarmup();
                     return true;
                 }
                 else
@@ -1683,32 +1680,9 @@ bool QHYCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
             }
             else
             {
-                if (HasCoolerManualMode)
-                {
-                    m_PWMRequest = 0;
-                    m_TemperatureRequest = 30;
-                    SetQHYCCDParam(m_CameraHandle, CONTROL_MANULPWM, 0);
-
-                    CoolerSP.s = IPS_IDLE;
-                    IDSetSwitch(&CoolerSP, nullptr);
-
-                    TemperatureNP.setState(IPS_IDLE);
-                    TemperatureNP.apply();
-
-                    setCoolerMode(COOLER_MANUAL);
-                    LOG_INFO("Camera is warming up.");
-                }
-                else
-                {
-                    // Warm up the camera in auto mode
-                    if (SetTemperature(30) == 0)
-                    {
-                        TemperatureNP.setState(IPS_IDLE);
-                        TemperatureNP.apply();
-                    }
-                    LOG_INFO("Camera is warming up.");
-                    return true;
-                }
+                CoolerSP.s = IPS_BUSY;
+                IDSetSwitch(&CoolerSP, nullptr);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
             }
 
             return true;
@@ -2222,6 +2196,54 @@ void QHYCCD::setCoolerEnabled(bool enable)
     IDSetSwitch(&CoolerSP, nullptr);
 }
 
+bool QHYCCD::SetCoolerEnabled(bool enable)
+{
+    if (!enable)
+    {
+        if (HasCoolerManualMode)
+        {
+            m_PWMRequest = 0;
+            m_TemperatureRequest = 30;
+            SetQHYCCDParam(m_CameraHandle, CONTROL_MANULPWM, 0);
+        }
+        else
+        {
+            // Auto-mode only: leave the SDK targeting 30 °C so the hardware idles at ambient.
+            m_TemperatureRequest = 30;
+        }
+
+        IUResetSwitch(&CoolerSP);
+        CoolerS[COOLER_ON].s = ISS_OFF;
+        CoolerS[COOLER_OFF].s = ISS_ON;
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+
+        TemperatureNP.setState(IPS_IDLE);
+        TemperatureNP.apply();
+
+        return true;
+    }
+    else
+    {
+        if (HasCoolerAutoMode)
+        {
+            // Start cooling toward 0 °C by default (or hold current if already below 0).
+            double targetTemperature = TemperatureNP[0].getValue();
+            if (targetTemperature > 0)
+                targetTemperature = 0;
+            m_TemperatureRequest = targetTemperature;
+            m_PWMRequest = -1;
+            SetQHYCCDParam(m_CameraHandle, CONTROL_COOLER, m_TemperatureRequest);
+            setCoolerMode(COOLER_AUTOMATIC);
+
+            TemperatureNP.setState(IPS_BUSY);
+            TemperatureNP.apply();
+        }
+        // CoolerSP is already IPS_BUSY — set by the caller.
+        return true;
+    }
+}
+
 bool QHYCCD::isQHY5PIIC()
 {
     return std::string(m_CamID, 9) == "QHY5PII-C";
@@ -2270,6 +2292,8 @@ void QHYCCD::updateTemperature()
         currentTemperature   = GetQHYCCDParam(m_CameraHandle, CONTROL_CURTEMP);
         currentCoolingPower = GetQHYCCDParam(m_CameraHandle, CONTROL_CURPWM);
     }
+
+    coolerWarmupTick(currentTemperature);
 
     // Only update if above update threshold
     if (std::abs(currentTemperature - TemperatureNP[0].getValue()) > UPDATE_THRESHOLD)

--- a/indi-qhy/qhy_ccd.h
+++ b/indi-qhy/qhy_ccd.h
@@ -66,7 +66,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
     protected:
 
         // Temperature
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;

--- a/indi-qhy/qhy_ccd.h
+++ b/indi-qhy/qhy_ccd.h
@@ -67,6 +67,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
 
         // Temperature
         virtual int SetTemperature(double temperature) override;
+        virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
 

--- a/indi-qsi/qsi_ccd.cpp
+++ b/indi-qsi/qsi_ccd.cpp
@@ -470,7 +470,8 @@ int QSICCD::SetTemperature(double temperature)
     if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
         return 1;
 
-    activateCooler(true);
+    if (!m_CoolerWarmingUp)
+        activateCooler(true);
 
     try
     {
@@ -542,9 +543,17 @@ bool QSICCD::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 return false;
 
             if (CoolerS[0].s == ISS_ON)
+            {
+                cancelCoolerWarmup();
                 activateCooler(true);
+                resumeCoolingAfterWarmup();
+            }
             else
-                activateCooler(false);
+            {
+                CoolerSP.s = IPS_BUSY;
+                IDSetSwitch(&CoolerSP, nullptr);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+            }
 
             return true;
         }
@@ -1124,6 +1133,59 @@ void QSICCD::activateCooler(bool enable)
     }
 }
 
+bool QSICCD::SetCoolerEnabled(bool enable)
+{
+    bool coolerOn;
+
+    if (enable)
+    {
+        try
+        {
+            QSICam.get_CoolerOn(&coolerOn);
+        }
+        catch (std::runtime_error &err)
+        {
+            LOGF_ERROR("Error: CoolerOn() failed. %s.", err.what());
+            return false;
+        }
+
+        if (!coolerOn)
+        {
+            try
+            {
+                QSICam.put_CoolerOn(true);
+            }
+            catch (std::runtime_error &err)
+            {
+                LOGF_ERROR("Error: put_CoolerOn(true) failed. %s.", err.what());
+                return false;
+            }
+        }
+    }
+    else
+    {
+        try
+        {
+            QSICam.get_CoolerOn(&coolerOn);
+            if (coolerOn)
+                QSICam.put_CoolerOn(false);
+        }
+        catch (std::runtime_error &err)
+        {
+            LOGF_ERROR("Error: CoolerOn() failed. %s.", err.what());
+            return false;
+        }
+
+        CoolerS[0].s = ISS_OFF;
+        CoolerS[1].s = ISS_ON;
+        CoolerSP.s   = IPS_IDLE;
+        LOG_INFO("Cooler is OFF.");
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
+
+    return true;
+}
+
 void QSICCD::shutterControl()
 {
     bool hasShutter;
@@ -1282,6 +1344,8 @@ void QSICCD::TimerHit()
         case IPS_ALERT:
             break;
     }
+
+    coolerWarmupTick(TemperatureNP[0].getValue());
 
     switch (CoolerNP.s)
     {

--- a/indi-qsi/qsi_ccd.cpp
+++ b/indi-qsi/qsi_ccd.cpp
@@ -445,7 +445,7 @@ bool QSICCD::setupParams()
     return true;
 }
 
-int QSICCD::SetTemperature(double temperature)
+int QSICCD::SetTemperature(double temperature, bool enableCooler)
 {
     bool canSetTemp;
     try
@@ -470,7 +470,7 @@ int QSICCD::SetTemperature(double temperature)
     if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
         return 1;
 
-    if (!m_CoolerWarmingUp)
+    if (enableCooler)
         activateCooler(true);
 
     try

--- a/indi-qsi/qsi_ccd.h
+++ b/indi-qsi/qsi_ccd.h
@@ -60,6 +60,7 @@ protected:
     bool Disconnect() override;
 
     int SetTemperature(double temperature) override;
+    bool SetCoolerEnabled(bool enable) override;
     bool StartExposure(float duration) override;
     bool AbortExposure() override;
 

--- a/indi-qsi/qsi_ccd.h
+++ b/indi-qsi/qsi_ccd.h
@@ -59,7 +59,7 @@ protected:
     bool Connect() override;
     bool Disconnect() override;
 
-    int SetTemperature(double temperature) override;
+    int SetTemperature(double temperature, bool enableCooler = false) override;
     bool SetCoolerEnabled(bool enable) override;
     bool StartExposure(float duration) override;
     bool AbortExposure() override;

--- a/indi-sbig/sbig_ccd.cpp
+++ b/indi-sbig/sbig_ccd.cpp
@@ -679,19 +679,28 @@ bool SBIGCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
         {
             IUUpdateSwitch(&CoolerSP, states, names, n);
             bool coolerON = CoolerS[0].s == ISS_ON;
-            if (SetTemperatureRegulation(TemperatureNP[0].getValue(), coolerON) == CE_NO_ERROR)
+            if (coolerON)
             {
-                CoolerSP.s = coolerON ? IPS_OK : IPS_IDLE;
-                LOGF_INFO("Cooler turned %s.", coolerON ? "On" : "Off");
+                cancelCoolerWarmup();
+                if (SetCoolerEnabled(true))
+                {
+                    CoolerSP.s = IPS_BUSY;
+                    IDSetSwitch(&CoolerSP, nullptr);
+                    resumeCoolingAfterWarmup();
+                    return true;
+                }
+                CoolerSP.s = IPS_ALERT;
+                LOG_ERROR("Failed to control cooler.");
                 IDSetSwitch(&CoolerSP, nullptr);
-
+                return false;
+            }
+            else
+            {
+                CoolerSP.s = IPS_BUSY;
+                IDSetSwitch(&CoolerSP, nullptr);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
                 return true;
             }
-
-            CoolerSP.s = IPS_ALERT;
-            LOG_ERROR("Failed to control cooler.");
-            IDSetSwitch(&CoolerSP, nullptr);
-            return false;
         }
         // AO Center
         else if (!strcmp(name, CenterSP.name))
@@ -1030,7 +1039,7 @@ int SBIGCCD::SetTemperature(double temperature)
         // Set property to busy and poll in ISPoll for CCD temp
         TemperatureRequest = temperature;
         LOGF_INFO("Temperature set to %+.1fC", temperature);
-        if (CoolerS[0].s != ISS_ON)
+        if (!m_CoolerWarmingUp && CoolerS[0].s != ISS_ON)
         {
             CoolerS[0].s = ISS_ON;
             CoolerS[1].s = ISS_OFF;
@@ -1041,6 +1050,22 @@ int SBIGCCD::SetTemperature(double temperature)
     }
     LOG_ERROR("Failed to set temperature");
     return -1;
+}
+
+bool SBIGCCD::SetCoolerEnabled(bool enable)
+{
+    if (SetTemperatureRegulation(TemperatureNP[0].getValue(), enable) == CE_NO_ERROR)
+    {
+        if (!enable)
+        {
+            CoolerSP.s = IPS_IDLE;
+            IDSetSwitch(&CoolerSP, nullptr);
+        }
+        LOGF_INFO("Cooler turned %s.", enable ? "On" : "Off");
+        return true;
+    }
+    LOG_ERROR("Failed to control cooler.");
+    return false;
 }
 
 int SBIGCCD::StartExposure(INDI::CCDChip *targetChip, double duration)
@@ -2540,6 +2565,7 @@ void SBIGCCD::updateTemperature()
             LOGF_DEBUG("CCD temperature %+.1f [C], TE cooler: %.1f [%%].", ccdTemp, power);
         }
         TemperatureNP[0].setValue(ccdTemp);
+        coolerWarmupTick(ccdTemp);
         // Check the TE cooler if inside the range:
         if (power <= CCD_COOLER_THRESHOLD)
         {

--- a/indi-sbig/sbig_ccd.cpp
+++ b/indi-sbig/sbig_ccd.cpp
@@ -1030,7 +1030,7 @@ bool SBIGCCD::setupParams()
     return true;
 }
 
-int SBIGCCD::SetTemperature(double temperature)
+int SBIGCCD::SetTemperature(double temperature, bool enableCooler)
 {
     if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
         return 1;
@@ -1039,7 +1039,7 @@ int SBIGCCD::SetTemperature(double temperature)
         // Set property to busy and poll in ISPoll for CCD temp
         TemperatureRequest = temperature;
         LOGF_INFO("Temperature set to %+.1fC", temperature);
-        if (!m_CoolerWarmingUp && CoolerS[0].s != ISS_ON)
+        if (enableCooler && CoolerS[0].s != ISS_ON)
         {
             CoolerS[0].s = ISS_ON;
             CoolerS[1].s = ISS_OFF;

--- a/indi-sbig/sbig_ccd.h
+++ b/indi-sbig/sbig_ccd.h
@@ -161,6 +161,7 @@ class SBIGCCD : public INDI::CCD, public INDI::FilterInterface
 
         virtual void TimerHit() override;
         virtual int SetTemperature(double temperature) override;
+        virtual bool SetCoolerEnabled(bool enable) override;
 
 
         virtual bool saveConfigItems(FILE *fp) override;

--- a/indi-sbig/sbig_ccd.h
+++ b/indi-sbig/sbig_ccd.h
@@ -160,7 +160,7 @@ class SBIGCCD : public INDI::CCD, public INDI::FilterInterface
 #endif
 
         virtual void TimerHit() override;
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool SetCoolerEnabled(bool enable) override;
 
 

--- a/indi-svbony/svbony_base.cpp
+++ b/indi-svbony/svbony_base.cpp
@@ -941,7 +941,18 @@ bool SVBONYBase::ISNewSwitch(const char *dev, const char *name, ISState *states,
                 return true;
             }
 
-            activateCooler(CoolerSP[0].getState() == ISS_ON);
+            if (CoolerSP[0].getState() == ISS_ON)
+            {
+                cancelCoolerWarmup();
+                if (activateCooler(true))
+                    resumeCoolingAfterWarmup();
+            }
+            else
+            {
+                CoolerSP.setState(IPS_BUSY);
+                beginCoolerWarmup(TemperatureNP[0].getValue());
+                CoolerSP.apply();
+            }
 
             return true;
         }
@@ -1003,14 +1014,26 @@ bool SVBONYBase::setVideoFormat(uint8_t index)
 int SVBONYBase::SetTemperature(double temperature)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
-    // #PS: how will it warm up?
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    if (activateCooler(true) == false)
+    // Enable the hardware TEC without touching CoolerSP; the caller is responsible for the
+    // switch presentation (e.g. during warm-up the switch stays in the OFF+BUSY state).
+    if (!SetCoolerEnabled(true))
     {
         LOG_ERROR("Failed to activate cooler.");
         return -1;
+    }
+
+    // Update CoolerSP only when we are not in a warm-up sequence.
+    // During warm-up, CoolerSP is already IPS_BUSY with OFF selected; flipping it back to
+    // ON+BUSY here would confuse the user.
+    if (!m_CoolerWarmingUp && CoolerSP.getState() != IPS_BUSY)
+    {
+        CoolerSP[0].setState(ISS_ON);
+        CoolerSP[1].setState(ISS_OFF);
+        CoolerSP.setState(IPS_BUSY);
+        CoolerSP.apply();
     }
 
     SVB_ERROR_CODE ret;
@@ -1029,23 +1052,47 @@ int SVBONYBase::SetTemperature(double temperature)
     return 0;
 }
 
-bool SVBONYBase::activateCooler(bool enable)
+bool SVBONYBase::SetCoolerEnabled(bool enable)
 {
-    SVB_ERROR_CODE ret = SVBSetControlValue(mCameraInfo.CameraID, SVB_COOLER_ENABLE, enable ? SVB_TRUE : SVB_FALSE, SVB_FALSE);
+    SVB_ERROR_CODE ret = SVBSetControlValue(mCameraInfo.CameraID, SVB_COOLER_ENABLE,
+                                            enable ? SVB_TRUE : SVB_FALSE, SVB_FALSE);
     if (ret != SVB_SUCCESS)
     {
-        CoolerSP.setState(IPS_ALERT);
-        LOGF_ERROR("Failed to activate cooler (%s).", Helpers::toString(ret));
+        LOGF_ERROR("Failed to set cooler enabled (%s).", Helpers::toString(ret));
+        return false;
     }
-    else
-    {
-        CoolerSP[0].setState(enable ? ISS_ON  : ISS_OFF);
-        CoolerSP[1].setState(enable ? ISS_OFF : ISS_ON);
-        CoolerSP.setState(enable ? IPS_BUSY : IPS_IDLE);
-    }
-    CoolerSP.apply();
 
-    return (ret == SVB_SUCCESS);
+    if (!enable)
+    {
+        CoolerSP[0].setState(ISS_OFF);
+        CoolerSP[1].setState(ISS_ON);
+        CoolerSP.setState(IPS_IDLE);
+        CoolerSP.apply();
+    }
+    // When enabling, leave CoolerSP for the caller to update (e.g. activateCooler or ISNewSwitch).
+
+    return true;
+}
+
+bool SVBONYBase::activateCooler(bool enable)
+{
+    bool success = SetCoolerEnabled(enable);
+    if (!success)
+    {
+        CoolerSP.setState(IPS_ALERT);
+        CoolerSP.apply();
+    }
+    else if (enable)
+    {
+        // SetCoolerEnabled(true) intentionally leaves CoolerSP alone; set it here.
+        CoolerSP[0].setState(ISS_ON);
+        CoolerSP[1].setState(ISS_OFF);
+        CoolerSP.setState(IPS_BUSY);
+        CoolerSP.apply();
+    }
+    // If !enable, SetCoolerEnabled already updated CoolerSP to IPS_IDLE.
+
+    return success;
 }
 
 bool SVBONYBase::StartExposure(float duration)
@@ -1194,6 +1241,7 @@ void SVBONYBase::temperatureTimerTimeout()
     else
     {
         mCurrentTemperature = value / 10.0;
+        coolerWarmupTick(mCurrentTemperature);
     }
 
     // Update if there is a change

--- a/indi-svbony/svbony_base.cpp
+++ b/indi-svbony/svbony_base.cpp
@@ -1011,29 +1011,26 @@ bool SVBONYBase::setVideoFormat(uint8_t index)
     return true;
 }
 
-int SVBONYBase::SetTemperature(double temperature)
+int SVBONYBase::SetTemperature(double temperature, bool enableCooler)
 {
     // If there difference, for example, is less than 0.1 degrees, let's immediately return OK.
     if (std::abs(temperature - mCurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    // Enable the hardware TEC without touching CoolerSP; the caller is responsible for the
-    // switch presentation (e.g. during warm-up the switch stays in the OFF+BUSY state).
-    if (!SetCoolerEnabled(true))
+    if (enableCooler)
     {
-        LOG_ERROR("Failed to activate cooler.");
-        return -1;
-    }
-
-    // Update CoolerSP only when we are not in a warm-up sequence.
-    // During warm-up, CoolerSP is already IPS_BUSY with OFF selected; flipping it back to
-    // ON+BUSY here would confuse the user.
-    if (!m_CoolerWarmingUp && CoolerSP.getState() != IPS_BUSY)
-    {
-        CoolerSP[0].setState(ISS_ON);
-        CoolerSP[1].setState(ISS_OFF);
-        CoolerSP.setState(IPS_BUSY);
-        CoolerSP.apply();
+        if (!SetCoolerEnabled(true))
+        {
+            LOG_ERROR("Failed to activate cooler.");
+            return -1;
+        }
+        if (CoolerSP[0].getState() == ISS_OFF)
+        {
+            CoolerSP[0].setState(ISS_ON);
+            CoolerSP[1].setState(ISS_OFF);
+            CoolerSP.setState(IPS_BUSY);
+            CoolerSP.apply();
+        }
     }
 
     SVB_ERROR_CODE ret;

--- a/indi-svbony/svbony_base.h
+++ b/indi-svbony/svbony_base.h
@@ -59,7 +59,7 @@ class SVBONYBase : public INDI::CCD
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
 

--- a/indi-svbony/svbony_base.h
+++ b/indi-svbony/svbony_base.h
@@ -89,6 +89,9 @@ class SVBONYBase : public INDI::CCD
 
         virtual bool SetCaptureFormat(uint8_t index) override;
 
+        /** Toggle the hardware TEC.  Called by the base-class warm-up machinery. */
+        virtual bool SetCoolerEnabled(bool enable) override;
+
         /** Get the current Bayer string used */
         const char *getBayerString() const;
 

--- a/indi-sx/sxccd.cpp
+++ b/indi-sx/sxccd.cpp
@@ -363,9 +363,10 @@ void SXCCD::TimerHit()
         {
             unsigned char status;
             unsigned short temperature;
-            sxSetCooler(handle, (unsigned char)(CoolerS[0].s == ISS_ON),
+            sxSetCooler(handle, (unsigned char)m_CoolerEnabled,
                         (unsigned short)(TemperatureRequest * 10 + 2730), &status, &temperature);
             TemperatureNP[0].setValue((temperature - 2730) / 10.0);
+            coolerWarmupTick(TemperatureNP[0].getValue());
             if (TemperatureReported != TemperatureNP[0].getValue())
             {
                 TemperatureReported = TemperatureNP[0].getValue();
@@ -389,11 +390,12 @@ int SXCCD::SetTemperature(double temperature)
 {
     int result         = 0;
     TemperatureRequest = temperature;
+    m_CoolerEnabled    = true;
     unsigned char status;
     unsigned short sx_temperature;
-    sxSetCooler(handle, (unsigned char)(CoolerS[0].s == ISS_ON), (unsigned short)(TemperatureRequest * 10 + 2730),
+    sxSetCooler(handle, 1, (unsigned short)(TemperatureRequest * 10 + 2730),
                 &status, &sx_temperature);
-    TemperatureReported =(sx_temperature - 2730) / 10.0;
+    TemperatureReported = (sx_temperature - 2730) / 10.0;
     TemperatureNP[0].setValue((sx_temperature - 2730) / 10.0);
 
     if (std::fabs(TemperatureRequest - TemperatureReported) < 1)
@@ -401,12 +403,36 @@ int SXCCD::SetTemperature(double temperature)
     else
         result = 0;
 
-    CoolerSP.s   = IPS_OK;
-    CoolerS[0].s = ISS_ON;
-    CoolerS[1].s = ISS_OFF;
-    IDSetSwitch(&CoolerSP, nullptr);
+    // Only update cooler switch state when not already in an active/warmup state.
+    if (CoolerSP.s == IPS_IDLE)
+    {
+        CoolerSP.s   = IPS_BUSY;
+        CoolerS[0].s = ISS_ON;
+        CoolerS[1].s = ISS_OFF;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
 
     return result;
+}
+
+bool SXCCD::SetCoolerEnabled(bool enable)
+{
+    m_CoolerEnabled = enable;
+    unsigned char status;
+    unsigned short temperature;
+    sxSetCooler(handle, (unsigned char)enable, (unsigned short)(TemperatureRequest * 10 + 2730),
+                &status, &temperature);
+    TemperatureReported = (temperature - 2730) / 10.0;
+    TemperatureNP[0].setValue((temperature - 2730) / 10.0);
+    TemperatureNP.setState(IPS_OK);
+    TemperatureNP.apply();
+
+    if (!enable)
+    {
+        CoolerSP.s = IPS_IDLE;
+        IDSetSwitch(&CoolerSP, nullptr);
+    }
+    return true;
 }
 
 bool SXCCD::StartExposure(float n)
@@ -767,17 +793,22 @@ bool SXCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, char
     else if (strcmp(name, CoolerSP.name) == 0)
     {
         IUUpdateSwitch(&CoolerSP, states, names, n);
-        CoolerSP.s = IPS_OK;
-        IDSetSwitch(&CoolerSP, nullptr);
-        unsigned char status;
-        unsigned short temperature;
-        sxSetCooler(handle, (unsigned char)(CoolerS[0].s == ISS_ON), (unsigned short)(TemperatureRequest * 10 + 2730),
-                    &status, &temperature);
-        TemperatureReported = (temperature - 2730) / 10.0;
-        TemperatureNP[0].setValue((temperature - 2730) / 10.0);
-
-        TemperatureNP.setState(IPS_OK);
-        TemperatureNP.apply();
+        if (CoolerS[0].s == ISS_ON)
+        {
+            // Cooler ON: cancel any in-progress warm-up, then enable hardware.
+            cancelCoolerWarmup();
+            CoolerSP.s = IPS_BUSY;
+            IDSetSwitch(&CoolerSP, nullptr);
+            if (SetCoolerEnabled(true))
+                resumeCoolingAfterWarmup();
+        }
+        else
+        {
+            // Cooler OFF: start gradual warm-up; base class calls SetCoolerEnabled(false) when done.
+            CoolerSP.s = IPS_BUSY;
+            IDSetSwitch(&CoolerSP, nullptr);
+            beginCoolerWarmup(TemperatureNP[0].getValue());
+        }
         result = true;
     }
     //    else if (strcmp(name, BayerSP.name) == 0)

--- a/indi-sx/sxccd.cpp
+++ b/indi-sx/sxccd.cpp
@@ -386,7 +386,7 @@ void SXCCD::TimerHit()
         SetTimer(TIMER);
 }
 
-int SXCCD::SetTemperature(double temperature)
+int SXCCD::SetTemperature(double temperature, bool enableCooler)
 {
     int result         = 0;
     TemperatureRequest = temperature;
@@ -404,7 +404,7 @@ int SXCCD::SetTemperature(double temperature)
         result = 0;
 
     // Only update cooler switch state when not already in an active/warmup state.
-    if (CoolerSP.s == IPS_IDLE)
+    if (enableCooler && CoolerSP.s == IPS_IDLE)
     {
         CoolerSP.s   = IPS_BUSY;
         CoolerS[0].s = ISS_ON;

--- a/indi-sx/sxccd.h
+++ b/indi-sx/sxccd.h
@@ -79,7 +79,7 @@ class SXCCD : public INDI::CCD
         bool UpdateCCDBin(int hor, int ver);
         bool Connect();
         bool Disconnect();
-        int SetTemperature(double temperature);
+        int SetTemperature(double temperature, bool enableCooler = false);
         bool SetCoolerEnabled(bool enable);
         bool StartExposure(float n);
         bool AbortExposure();

--- a/indi-sx/sxccd.h
+++ b/indi-sx/sxccd.h
@@ -68,6 +68,7 @@ class SXCCD : public INDI::CCD
         bool DidGuideLatch;
         bool InGuideExposure;
         char GuideStatus;
+        bool m_CoolerEnabled {false};
 
     protected:
         const char *getDefaultName();
@@ -79,6 +80,7 @@ class SXCCD : public INDI::CCD
         bool Connect();
         bool Disconnect();
         int SetTemperature(double temperature);
+        bool SetCoolerEnabled(bool enable);
         bool StartExposure(float n);
         bool AbortExposure();
         bool StartGuideExposure(float n);

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1183,7 +1183,18 @@ bool ToupBase::ISNewSwitch(const char *dev, const char *name, ISState *states, c
             if (m_CoolerSP.isUpdated(states, names, n))
             {
                 m_CoolerSP.update(states, names, n);
-                activateCooler(m_CoolerSP[INDI_ENABLED].getState() == ISS_ON);
+                if (m_CoolerSP[INDI_ENABLED].getState() == ISS_ON)
+                {
+                    cancelCoolerWarmup();
+                    if (SetCoolerEnabled(true))
+                        resumeCoolingAfterWarmup();
+                }
+                else
+                {
+                    m_CoolerSP.setState(IPS_BUSY);
+                    beginCoolerWarmup(TemperatureNP[0].getValue());
+                    m_CoolerSP.apply();
+                }
             }
             else
             {
@@ -1622,7 +1633,7 @@ bool ToupBase::StopStreaming()
 int ToupBase::SetTemperature(double temperature)
 {
     // JM 2023.11.21: Only activate cooler if the requested temperature is below current temperature
-    if (temperature < TemperatureNP[0].getValue() && activateCooler(true) == false)
+    if (temperature < TemperatureNP[0].getValue() && SetCoolerEnabled(true) == false)
     {
         LOG_ERROR("Failed to toggle cooler.");
         return -1;
@@ -1642,7 +1653,7 @@ int ToupBase::SetTemperature(double temperature)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-bool ToupBase::activateCooler(bool enable)
+bool ToupBase::SetCoolerEnabled(bool enable)
 {
     int val = 0;
     auto isCoolerOn = false;
@@ -1666,19 +1677,28 @@ bool ToupBase::activateCooler(bool enable)
     }
     else
     {
-        m_CoolerSP[enable ? INDI_ENABLED : INDI_DISABLED].setState(ISS_ON);
-        m_CoolerSP.setState(enable ? IPS_BUSY : IPS_IDLE);
-        m_CoolerSP.apply();
-
-        /* turn on TEC may force to turn on the fan */
-        if (enable && (m_Instance->model->flag & CP(FLAG_FAN)))
+        if (enable)
         {
-            int fan = 0;
-            FP(get_Option(m_Handle, CP(OPTION_FAN), &fan));
-            m_FanSP.reset();
-            for (unsigned i = 0; i <= m_Instance->model->maxfanspeed; ++i)
-                m_FanSP[i].setState((fan == static_cast<int>(i)) ? ISS_ON : ISS_OFF);
-            m_FanSP.apply();
+            m_CoolerSP[INDI_ENABLED].setState(ISS_ON);
+            m_CoolerSP.setState(IPS_BUSY);
+            m_CoolerSP.apply();
+
+            /* turn on TEC may force to turn on the fan */
+            if (m_Instance->model->flag & CP(FLAG_FAN))
+            {
+                int fan = 0;
+                FP(get_Option(m_Handle, CP(OPTION_FAN), &fan));
+                m_FanSP.reset();
+                for (unsigned i = 0; i <= m_Instance->model->maxfanspeed; ++i)
+                    m_FanSP[i].setState((fan == static_cast<int>(i)) ? ISS_ON : ISS_OFF);
+                m_FanSP.apply();
+            }
+        }
+        else
+        {
+            m_CoolerSP[INDI_DISABLED].setState(ISS_ON);
+            m_CoolerSP.setState(IPS_IDLE);
+            m_CoolerSP.apply();
         }
 
         return true;
@@ -1885,6 +1905,7 @@ void ToupBase::TimerHit()
             TemperatureNP.setState(IPS_OK);
 
         TemperatureNP[0].setValue(nTemperature / 10.0);
+        coolerWarmupTick(TemperatureNP[0].getValue());
 
         auto threshold = HasCooler() ? 0.1 : 0.2;
 

--- a/indi-toupbase/indi_toupbase.cpp
+++ b/indi-toupbase/indi_toupbase.cpp
@@ -1630,10 +1630,10 @@ bool ToupBase::StopStreaming()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-int ToupBase::SetTemperature(double temperature)
+int ToupBase::SetTemperature(double temperature, bool enableCooler)
 {
     // JM 2023.11.21: Only activate cooler if the requested temperature is below current temperature
-    if (temperature < TemperatureNP[0].getValue() && SetCoolerEnabled(true) == false)
+    if (enableCooler && temperature < TemperatureNP[0].getValue() && SetCoolerEnabled(true) == false)
     {
         LOG_ERROR("Failed to toggle cooler.");
         return -1;

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -59,6 +59,7 @@ class ToupBase : public INDI::CCD
         virtual bool AbortExposure() override;
 
     protected:
+        virtual bool SetCoolerEnabled(bool enable) override;
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
@@ -168,8 +169,6 @@ class ToupBase : public INDI::CCD
         } BINNING_MODE;
 
         INDI::PropertySwitch m_HighFullwellSP {2};
-
-        bool activateCooler(bool enable);
 
         INDI::PropertySwitch m_CoolerSP {2};
 

--- a/indi-toupbase/indi_toupbase.h
+++ b/indi-toupbase/indi_toupbase.h
@@ -54,7 +54,7 @@ class ToupBase : public INDI::CCD
         virtual bool Connect() override;
         virtual bool Disconnect() override;
 
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
 


### PR DESCRIPTION
Previously, switching the Cooler OFF immediately cut TEC power and set
CoolerSP to IPS_IDLE, bypassing the temperature-ramp machinery entirely.
This could cause thermal shock on sensors that were significantly below
ambient temperature.

This commit introduces a full warm-up state machine that mirrors the
existing cooling ramp (driven by TemperatureRampNP RAMP_SLOPE /
RAMP_THRESHOLD in the INDI::CCD base class) and keeps the Cooler switch
in IPS_BUSY until the camera has safely returned to near-ambient
temperature.

New behaviour
─────────────
• Cooler OFF with RAMP_SLOPE = 0 (ramping disabled): unchanged, TEC
  cuts immediately.
• Cooler OFF with RAMP_SLOPE > 0: begins a gradual warm-up toward the
  configurable "Warm Up Target" temperature (CCD_WARMUP_TARGET, default
  25 °C, persisted in the driver config).  CoolerSP stays IPS_BUSY
  (switch shows OFF) until complete.
• Warm-up completion is detected by two independent criteria, whichever
  fires first:
    1. Temperature reading reaches within RAMP_THRESHOLD of the warm-up
       target — handled by the existing INDI::CCD::checkTemperatureTarget()
       override.
    2. Temperature has been stable (changed less than 0.5 °C) for 60 s —
       catches the case where the actual room temperature is below the
       configured warm-up target, so the camera equilibrates below 25 °C
       and would otherwise never cross the threshold.
• Cooler ON during an active warm-up: cancels the warm-up immediately
  and resumes cooling toward the previously set target temperature,
  respecting the ramp slope.
• An explicit temperature request (TemperatureNP) while warming up also
  cancels the warm-up and hands control back to the standard ramp path.

Key implementation details
──────────────────────────
• Split activateCooler() into setCoolerPower() (raw TEC toggle, no UI
  update) and activateCooler() (TEC toggle + CoolerSP state update).
  SetTemperature() calls setCoolerPower() during warm-up so that the
  ~60 s ramp steps driven by m_TemperatureCheckTimer do not flip
  CoolerSP back to ISS_ON/IPS_BUSY on every iteration.
• mSavedCoolingTarget captures m_TargetTemperature (the base-class
  member set by ISNewNumber, holding the user's final cooling setpoint)
  at the start of beginCoolerWarmup(), before it is overwritten with the
  warm-up target.  mTargetTemperature (ASIBase's own member) was
  intentionally not used here because it only tracks the last ramp step,
  not the user's original request.
• ASI TECs are unidirectional (cooling only); TEC power reads 0 % for
  the entire warm-up ramp, so a raw "power idle" check is not a useful
  completion signal.  The stability-based secondary check avoids this
  pitfall.

New property
────────────
CCD_WARMUP_TARGET ("Warm Up Target") — configurable warm-up target
temperature in °C, shown in the main control tab for cooled cameras.
Saved to and restored from the driver configuration file.