### PR TITLE
indi-asi: fix ZWO EAF driver crash on hot-plug enumeration

### DIFF
--- a/indi-asi/asi_focuser_hotplug_handler.cpp
+++ b/indi-asi/asi_focuser_hotplug_handler.cpp
@@ -90,7 +90,26 @@ std::shared_ptr<DefaultDevice> ASIEAFHotPlugHandler::createDevice(const std::str
         return nullptr;
     }
 
+    // Check if a device with this ID is already managed (before touching the hardware)
+    for (const auto& device : m_internalFocusers)
+    {
+        if (device->getEAFInfo().ID == focuserID)
+        {
+            LOGF_DEBUG("HotPlugManager: Device with focuser ID %d already managed, not creating new.", focuserID);
+            return device;
+        }
+    }
+
+    // Single open/close cycle: read properties AND serial number in one session.
+    // Performing multiple rapid EAFOpen/EAFClose cycles on the same device (as the
+    // previous code did: once here for the property, then again in
+    // getSerialNumberFromID) can trigger a libusb assertion failure
+    // ("usbi_mutex_lock: Assertion `pthread_mutex_lock(mutex) == 0' failed") and
+    // abort the driver, because the SDK's internal HID/USB teardown from the first
+    // close may not have completed before the next open. The failure is
+    // timing-dependent and shows up intermittently at profile load / enumeration.
     EAF_INFO eafInfo;
+    std::string serialNumber;
     bool foundFocuser = false;
     int numFocusers = EAFGetNum();
     if (numFocusers >= 0)
@@ -100,17 +119,28 @@ std::shared_ptr<DefaultDevice> ASIEAFHotPlugHandler::createDevice(const std::str
             int id;
             if (EAFGetID(i, &id) == EAF_SUCCESS && id == focuserID)
             {
-                // Open device to get properties
+                // Open the device once and query everything we need.
                 if (EAFOpen(id) == EAF_SUCCESS)
                 {
                     if (EAFGetProperty(id, &eafInfo) == EAF_SUCCESS)
                     {
                         foundFocuser = true;
-                        EAFClose(id);
-                        break;
+
+                        // Read the serial number while the device is still open.
+                        EAF_SN sn;
+                        if (EAFGetSerialNumber(id, &sn) == EAF_SUCCESS)
+                        {
+                            char snChars[17];
+                            sprintf(snChars, "%02X%02X%02X%02X%02X%02X%02X%02X",
+                                    sn.id[0], sn.id[1], sn.id[2], sn.id[3],
+                                    sn.id[4], sn.id[5], sn.id[6], sn.id[7]);
+                            snChars[16] = 0;
+                            serialNumber = snChars;
+                        }
                     }
                     EAFClose(id);
                 }
+                break;
             }
         }
     }
@@ -119,16 +149,6 @@ std::shared_ptr<DefaultDevice> ASIEAFHotPlugHandler::createDevice(const std::str
     {
         LOGF_ERROR("HotPlugManager: Failed to get focuser info for ID: %d", focuserID);
         return nullptr;
-    }
-
-    // Check if a device with this ID is already managed
-    for (const auto& device : m_internalFocusers)
-    {
-        if (device->getEAFInfo().ID == focuserID)
-        {
-            LOGF_DEBUG("HotPlugManager: Device with focuser ID %d already managed, not creating new.", focuserID);
-            return device;
-        }
     }
 
     // Generate a unique name for the new device
@@ -153,9 +173,6 @@ std::shared_ptr<DefaultDevice> ASIEAFHotPlugHandler::createDevice(const std::str
             uniqueName = baseName + " " + std::to_string(index);
         }
     }
-
-    // Retrieve serial number for the ASIEAF constructor
-    std::string serialNumber = getSerialNumberFromID(focuserID);
 
     std::shared_ptr<ASIEAF> newDevice = std::make_shared<ASIEAF>(eafInfo, uniqueName.c_str(), serialNumber);
     m_internalFocusers.push_back(newDevice);


### PR DESCRIPTION
## Summary

`ASIEAFHotPlugHandler::createDevice()` can crash the `indi_asi_focuser` driver during device enumeration (e.g. at profile load / boot) with a libusb assertion failure. This PR fixes it by consolidating the device access into a single open/close cycle.

## Symptom

Intermittent driver abort, most often seen while a profile is loading:

```
indi_asi_focuser: os/threads_posix.h:46: usbi_mutex_lock:
Assertion `pthread_mutex_lock(mutex) == 0' failed.
```

Backtrace (systemd-coredump):

```
#4  __assert_fail                       (libc)
#5  libusb-1.0.so.0 (+0x4064)
#6  libusb-1.0.so.0 (+0x4733)
#7  hid_close                           (libindidriver)
#8  CEAF::close()                       (libEAFFocuser)
#9  EAFClose                            (libEAFFocuser)
#10 INDI::ASIEAFHotPlugHandler::createDevice(...)
#11 INDI::HotPlugManager::checkHotPlugEvents()
```

## Root cause

`createDevice()` opened and closed the EAF device **twice in rapid succession**:

1. `EAFOpen` -> `EAFGetProperty` -> `EAFClose` (to read the properties), then
2. `getSerialNumberFromID()`: `EAFOpen` -> `EAFGetSerialNumber` -> `EAFClose` (to read the serial number).

The EAF SDK (`libEAFFocuser`) uses hidapi/libusb internally. `EAFClose` -> `hid_close` -> `libusb_close` tears down the HID handle and its mutexes, and part of that teardown (transfer cancellation) is asynchronous. Reopening the same ID immediately can race that teardown, so the second `EAFClose` locks an already-destroyed mutex and the driver aborts.

Because it is a race, it reproduces only intermittently — typically at enumeration time when the USB device has just appeared.

## Fix

- Perform a **single** `EAFOpen`/`EAFClose` cycle and read both the property and the serial number while the device is open.
- Move the "already managed" check ahead of the hardware access, so repeated hot-plug poll ticks for a known device don't touch USB at all.

This mirrors the single open/close pattern already used by the ASI CCD hot-plug handler (`getSerialNumberFromCameraID`).

## Notes

- `getSerialNumberFromID()` is now unused by `createDevice()` but left in place (it is a self-contained, safe single-cycle helper).
- No SDK or API changes; behavior (device name, serial number) is unchanged on the success path.

## Testing

- [x] Build `indi_asi_focuser`.
- [x] Load a profile containing a ZWO EAF and confirm no `usbi_mutex_lock` abort in the journal, and that the focuser enumerates with the correct name and serial number. Verified on StellarMate (Arch, x86_64): driver starts once (no restart cycle), `focuser ready for use`, `is connected and ready`, no coredump.
