### PR TITLE
indi-aagcloudwatcher-ng: persist Options and Rain Heater settings (#1365)

### DIFF
--- a/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
+++ b/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
@@ -140,6 +140,51 @@ bool AAGCloudWatcher::initProperties()
     return true;
 }
 
+/**********************************************************************
+ ** Restore the saved settings.
+ **
+ ** This must happen after the base class has defined the properties:
+ ** the driver-side dispatcher rejects a value for a property that has not
+ ** been defined yet, so calling loadConfig() from initProperties() silently
+ ** does nothing.
+ **
+ ** Loading goes through the regular ISNew*() handlers, so driver state derived
+ ** from these properties (anemometer type, heating algorithm) is set up as well.
+ ** Doing it here instead of relying on the client pressing "Load" keeps the
+ ** settings working under a plain indiserver too.
+ **********************************************************************/
+void AAGCloudWatcher::ISGetProperties(const char *dev)
+{
+    INDI::Weather::ISGetProperties(dev);
+
+    if (!m_ConfigLoaded)
+    {
+        m_ConfigLoaded = true;
+        for (const auto &property : CONFIGURABLE_PROPERTIES)
+            loadConfig(true, property);
+    }
+}
+
+/**********************************************************************
+ ** Persist the user-configurable settings.
+ **********************************************************************/
+bool AAGCloudWatcher::saveConfigItems(FILE *fp)
+{
+    INDI::Weather::saveConfigItems(fp);
+
+    // buildSkeleton() may have failed (missing indi_aagcloudwatcher_ng_sk.xml), in
+    // which case these properties do not exist. save() on an invalid property is a
+    // no-op, but check explicitly so the intent is clear.
+    for (const auto &name : CONFIGURABLE_PROPERTIES)
+    {
+        auto property = getProperty(name);
+        if (property.isValid())
+            property.save(fp);
+    }
+
+    return true;
+}
+
 IPState AAGCloudWatcher::updateWeather()
 {
     // in case elevation updated as GPS gets a better fix
@@ -274,7 +319,8 @@ bool AAGCloudWatcher::ISNewNumber(const char *dev, const char *name, double valu
 
             if (nvp.isNameMatch("skyCorrection"))
             {
-                for (int i = 0; i < 5; i++)
+                // Bound by n, not by the vector size: a client may send a subset.
+                for (int i = 0; i < n; i++)
                 {
                     if (values[i] < -999)
                     {
@@ -310,11 +356,18 @@ bool AAGCloudWatcher::ISNewSwitch(const char *dev, const char *name, ISState *st
 
             if (svp.isNameMatch("heatingAlgorithm"))
             {
-                LOGF_INFO("Changing heating algorithm to %s\n", names[0]);
-                usePIDforHeating = (strcmp(names[0], "pid") == 0);
                 svp.update(states, names, n);
                 svp.setState(IPS_OK);
                 svp.apply();
+
+                // Derive the flag from the resulting switch state rather than from
+                // names[0]. A GUI client sends only the switch it turned on, but a
+                // configuration load sends the whole vector, in which case names[0]
+                // is not necessarily the selected one.
+                auto pid = svp.findWidgetByName("pid");
+                usePIDforHeating = (pid != nullptr && pid->getState() == ISS_ON);
+                LOGF_INFO("Changing heating algorithm to %s", usePIDforHeating ? "pid" : "original");
+
                 return true;
             }
 
@@ -394,12 +447,14 @@ bool AAGCloudWatcher::ISNewSwitch(const char *dev, const char *name, ISState *st
 
             if (svp.isNameMatch("anemometerType"))
             {
-                svp.update(states, names, 2);
+                // Use n, not a hard-coded 2: a client may send only the switch it
+                // turned on, and reading past the end of states[]/names[] is UB.
+                svp.update(states, names, n);
                 svp.setState(IPS_OK);
                 svp.apply();
 
                 auto sp = svp.findWidgetByName("BLACK");
-                if (sp->getState() == ISS_ON)
+                if (sp != nullptr && sp->getState() == ISS_ON)
                 {
                     cwc->setAnemometerType(BLACK);
                 }

--- a/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
+++ b/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.cpp
@@ -317,6 +317,19 @@ bool AAGCloudWatcher::ISNewNumber(const char *dev, const char *name, double valu
                 return true;
             }
 
+            // Broadcast the loaded/changed value to clients. Without a driver
+            // handler, sqmLimit falls through to DefaultDevice::ISNewNumber, which
+            // update()s the value internally but never apply()s it, so a config
+            // load would silently leave connected clients on the skeleton default.
+            if (nvp.isNameMatch("sqmLimit"))
+            {
+                nvp.update(values, names, n);
+                nvp.setState(IPS_OK);
+                nvp.apply();
+
+                return true;
+            }
+
             if (nvp.isNameMatch("skyCorrection"))
             {
                 // Bound by n, not by the vector size: a client may send a subset.

--- a/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.h
+++ b/indi-aagcloudwatcher-ng/indi_aagcloudwatcher_ng.h
@@ -45,6 +45,7 @@ public:
     virtual ~AAGCloudWatcher() override;
 
     virtual bool initProperties() override;
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
@@ -58,9 +59,26 @@ public:
 protected:
     virtual bool Handshake() override;
     virtual IPState updateWeather() override;
+    virtual bool saveConfigItems(FILE *fp) override;
 
 
 private:
+    // Skeleton properties holding user settings that must survive a restart.
+    // Shared by saveConfigItems() and ISGetProperties() so the two cannot drift apart.
+    // "deviceSwitch" is deliberately excluded: it drives the unit's relay and must
+    // not be re-asserted automatically at startup.
+    static constexpr const char *CONFIGURABLE_PROPERTIES[] =
+    {
+        "skyCorrection",
+        "sqmLimit",
+        "anemometerType",
+        "heaterParameters",
+        "heatingAlgorithm",
+        "heaterPIDParameters"
+    };
+
+    bool m_ConfigLoaded {false};
+
     float lastReadPeriod {0};
     CloudWatcherConstants constants;
     CloudWatcherController *cwc {nullptr};


### PR DESCRIPTION
## Summary

Fixes #1365. The AAG Cloud Watcher NG driver never persisted its user-configurable settings, so the Sky Temp. Correction parameters (K1..K5), SQM limit, anemometer type, rain-heater parameters, heating algorithm and heater PID parameters reverted to the skeleton defaults on every restart.

This adds a `saveConfigItems()` override for the six affected skeleton properties and restores them from an `ISGetProperties()` override. `deviceSwitch` is deliberately **not** persisted — it drives the unit's relay and must not be re-asserted automatically at startup.

# Why the load happens in `ISGetProperties()`, not `initProperties()`

The placement (`loadConfig()` in `initProperties()`) looks correct but silently does nothing. `loadConfig()` → `IUReadConfig()` → `dispatch()`, and `dispatch()` rejects any value for a property that is not yet defined:

```c
if (rosc_find(name, dev) == NULL) {
    snprintf(msg, MAXRBUF, "Property %s is not defined in %s.", name, dev);
    return -1;
}
```

`DefaultDevice::ISGetProperties()` runs `initProperties()` *before* its define loop, so at that point nothing is registered. And `IUReadConfig()` discards the `dispatch()` return value, so `loadConfig()` still reports success. Loading from `ISGetProperties()` after the base class has defined the (dynamic/skeleton) properties is the established pattern — same as `joystick.cpp`.

## Handler fixes required by the load path

A config load dispatches through `ISNewSwitch()`/`ISNewNumber()` with the **whole** vector, whereas a GUI client sends only the widget it changed. Three spots assumed the client-style call:

- **`heatingAlgorithm`** derived `usePIDforHeating` from `names[0]`, which on a config load is not necessarily the selected switch. Result: the Options tab shows PID selected while the driver keeps running the original algorithm. Now derived from the resulting switch state.
- **`anemometerType`** passed a hard-coded `n` of 2 to `update()`, reading past the end of `states[]`/`names[]` when a client sends a single switch.
- **`skyCorrection`** clamped `values[0..4]` regardless of `n`.

## Testing

No hardware required — `saveConfigItems()`/`loadConfig()` run in the property layer, before and independently of `Handshake()`. Verified end-to-end against a plain `indiserver` using `indi_setprop`/`indi_getprop`:

- All six vectors are written on Save and restored after an `indiserver` restart.
- `usePIDforHeating` is correctly `true` after loading `pid=On` (the naive patch leaves it `false`).
- The unpatched binary reverts all six to defaults and writes none of them to the config file.
- Fresh install with no config → skeleton defaults; missing skeleton file → no crash, no junk written.

**Not verified without hardware:** the anemometer wind-speed scaling side effect. `setAnemometerType()` only affects scaling applied during real sensor reads; the switch state restores and the handler runs, but the resulting km/h value wasn't exercised. A sanity check by someone with grey-cup hardware would be appreciated.



---

## Update — `sqmLimit` broadcast fix (2nd commit)

Follow-up to GUI verification by @zero-drift-ops. Of the six persisted vectors, `sqmLimit` was the only one without an `ISNewNumber` handler, so it fell through to `DefaultDevice::ISNewNumber`. That path calls `PropertyNumber::update()` (which writes the value into storage) but, with no registered update callback, returns without ever calling `apply()`. `apply()` is what emits `setNumber` to clients, so on a config load the value was applied internally but never broadcast: the client attached across the define→load window (the Ekos/KStars GUI) kept the skeleton default (19.60) while the driver used the loaded value. The same missing broadcast also meant a `sqmLimit` change from one client was not pushed to other connected clients. `indi_setprop`/`indi_getprop` masked both, since a fresh client re-reads the property from the already-updated storage — which is why the round-trip test above didn't catch it.

The 2nd commit adds a `sqmLimit` handler (`update`/`apply`) mirroring the existing `heaterPIDParameters`/`skyCorrection` branches; `update()` already clamps to the skeleton min/max. No change to the save/load logic. Verified: builds clean, round-trip still passes, and (per @zero-drift-ops) set SQM=20 → Save → full Ekos/KStars restart now shows 20 (was reverting to 19.60), and a value set by one client is now broadcast to a second connected client.
