### PR TITLE
indi-asi: migrate ZWO CAA rotator to HotPlugManager framework

### DIFF
--- a/indi-asi/CMakeLists.txt
+++ b/indi-asi/CMakeLists.txt
@@ -102,7 +102,12 @@ target_link_libraries(indi_asi_focuser ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBR
 ENDIF()
 
 ########### indi_asi_rotator ###########
-add_executable(indi_asi_rotator ${CMAKE_CURRENT_SOURCE_DIR}/asi_rotator.cpp)
+set(indi_asi_rotator_SRCS
+   ${CMAKE_CURRENT_SOURCE_DIR}/asi_rotator.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/asi_rotator_hotplug_handler.cpp
+   )
+
+add_executable(indi_asi_rotator ${indi_asi_rotator_SRCS})
 IF (APPLE)
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework CoreFoundation")
 target_link_libraries(indi_asi_rotator ${INDI_LIBRARIES} ${HIDAPILIB} ${ASI_LIBRARIES} ${LIBUSB_LIBRARIES})

--- a/indi-asi/asi_rotator.cpp
+++ b/indi-asi/asi_rotator.cpp
@@ -20,108 +20,31 @@
 #include "asi_rotator.h"
 #include "config.h"
 
-#include <CAA_API.h>
+#include <hotplugmanager.h>
+#include "asi_rotator_hotplug_handler.h"
+
 #include <inditimer.h>
 #include <map>
+#include <memory>
 
 static class Loader
 {
-        INDI::Timer hotPlugTimer;
-        std::map<int, std::shared_ptr<ASICAA>> rotators;
+        std::shared_ptr<INDI::ASICAAHotPlugHandler> hotPlugHandler;
     public:
         Loader()
         {
-            load(false);
+            hotPlugHandler = std::make_shared<INDI::ASICAAHotPlugHandler>();
+            INDI::HotPlugManager::getInstance().registerHandler(hotPlugHandler);
+            INDI::HotPlugManager::getInstance().start(1000); // Start hot-plug checks every 1 second
         }
-
-    public:
-        static size_t getCountOfConnectedRotators()
-        {
-            return size_t(std::max(CAAGetNum(), 0));
-        }
-
-        static std::vector<CAA_INFO> getConnectedRotators()
-        {
-            std::vector<CAA_INFO> result;
-            int count = getCountOfConnectedRotators();
-            for(int i = 0; i < count; i++)
-            {
-                int id = -1;
-                if (CAAGetID(i, &id) == CAA_SUCCESS)
-                {
-                    CAA_INFO info;
-                    if (CAAGetProperty(id, &info) == CAA_SUCCESS)
-                        result.push_back(info);
-                }
-            }
-            return result;
-        }
-
-    public:
-        void load(bool isHotPlug)
-        {
-            auto usedRotators = std::move(rotators);
-            UniqueName uniqueName(usedRotators);
-
-            for(const auto &rotatorInfo : getConnectedRotators())
-            {
-                int id = rotatorInfo.ID;
-
-                // rotator already created
-                if (usedRotators.find(id) != usedRotators.end())
-                {
-                    std::swap(rotators[id], usedRotators[id]);
-                    continue;
-                }
-
-                CAA_SN serialNumber;
-                std::string serialNumberStr = "";
-                if(CAAGetSerialNumber(id, &serialNumber) == CAA_SUCCESS)
-                {
-                    char snChars[100];
-                    auto &sn = serialNumber;
-                    sprintf(snChars, "%02x%02x%02x%02x%02x%02x%02x%02x", sn.id[0], sn.id[1],
-                            sn.id[2], sn.id[3], sn.id[4], sn.id[5], sn.id[6], sn.id[7]);
-                    snChars[16] = 0;
-                    serialNumberStr = std::string(snChars);
-                }
-
-                ASICAA *asiRotator = new ASICAA(rotatorInfo.ID, uniqueName.make(rotatorInfo));
-                rotators[id] = std::shared_ptr<ASICAA>(asiRotator);
-                if (isHotPlug)
-                    asiRotator->ISGetProperties(nullptr);
-            }
-        }
-
-    public:
-        class UniqueName
-        {
-                std::map<std::string, bool> used;
-            public:
-                UniqueName() = default;
-                UniqueName(const std::map<int, std::shared_ptr<ASICAA>> &usedRotators)
-                {
-                    for (const auto &rotator : usedRotators)
-                        used[rotator.second->getDeviceName()] = true;
-                }
-
-                std::string make(const CAA_INFO &rotatorInfo)
-                {
-                    std::string rotatorName = "ZWO CAA " + std::string(rotatorInfo.Name);
-                    std::string uniqueName = rotatorName;
-
-                    for (int index = 0; used[uniqueName] == true; )
-                        uniqueName = rotatorName + " " + std::to_string(++index);
-
-                    used[uniqueName] = true;
-                    return uniqueName;
-                }
-        };
 } loader;
 
-ASICAA::ASICAA(int ID, const std::string &rotatorName) : m_ID(ID)
+ASICAA::ASICAA(const CAA_INFO &info, const char *name, const std::string &serialNumber)
+    : m_ID(info.ID)
+    , m_Info(info)
+    , m_SerialNumber(serialNumber)
 {
-    setDeviceName(rotatorName.c_str());
+    setDeviceName(name);
 
     setVersion(ASI_VERSION_MAJOR, ASI_VERSION_MINOR);
 

--- a/indi-asi/asi_rotator.h
+++ b/indi-asi/asi_rotator.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <CAA_API.h>
+
 #include <indirotator.h>
 #include <indipropertyswitch.h>
 #include <indipropertynumber.h>
@@ -29,8 +31,26 @@
 class ASICAA : public INDI::Rotator
 {
     public:
-        ASICAA(int ID, const std::string &rotatorName);
+        ASICAA(const CAA_INFO &info, const char *name, const std::string &serialNumber);
         virtual ~ASICAA() = default;
+
+        /**
+         * @brief Returns the CAA_INFO structure for this rotator.
+         * @return The CAA_INFO structure.
+         */
+        const CAA_INFO &getCAAInfo() const
+        {
+            return m_Info;
+        }
+
+        /**
+         * @brief Returns the serial number of the rotator (may be empty).
+         * @return The serial number as a string.
+         */
+        const std::string &getSerialNumber() const
+        {
+            return m_SerialNumber;
+        }
 
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
@@ -55,6 +75,8 @@ class ASICAA : public INDI::Rotator
 
     private:
         int m_ID { -1 };
+        CAA_INFO m_Info {};
+        std::string m_SerialNumber;
         bool m_IsMoving { false };
         bool m_IsHandControl { false };
 

--- a/indi-asi/asi_rotator_hotplug_handler.cpp
+++ b/indi-asi/asi_rotator_hotplug_handler.cpp
@@ -1,0 +1,221 @@
+/*
+    ZWO CAA Rotator Hot Plug Handler Class Source File
+
+    Copyright (C) 2026 Jasem Mutlaq (mutlaqja@ikarustech.com)
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "asi_rotator_hotplug_handler.h"
+#include "indilogger.h"   // For LOG_INFO, LOG_DEBUG, etc.
+#include <algorithm>      // For std::remove_if, std::find_if
+#include <CAA_API.h>      // For CAA SDK functions
+#include <cstdio>         // For snprintf
+#include <string>         // For std::string, std::to_string
+#include <vector>         // For std::vector
+#include <map>            // For std::map
+#include <memory>         // For std::shared_ptr
+#include <stdexcept>      // For std::invalid_argument, std::out_of_range
+
+namespace INDI
+{
+
+ASICAAHotPlugHandler::ASICAAHotPlugHandler()
+{
+    LOG_DEBUG("HotPlugManager: ASICAAHotPlugHandler initialized.");
+}
+
+ASICAAHotPlugHandler::~ASICAAHotPlugHandler()
+{
+    // Clean up any remaining devices, deleting their properties from the server.
+    for (const auto& device : m_internalRotators)
+        device->deleteProperty(nullptr); // Delete all properties for this device
+
+    m_internalRotators.clear();
+    m_managedDevicesView.clear();
+    LOG_DEBUG("HotPlugManager: ASICAAHotPlugHandler shut down.");
+}
+
+std::vector<std::string> ASICAAHotPlugHandler::discoverConnectedDeviceIdentifiers()
+{
+    std::vector<std::string> identifiers;
+
+    // CAAGetNum() refreshes the SDK's device list. We deliberately do NOT call
+    // CAAOpen() here: opening claims the USB interface, and doing so during
+    // discovery would collide with the already-connected driver instance
+    // (LIBUSB_ERROR_BUSY). CAAGetID() only needs the enumeration.
+    int numRotators = CAAGetNum();
+    if (numRotators < 0)
+    {
+        LOG_ERROR("HotPlugManager: CAAGetNum returned an error.");
+        return identifiers;
+    }
+
+    for (int i = 0; i < numRotators; ++i)
+    {
+        int id = -1;
+        if (CAAGetID(i, &id) == CAA_SUCCESS)
+        {
+            identifiers.push_back(std::to_string(id));
+            LOGF_DEBUG("HotPlugManager: Discovered ZWO CAA with ID: %d", id);
+        }
+        else
+        {
+            LOGF_WARN("HotPlugManager: Failed to get rotator ID for index %d.", i);
+        }
+    }
+    return identifiers;
+}
+
+std::shared_ptr<DefaultDevice> ASICAAHotPlugHandler::createDevice(const std::string& identifier)
+{
+    int rotatorID;
+    try
+    {
+        rotatorID = std::stoi(identifier);
+    }
+    catch (const std::exception& e)
+    {
+        LOGF_ERROR("HotPlugManager: Invalid identifier format for rotator ID: %s. Error: %s",
+                   identifier.c_str(), e.what());
+        return nullptr;
+    }
+
+    // Resolve the CAA_INFO for this ID from the current enumeration. As in
+    // discovery, no CAAOpen() is used here so we never claim the interface
+    // before the device instance connects.
+    CAA_INFO info;
+    bool foundRotator = false;
+    int numRotators = CAAGetNum();
+    for (int i = 0; i < numRotators; ++i)
+    {
+        int id = -1;
+        if (CAAGetID(i, &id) == CAA_SUCCESS && id == rotatorID)
+        {
+            if (CAAGetProperty(id, &info) == CAA_SUCCESS)
+                foundRotator = true;
+            break;
+        }
+    }
+
+    if (!foundRotator)
+    {
+        LOGF_ERROR("HotPlugManager: Failed to get rotator info for ID: %d", rotatorID);
+        return nullptr;
+    }
+
+    // If a device with this ID is already managed, return it (do not duplicate).
+    for (const auto& device : m_internalRotators)
+    {
+        if (device->getCAAInfo().ID == rotatorID)
+        {
+            LOGF_DEBUG("HotPlugManager: Device with rotator ID %d already managed, not creating new.", rotatorID);
+            return device;
+        }
+    }
+
+    // Generate a unique device name. Preserve the historical "ZWO CAA <Name>"
+    // scheme (e.g. "ZWO CAA CAA") so existing saved configurations keep working,
+    // appending a counter only when more than one identical device is present.
+    std::string baseName = std::string("ZWO CAA ") + info.Name;
+    std::string uniqueName = baseName;
+    int index = 0;
+    bool nameExists = true;
+    while (nameExists)
+    {
+        nameExists = false;
+        for (const auto& device : m_internalRotators)
+        {
+            if (uniqueName == device->getDeviceName())
+            {
+                nameExists = true;
+                break;
+            }
+        }
+        if (nameExists)
+        {
+            index++;
+            uniqueName = baseName + " " + std::to_string(index);
+        }
+    }
+
+    std::string serialNumber = getSerialNumberFromID(rotatorID);
+
+    std::shared_ptr<ASICAA> newDevice = std::make_shared<ASICAA>(info, uniqueName.c_str(), serialNumber);
+    m_internalRotators.push_back(newDevice);
+    LOGF_INFO("HotPlugManager: Created new ASICAA device: %s (ID: %d)", uniqueName.c_str(), rotatorID);
+    return newDevice;
+}
+
+void ASICAAHotPlugHandler::destroyDevice(std::shared_ptr<DefaultDevice> device)
+{
+    std::shared_ptr<ASICAA> asiCaa = std::dynamic_pointer_cast<ASICAA>(device);
+    if (!asiCaa)
+    {
+        LOG_ERROR("HotPlugManager: Attempted to destroy a non-ASICAA device with ASICAAHotPlugHandler.");
+        return;
+    }
+
+    // Delete properties from the INDI server (this also handles disconnection).
+    asiCaa->deleteProperty(nullptr);
+
+    // Remove from internal storage.
+    auto it = std::remove_if(m_internalRotators.begin(), m_internalRotators.end(),
+                             [&](const std::shared_ptr<ASICAA> &d)
+    {
+        return d == asiCaa;
+    });
+
+    if (it != m_internalRotators.end())
+    {
+        LOGF_INFO("HotPlugManager: Destroyed ASICAA device: %s (ID: %d)",
+                  asiCaa->getDeviceName(), asiCaa->getCAAInfo().ID);
+        m_internalRotators.erase(it, m_internalRotators.end());
+    }
+    else
+    {
+        LOGF_WARN("HotPlugManager: Attempted to destroy ASICAA device %s not found in managed list.",
+                  asiCaa->getDeviceName());
+    }
+}
+
+const std::map<std::string, std::shared_ptr<DefaultDevice>> &ASICAAHotPlugHandler::getManagedDevices() const
+{
+    // Dynamically construct the map view from m_internalRotators.
+    m_managedDevicesView.clear();
+    for (const auto& device : m_internalRotators)
+        m_managedDevicesView[std::to_string(device->getCAAInfo().ID)] = device;
+    return m_managedDevicesView;
+}
+
+std::string ASICAAHotPlugHandler::getSerialNumberFromID(int rotatorID)
+{
+    // Best effort: the serial number may require the device to be open, so a
+    // failure here is non-fatal. The connected device also reads the serial in
+    // updateProperties(); an empty value simply falls back to the unique name.
+    CAA_SN serialNumber;
+    if (CAAGetSerialNumber(rotatorID, &serialNumber) == CAA_SUCCESS)
+    {
+        char snChars[17];
+        snprintf(snChars, sizeof(snChars), "%02x%02x%02x%02x%02x%02x%02x%02x",
+                 serialNumber.id[0], serialNumber.id[1], serialNumber.id[2], serialNumber.id[3],
+                 serialNumber.id[4], serialNumber.id[5], serialNumber.id[6], serialNumber.id[7]);
+        snChars[16] = 0;
+        return std::string(snChars);
+    }
+    return "";
+}
+
+} // namespace INDI

--- a/indi-asi/asi_rotator_hotplug_handler.h
+++ b/indi-asi/asi_rotator_hotplug_handler.h
@@ -1,0 +1,75 @@
+/*
+    ZWO CAA Rotator Hot Plug Handler Class Header File
+
+    Copyright (C) 2026 Jasem Mutlaq (mutlaqja@ikarustech.com)
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include <hotplugcapabledevice.h>
+#include "asi_rotator.h"
+#include <deque>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace INDI
+{
+
+class ASICAAHotPlugHandler : public HotPlugCapableDevice
+{
+    public:
+        ASICAAHotPlugHandler();
+        ~ASICAAHotPlugHandler() override;
+
+        /**
+         * @brief Discovers currently connected ZWO CAA rotators.
+         * @return A vector of unique string identifiers for connected ZWO CAA rotators.
+         */
+        std::vector<std::string> discoverConnectedDeviceIdentifiers() override;
+
+        /**
+         * @brief Factory method to create a new ASICAA instance.
+         * @param identifier The unique string identifier of the ZWO CAA rotator to create.
+         * @return A shared pointer to the newly created ASICAA instance.
+         */
+        std::shared_ptr<DefaultDevice> createDevice(const std::string& identifier) override;
+
+        /**
+         * @brief Destroys an ASICAA instance and performs driver-specific cleanup.
+         * @param device A shared pointer to the device to destroy.
+         */
+        void destroyDevice(std::shared_ptr<DefaultDevice> device) override;
+
+        /**
+         * @brief Provides a unified map view of currently managed ASICAA devices.
+         * @return A const reference to a map of managed ASICAA devices, keyed by their unique string identifiers.
+         */
+        const std::map<std::string, std::shared_ptr<DefaultDevice>> &getManagedDevices() const override;
+
+    private:
+        // Internal storage for managed ZWO CAA devices
+        std::deque<std::shared_ptr<ASICAA>> m_internalRotators;
+        // A map view for getManagedDevices() to satisfy the interface
+        mutable std::map<std::string, std::shared_ptr<DefaultDevice>> m_managedDevicesView;
+
+        // Helper to read the serial number for a rotator ID (best effort, may be empty)
+        static std::string getSerialNumberFromID(int id);
+};
+
+} // namespace INDI


### PR DESCRIPTION
## Summary

Migrate the ZWO CAA rotator driver to the shared `HotPlugManager` / `HotPlugCapableDevice` framework already used by the ASI CCD, focuser (EAF) and filter wheel (EFW) drivers.

## Motivation

The CAA rotator is the **only** ASI driver still using a bespoke static `Loader`. That loader enumerates devices once at startup, and its `hotPlugTimer` is declared but never wired — so the driver does **no in-process hotplug detection**. The other ASI drivers register with `HotPlugManager` (periodic poll, create/destroy device objects live), so they handle unplug/replug while the driver is running. The rotator does not: a replugged rotator is not re-detected until the driver process is restarted, which is inconsistent with the rest of the ASI family.

## Changes

- Add `ASICAAHotPlugHandler` (`HotPlugCapableDevice`) implementing `discoverConnectedDeviceIdentifiers` / `createDevice` / `destroyDevice` / `getManagedDevices` via the CAA SDK. Discovery and creation deliberately avoid `CAAOpen()` so enumeration never claims the USB interface.
- Replace the custom `Loader` with the standard `registerHandler()` / `start()` wiring.
- Give `ASICAA` a `(CAA_INFO, name, serial)` constructor with `getCAAInfo()` / `getSerialNumber()` accessors, matching the other ASI device classes. The historical `"ZWO CAA <Name>"` device-name scheme is preserved so existing saved configurations keep working.
- Add the new source to the `indi_asi_rotator` CMake target.

## Scope / notes

- This is a **consistency / modernization** change — it brings the rotator's hotplug behaviour in line with the other ASI drivers. It is **not** a fix for any specific field failure.
- Builds and links against libindi. **Not yet validated on hardware** — the meaningful test is an **unplug/replug** of the CAA with the driver running, confirming it re-detects in-process like the camera/focuser/wheel.
- Mirrors `asi_focuser_hotplug_handler.{h,cpp}` closely.
