### PR TITLE
Libcamera add version info

### DIFF
--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -31,6 +31,8 @@
 #include "core/rpicam_encoder.hpp"
 #include "output/output.hpp"
 
+#include <libcamera/camera_manager.h>
+
 #include <algorithm>
 #include <cmath>
 #include <vector>
@@ -736,6 +738,10 @@ bool INDILibCamera::initProperties()
 
     LOGF_DEBUG("Initializing properties for %s", getDeviceName());
     INDI::CCD::initProperties();
+
+    LibCameraVersionTP[0].fill("VERSION", "Version", libcamera::CameraManager::version().c_str());
+    LibCameraVersionTP.fill(getDeviceName(), "LIBCAMERA_VERSION", "LibCamera", INFO_TAB, IP_RO, 60, IPS_IDLE);
+    registerProperty(LibCameraVersionTP);
 
     // Temperature is read-only (sensor temp, no cooler control).
     // IP_RO causes the base class to include CCD-TEMP in FITS automatically.

--- a/indi-libcamera/indi_libcamera.cpp
+++ b/indi-libcamera/indi_libcamera.cpp
@@ -49,6 +49,8 @@
 
 #define CONTROL_TAB "Controls"
 
+static constexpr const char *DRIVER_NAME = "LibCamera";
+
 namespace
 {
 constexpr const char *HCG_SYSFS =
@@ -99,7 +101,8 @@ INDILibCamera::INDILibCamera(uint8_t index, std::shared_ptr<libcamera::Camera> c
     setVersion(LIBCAMERA_VERSION_MAJOR, LIBCAMERA_VERSION_MINOR);
     signal(SIGBUS, default_signal_handler);
     auto model = m_ControlList.get(properties::Model).value();
-    auto fullName = std::string("LibCamera ")
+    auto fullName = std::string(DRIVER_NAME)
+              + " "
               + std::string(model)
               + "-"
               + std::to_string(index);
@@ -111,7 +114,7 @@ INDILibCamera::INDILibCamera(uint8_t index, std::shared_ptr<libcamera::Camera> c
 /////////////////////////////////////////////////////////////////////////////
 const char *INDILibCamera::getDefaultName()
 {
-    return "LibCamera";
+    return DRIVER_NAME;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/indi-libcamera/indi_libcamera.h
+++ b/indi-libcamera/indi_libcamera.h
@@ -154,6 +154,7 @@ class INDILibCamera : public INDI::CCD
             AdjustAwbRed, AdjustAwbBlue
         };
 
+        INDI::PropertyText  LibCameraVersionTP {1};
         INDI::PropertySwitch AdjustExposureModeSP {0}, AdjustAwbModeSP {0}, AdjustMeteringModeSP {0}, AdjustDenoiseModeSP {0} ;
         INDI::PropertyNumber AdjustmentNP {AdjustAwbBlue + 1};
         INDI::PropertyNumber GainNP {1};


### PR DESCRIPTION
Adds the libcamera library version info to the general device info:

<img width="833" height="958" alt="image" src="https://github.com/user-attachments/assets/bc6eff4c-76ef-42d1-afd4-cb6f08f5c6a4" />
